### PR TITLE
Persist Notification when dispatched

### DIFF
--- a/lib/mbta_server/alert_processor/atom_type.ex
+++ b/lib/mbta_server/alert_processor/atom_type.ex
@@ -1,0 +1,11 @@
+defmodule MbtaServer.AlertProcessor.AtomType do
+  @moduledoc """
+  Atom type for Ecto
+  """
+  @behaviour Ecto.Type
+  def type, do: :string
+  def cast(value), do: {:ok, value}
+  def load(value), do: {:ok, String.to_existing_atom(value)}
+  def dump(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
+  def dump(_), do: :error
+end

--- a/lib/mbta_server/alert_processor/dissemination/dispatcher.ex
+++ b/lib/mbta_server/alert_processor/dissemination/dispatcher.ex
@@ -4,7 +4,7 @@ defmodule MbtaServer.AlertProcessor.Dispatcher do
   """
   @ex_aws Application.get_env(:mbta_server, :ex_aws)
 
-  alias MbtaServer.{NotificationMailer, Mailer, Repo}
+  alias MbtaServer.{NotificationMailer, Mailer}
   alias MbtaServer.AlertProcessor.{NotificationSmser, Model.Notification}
 
   @type ex_aws_success :: {:ok, map}
@@ -17,19 +17,12 @@ defmodule MbtaServer.AlertProcessor.Dispatcher do
   """
   @spec send_notification(Notification.t) ::
   ex_aws_success | ex_aws_error | request_error
-  def send_notification(%Notification{message: message, email: email, phone_number: phone_number} = notification) do
-    persist_notification(notification)
+  def send_notification(%Notification{message: message, email: email, phone_number: phone_number}) do
     do_send_notification(email, phone_number, message)
   end
 
   def send_notification(_) do
     {:error, "invalid or missing params"}
-  end
-
-  @spec persist_notification(Notification.t) ::
-  {:ok, Notification.t} | {:error, Ecto.Changeset.t}
-  defp persist_notification(%Notification{} = notification) do
-    Repo.insert(Notification.create_changeset(notification))
   end
 
   @spec do_send_notification(String.t, String.t, nil) :: request_error

--- a/lib/mbta_server/alert_processor/model/notification.ex
+++ b/lib/mbta_server/alert_processor/model/notification.ex
@@ -10,11 +10,19 @@ defmodule MbtaServer.AlertProcessor.Model.Notification do
     message: String.t,
     header: String.t,
     phone_number: String.t,
-    email: String.t
+    email: String.t,
+    status: atom
   }
 
   use Ecto.Schema
   import Ecto.Changeset
+  alias MbtaServer.Repo
+
+  @spec save(__MODULE__.t, atom) ::
+  {:ok, __MODULE__.t} | {:error, Ecto.Changeset.t}
+  def save(notification, status) do
+    Repo.insert(__MODULE__.create_changeset(%{notification | status: status}))
+  end
 
   @primary_key {:id, :binary_id, autogenerate: true}
 
@@ -27,11 +35,12 @@ defmodule MbtaServer.AlertProcessor.Model.Notification do
     field :header, :string
     field :phone_number, :string
     field :email, :string
+    field :status, MbtaServer.AlertProcessor.AtomType
 
     timestamps()
   end
 
-  @permitted_fields ~w(alert_id user_id send_after message header phone_number email)a
+  @permitted_fields ~w(alert_id user_id send_after message header phone_number email status)a
   @required_fields ~w(alert_id user_id message)a
 
   @doc """
@@ -41,6 +50,7 @@ defmodule MbtaServer.AlertProcessor.Model.Notification do
     struct
     |> cast(params, @permitted_fields)
     |> validate_required(@required_fields)
+    |> validate_inclusion(:status, [:sent, :failed])
     |> validate_email_or_phone
   end
 

--- a/priv/repo/migrations/20170411193142_create_notification.exs
+++ b/priv/repo/migrations/20170411193142_create_notification.exs
@@ -9,8 +9,9 @@ defmodule MbtaServer.Repo.Migrations.CreateNotification do
       add :email, :string
       add :phone_number, :string
       add :header, :string
-      add :message, :string
+      add :message, :string, null: false
       add :send_after, :utc_datetime
+      add :status, :string, null: false
 
       timestamps(type: :utc_datetime)
     end

--- a/test/alert_processor/dissemination/dispatcher_test.exs
+++ b/test/alert_processor/dissemination/dispatcher_test.exs
@@ -1,9 +1,8 @@
 defmodule MbtaServer.AlertProcessor.DispatcherTest do
   use MbtaServer.DataCase
   use Bamboo.Test
-  import MbtaServer.Factory
 
-  alias MbtaServer.{NotificationMailer, Repo}
+  alias MbtaServer.NotificationMailer
   alias MbtaServer.AlertProcessor.{Dispatcher, Model.Notification}
 
   @email "test@example.com"
@@ -62,24 +61,5 @@ defmodule MbtaServer.AlertProcessor.DispatcherTest do
     {:ok, _} = Dispatcher.send_notification(notification)
     assert_delivered_email NotificationMailer.notification_email(@body, @email)
     assert_received :published_sms
-  end
-
-  test "send_notification/1 persists Notification" do
-    user = insert(:user)
-    notification = %Notification{
-      message: @body,
-      phone_number: @phone_number,
-      user_id: user.id,
-      alert_id: "123"
-    }
-
-    {:ok, _} = Dispatcher.send_notification(notification)
-
-    saved_notification = Repo.one(Notification)
-
-    assert %Notification{} = saved_notification
-    assert saved_notification.user_id == user.id
-    assert saved_notification.message == @body
-    assert saved_notification.phone_number == @phone_number
   end
 end

--- a/test/alert_processor/dissemination/notification_worker_test.exs
+++ b/test/alert_processor/dissemination/notification_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule MbtaServer.AlertProcessor.MessageWorkerTest do
-  use MbtaServer.Web.ConnCase, async: false
+  use MbtaServer.DataCase
   use Bamboo.Test, shared: true
 
   alias MbtaServer.NotificationMailer
@@ -13,19 +13,22 @@ defmodule MbtaServer.AlertProcessor.MessageWorkerTest do
     body = "This is a test alert"
     body_2 = "Another alert"
     phone_number = "+15555551234"
+    status = "unsent"
 
     notification = %Notification{
       message: body,
       email: email,
       phone_number: phone_number,
-      send_after: DateTime.utc_now()
+      send_after: DateTime.utc_now(),
+      status: status
     }
 
     notification_2 = %Notification{
       message: body_2,
       email: email,
       phone_number: phone_number,
-      send_after: DateTime.utc_now()
+      send_after: DateTime.utc_now(),
+      status: status
     }
 
     {:ok, notification: notification, notification_2: notification_2, email: email, body: body, body_2: body_2}

--- a/test/alert_processor/model/notification_test.exs
+++ b/test/alert_processor/model/notification_test.exs
@@ -12,7 +12,8 @@ defmodule MbtaServer.AlertProcessor.Model.NotificationTest do
     header: "Short header",
     message: "There is a delay",
     send_after: DateTime.utc_now,
-    alert_id: "12345678"
+    alert_id: "12345678",
+    status: :sent
   }
 
   setup do
@@ -27,7 +28,7 @@ defmodule MbtaServer.AlertProcessor.Model.NotificationTest do
     assert changeset.valid?
   end
 
-  test "create_changeset/2 requires a user", %{valid_attrs: valid_attrs} do
+  test "create_changeset/2 requires a user_id", %{valid_attrs: valid_attrs} do
     attrs = Map.delete(valid_attrs, :user_id)
     changeset = Notification.create_changeset(%Notification{}, attrs)
 
@@ -61,5 +62,27 @@ defmodule MbtaServer.AlertProcessor.Model.NotificationTest do
     assert no_phone_changeset.valid?
     assert no_email_changeset.valid?
     refute no_email_or_phone_changeset.valid?
+  end
+
+  test "create_changeset/2 validates inclusion of status", %{valid_attrs: valid_attrs} do
+    invalid_attrs = Map.put(valid_attrs, :status, "example")
+    invalid_changeset = Notification.create_changeset(%Notification{}, invalid_attrs)
+
+    valid = Map.put(valid_attrs, :status, :sent)
+    valid_changeset = Notification.create_changeset(%Notification{}, valid)
+
+    valid_2 = Map.put(valid_attrs, :status, :failed)
+    valid_changeset_2 = Notification.create_changeset(%Notification{}, valid_2)
+
+    assert valid_changeset.valid?
+    assert valid_changeset_2.valid?
+    refute invalid_changeset.valid?
+  end
+
+  test "save/2 saves notification with given status", %{valid_attrs: valid_attrs} do
+    notification = struct(Notification, valid_attrs)
+    {:ok, saved_notification} = Notification.save(notification, :sent)
+
+    assert saved_notification.status == :sent
   end
 end


### PR DESCRIPTION
We want to be able to keep data on notifications that were sent. In this PR, we persist notifications when we dispatch them.

1. Add migration and Schema
2. Add changeset and validations
3. Add method to Dispatcher to persist at dispatch time