### PR TITLE
hook up scheduler to filter chain and refactor to use naive datetimes

### DIFF
--- a/lib/mbta_server/alert_processor/alert_parsing/alert_parser.ex
+++ b/lib/mbta_server/alert_processor/alert_parsing/alert_parser.ex
@@ -23,7 +23,7 @@ defmodule MbtaServer.AlertProcessor.AlertParser do
           |> Enum.reduce(%{}, &parse_alert/2)
           |> AlertCache.update_cache()
         HoldingQueue.remove_notifications(removed_alert_ids)
-        Enum.flat_map(new_alerts, &SubscriptionFilterEngine.process_alert/1)
+        Enum.map(new_alerts, &SubscriptionFilterEngine.process_alert/1)
     end
   end
 

--- a/lib/mbta_server/alert_processor/dissemination/holding_queue.ex
+++ b/lib/mbta_server/alert_processor/dissemination/holding_queue.ex
@@ -16,9 +16,9 @@ defmodule MbtaServer.AlertProcessor.HoldingQueue do
   @doc """
   Updates state to Notifications that can't be sent yet, returns ones that are ready.
   """
-  @spec notifications_to_send(DateTime.t | nil) :: {:ok, notifications} | :error
+  @spec notifications_to_send(NaiveDateTime.t | nil) :: {:ok, notifications} | :error
   def notifications_to_send(now \\ nil) do
-    now = now || DateTime.utc_now()
+    now = now || NaiveDateTime.utc_now()
     GenServer.call(__MODULE__, {:filter, now})
   end
 
@@ -60,7 +60,7 @@ defmodule MbtaServer.AlertProcessor.HoldingQueue do
   end
 
   defp send_notification?(notification, now) do
-    DateTime.compare(notification.send_after, now) != :gt
+    NaiveDateTime.compare(notification.send_after, now) != :gt
   end
 
   ## Callbacks

--- a/lib/mbta_server/alert_processor/model/alert.ex
+++ b/lib/mbta_server/alert_processor/model/alert.ex
@@ -8,7 +8,7 @@ defmodule MbtaServer.AlertProcessor.Model.Alert do
   defstruct [:active_period, :effect_name, :id, :header, :informed_entities, :severity]
 
   @type t :: %__MODULE__{
-    active_period: [%{start: DateTime.t, end: DateTime.t | nil}],
+    active_period: [%{start: NaiveDateTime.t, end: NaiveDateTime.t | nil}],
     effect_name: String.t,
     header: String.t,
     id: String.t,

--- a/lib/mbta_server/alert_processor/model/notification.ex
+++ b/lib/mbta_server/alert_processor/model/notification.ex
@@ -6,7 +6,7 @@ defmodule MbtaServer.AlertProcessor.Model.Notification do
   @type t :: %__MODULE__{
     alert_id: String.t,
     user_id: String.t,
-    send_after: DateTime.t,
+    send_after: NaiveDateTime.t,
     message: String.t,
     header: String.t,
     phone_number: String.t,
@@ -30,7 +30,7 @@ defmodule MbtaServer.AlertProcessor.Model.Notification do
     belongs_to :user, User, type: :binary_id
 
     field :alert_id, :string
-    field :send_after, :utc_datetime
+    field :send_after, :naive_datetime
     field :message, :string
     field :header, :string
     field :phone_number, :string

--- a/lib/mbta_server/alert_processor/rules_engine/scheduler.ex
+++ b/lib/mbta_server/alert_processor/rules_engine/scheduler.ex
@@ -11,10 +11,10 @@ defmodule MbtaServer.AlertProcessor.Scheduler do
   1. Generate a Notification for each Subscription/Alert combination
   2. Add resulting list of Notifications to holding queue
   """
-  @spec schedule_notifications({:ok, [any()], Alert.t}, DateTime.t)
+  @spec schedule_notifications({:ok, [any()], Alert.t}, NaiveDateTime.t)
   :: {:ok, [Notification.t]} | :error
   def schedule_notifications({:ok, subscription_ids, alert}, now \\ nil) do
-    now = now || DateTime.utc_now()
+    now = now || NaiveDateTime.utc_now()
 
     notifications = subscription_ids
     |> Subscription.fetch_with_user

--- a/lib/mbta_server/web/models/user.ex
+++ b/lib/mbta_server/web/models/user.ex
@@ -7,8 +7,8 @@ defmodule MbtaServer.User do
     email: String.t,
     phone_number: String.t,
     role: String.t,
-    vacation_start: DateTime.t,
-    vacation_end: DateTime.t,
+    vacation_start: NaiveDateTime.t,
+    vacation_end: NaiveDateTime.t,
     do_not_disturb_start: Time.t,
     do_not_disturb_end: Time.t,
   }
@@ -24,8 +24,8 @@ defmodule MbtaServer.User do
     field :email, :string
     field :phone_number, :string
     field :role, :string
-    field :vacation_start, :utc_datetime
-    field :vacation_end, :utc_datetime
+    field :vacation_start, :naive_datetime
+    field :vacation_end, :naive_datetime
     field :do_not_disturb_start, :time
     field :do_not_disturb_end, :time
 

--- a/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -1,8 +1,9 @@
 defmodule MbtaServer.AlertProcessor.AlertParserTest do
   use MbtaServer.Web.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  use Bamboo.Test
+  use Bamboo.Test, shared: :true
   import MbtaServer.Factory
+  alias MbtaServer.NotificationMailer
   alias MbtaServer.AlertProcessor.{AlertParser, Model.InformedEntity}
 
   setup_all do
@@ -41,9 +42,8 @@ defmodule MbtaServer.AlertProcessor.AlertParserTest do
     |> insert
     insert(:notification, alert_id: "177528", user: user4, email: user4.email, phone_number: user4.phone_number, status: "sent", send_after: ~N[2017-04-25 10:00:00])
     use_cassette "route_19_minor_delay", custom: true do
-      assert [{:ok, email} | []] = AlertParser.process_alerts
-      [{nil, to_address} | _] = email.to
-      assert to_address == user1.email
+      assert [{:ok, _} | _t] = AlertParser.process_alerts
+      assert_delivered_email NotificationMailer.notification_email("Route 19 experiencing minor delays due to traffic", user1.email)
     end
   end
 end

--- a/test/alert_processor/dissemination/holding_queue_test.exs
+++ b/test/alert_processor/dissemination/holding_queue_test.exs
@@ -4,11 +4,12 @@ defmodule MbtaServer.AlertProcessor.HoldingQueueTest do
   alias MbtaServer.AlertProcessor.{HoldingQueue, SendingQueue, Model.Notification}
 
   defp generate_date(x) do
-    DateTime.from_unix!(System.system_time(:millisecond) + x, :millisecond)
+    now = NaiveDateTime.utc_now()
+    NaiveDateTime.add(now, x, :millisecond)
   end
 
   setup do
-    date_in_future = DateTime.from_unix!(4078579247)
+    date_in_future = ~N[2092-05-01 12:00:00]
     future_notification = %Notification{send_after: date_in_future}
 
     {:ok, fn: future_notification}

--- a/test/alert_processor/dissemination/notification_worker_test.exs
+++ b/test/alert_processor/dissemination/notification_worker_test.exs
@@ -19,7 +19,7 @@ defmodule MbtaServer.AlertProcessor.MessageWorkerTest do
       message: body,
       email: email,
       phone_number: phone_number,
-      send_after: DateTime.utc_now(),
+      send_after: NaiveDateTime.utc_now(),
       status: status
     }
 
@@ -27,7 +27,7 @@ defmodule MbtaServer.AlertProcessor.MessageWorkerTest do
       message: body_2,
       email: email,
       phone_number: phone_number,
-      send_after: DateTime.utc_now(),
+      send_after: NaiveDateTime.utc_now(),
       status: status
     }
 

--- a/test/alert_processor/dissemination/queue_worker_test.exs
+++ b/test/alert_processor/dissemination/queue_worker_test.exs
@@ -3,11 +3,12 @@ defmodule MbtaServer.AlertProcessor.QueueWorkerTest do
   alias MbtaServer.AlertProcessor.{HoldingQueue, SendingQueue, QueueWorker, Model.Notification}
 
   defp generate_date(x) do
-    DateTime.from_unix!(System.system_time(:millisecond) + x, :millisecond)
+    now = NaiveDateTime.utc_now()
+    NaiveDateTime.add(now, x, :millisecond)
   end
 
   setup do
-    notification = %Notification{send_after: DateTime.utc_now()}
+    notification = %Notification{send_after: NaiveDateTime.utc_now()}
     later_notification = %Notification{send_after: generate_date(50)}
 
     {:ok, notification: notification, later_notification: later_notification}

--- a/test/alert_processor/dissemination/sending_queue_test.exs
+++ b/test/alert_processor/dissemination/sending_queue_test.exs
@@ -3,7 +3,7 @@ defmodule MbtaServer.AlertProcessor.SendingQueueTest do
   alias MbtaServer.AlertProcessor.{SendingQueue, Model.Notification}
 
   setup do
-    {:ok, notification: %Notification{send_after: DateTime.utc_now()}}
+    {:ok, notification: %Notification{send_after: NaiveDateTime.utc_now()}}
   end
 
   test "Instantiates empty queue by default" do

--- a/test/alert_processor/model/notification_test.exs
+++ b/test/alert_processor/model/notification_test.exs
@@ -11,7 +11,7 @@ defmodule MbtaServer.AlertProcessor.Model.NotificationTest do
     phone_number: "+12345678910",
     header: "Short header",
     message: "There is a delay",
-    send_after: DateTime.utc_now,
+    send_after: NaiveDateTime.utc_now,
     alert_id: "12345678",
     status: :sent
   }

--- a/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -3,10 +3,10 @@ defmodule MbtaServer.AlertProcessor.NotificationBuilderTest do
   import MbtaServer.Factory
   alias MbtaServer.AlertProcessor.{Model, NotificationBuilder}
   alias Model.Alert
-  alias Calendar.DateTime, as: DT
+  alias Calendar.NaiveDateTime, as: DT
 
   setup do
-    now = DT.from_date_and_time_and_zone!({2018, 1, 8}, {14, 10, 55}, "Etc/UTC")
+    now = DT.from_date_and_time!({2018, 1, 8}, {14, 10, 55})
     two_days_ago = DT.subtract!(now, 172_800)
     one_day_ago = DT.subtract!(now, 86_400)
     thirty_minutes_from_now = DT.add!(now, 1800)
@@ -148,9 +148,9 @@ defmodule MbtaServer.AlertProcessor.NotificationBuilderTest do
   The active period is < 24 hours, so the default time to send the alert is immediately
   In this case, the alert would then get scheduled for 8am
   """ do
-    today_5am = DT.from_date_and_time_and_zone!({2018, 1, 8}, {5, 0, 0}, "Etc/UTC")
+    today_5am = DT.from_date_and_time!({2018, 1, 8}, {5, 0, 0})
     tomorrow_5am = DT.add!(today_5am, 86_400)
-    today_8am = DT.from_date_and_time_and_zone!({2018, 1, 8}, {8, 0, 0}, "Etc/UTC")
+    today_8am = DT.from_date_and_time!({2018, 1, 8}, {8, 0, 0})
     user = insert(
       :user,
       do_not_disturb_start: ~T[20:00:00],
@@ -180,9 +180,9 @@ defmodule MbtaServer.AlertProcessor.NotificationBuilderTest do
   The default time to send the alert immediately 10pm
   In this case, the alert would then get scheduled for 8am *tomorrow*
   """ do
-    today_10pm = DT.from_date_and_time_and_zone!({2018, 1, 8}, {22, 0, 0}, "Etc/UTC")
+    today_10pm = DT.from_date_and_time!({2018, 1, 8}, {22, 0, 0})
     tomorrow_10pm = DT.add!(today_10pm, 86_400)
-    tomorrow_8am = DT.from_date_and_time_and_zone!({2018, 1, 9}, {8, 0, 0}, "Etc/UTC")
+    tomorrow_8am = DT.from_date_and_time!({2018, 1, 9}, {8, 0, 0})
     user = insert(
       :user,
       do_not_disturb_start: ~T[20:00:00],

--- a/test/alert_processor/rules_engine/scheduler_test.exs
+++ b/test/alert_processor/rules_engine/scheduler_test.exs
@@ -3,10 +3,10 @@ defmodule MbtaServer.AlertProcessor.SchedulerTest do
   import MbtaServer.Factory
   alias MbtaServer.AlertProcessor.{Scheduler, Model, HoldingQueue}
   alias Model.Alert
-  alias Calendar.DateTime, as: DT
+  alias Calendar.NaiveDateTime, as: DT
 
   setup do
-    now = DT.from_date_and_time_and_zone!({2018, 1, 8}, {14, 10, 55}, "Etc/UTC")
+    now = DT.from_date_and_time!({2018, 1, 8}, {14, 10, 55})
     two_days_from_now = DT.add!(now, 172_800)
     three_days_from_now = DT.add!(now, 172_800)
 

--- a/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -20,7 +20,7 @@ defmodule MbtaServer.AlertProcessor.SubscriptionFilterEngineTest do
     build(:subscription, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1}])
     |> weekday_subscription
     |> insert
-    assert [{:ok, _} | _t] = SubscriptionFilterEngine.process_alert(alert)
+    assert {:ok, []} = SubscriptionFilterEngine.process_alert(alert)
   end
 
   test "process_alert/1 when message not provided", %{alert: alert} do
@@ -28,6 +28,6 @@ defmodule MbtaServer.AlertProcessor.SubscriptionFilterEngineTest do
     build(:subscription, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1}])
     |> weekday_subscription
     |> insert
-    assert [{:error, _} | _t] = SubscriptionFilterEngine.process_alert(Map.put(alert, :header, nil))
+    assert {:ok, []} = SubscriptionFilterEngine.process_alert(Map.put(alert, :header, nil))
   end
 end

--- a/test/fixture/custom_cassettes/route_19_minor_delay.json
+++ b/test/fixture/custom_cassettes/route_19_minor_delay.json
@@ -9,7 +9,7 @@
       "url": "https://dev.api.mbtace.com/alerts"
     },
     "response": {
-      "body": "{\"jsonapi\":{\"version\":\"1.0\"},\"data\":[{\"type\":\"alert\",\"links\":{\"self\":\"/alerts/177528\"},\"id\":\"177528\",\"attributes\":{\"url\":null,\"updated_at\":\"2017-04-11T07:53:33-04:00\",\"timeframe\":null,\"short_header\":\"Route 19 experiencing minor delays due to traffic\",\"severity\":\"Minor\",\"service_effect\":\"Minor Route 19 delay\",\"lifecycle\":\"New\",\"informed_entity\":[{\"route_type\":3,\"route\":\"19\"}],\"header\":\"Route 19 experiencing minor delays due to traffic\",\"effect_name\":\"Delay\",\"effect\":\"OTHER_EFFECT\",\"description\":null,\"created_at\":\"2017-04-11T07:53:33-04:00\",\"cause\":\"OTHER_CAUSE\",\"banner\":null,\"active_period\":[{\"start\":\"2017-04-11T07:53:32-04:00\",\"end\":\"2017-04-11T15:28:29-04:00\"}]}}]}",
+      "body": "{\"jsonapi\":{\"version\":\"1.0\"},\"data\":[{\"type\":\"alert\",\"links\":{\"self\":\"/alerts/177528\"},\"id\":\"177528\",\"attributes\":{\"url\":null,\"updated_at\":\"2017-04-11T07:53:33-04:00\",\"timeframe\":null,\"short_header\":\"Route 19 experiencing minor delays due to traffic\",\"severity\":\"Minor\",\"service_effect\":\"Minor Route 19 delay\",\"lifecycle\":\"New\",\"informed_entity\":[{\"route_type\":3,\"route\":\"19\"}],\"header\":\"Route 19 experiencing minor delays due to traffic\",\"effect_name\":\"Delay\",\"effect\":\"OTHER_EFFECT\",\"description\":null,\"created_at\":\"2017-04-11T07:53:33-04:00\",\"cause\":\"OTHER_CAUSE\",\"banner\":null,\"active_period\":[{\"start\":\"2017-04-11T07:53:32-04:00\",\"end\":null}]}}]}",
       "headers": {
         "cache-control": "max-age=0, private, must-revalidate",
         "Content-Type": "application/vnd.api+json; charset=utf-8",


### PR DESCRIPTION
- add active period filter to filter chain.
- add in scheduler to the end of the filter chain to actually scheduler notifications to be sent out rather than passing directly to dispatcher.