### PR TITLE
fix time ranges for comparison

### DIFF
--- a/lib/mbta_server/alert_processor/model/alert.ex
+++ b/lib/mbta_server/alert_processor/model/alert.ex
@@ -292,7 +292,7 @@ defmodule MbtaServer.AlertProcessor.Model.Alert do
           ^start_date ->
             day_of_week_atom = Subscription.relevant_day_of_week_type(Date.day_of_week(start_date))
 
-            Map.put(acc, day_of_week_atom, %{start: DateTimeHelper.seconds_of_day(start_time), end: 85_399})
+            Map.put(acc, day_of_week_atom, %{start: DateTimeHelper.seconds_of_day(start_time), end: 86_399})
           ^end_date ->
             relevant_day_of_week_atom = Subscription.relevant_day_of_week_type(Date.day_of_week(end_date))
 
@@ -300,7 +300,7 @@ defmodule MbtaServer.AlertProcessor.Model.Alert do
           date ->
             relevant_day_of_week_atom = Subscription.relevant_day_of_week_type(Date.day_of_week(date))
 
-            Map.put(acc, relevant_day_of_week_atom, %{start: 0, end: 85_399})
+            Map.put(acc, relevant_day_of_week_atom, %{start: 0, end: 86_399})
         end
       end)
     end

--- a/lib/mbta_server/alert_processor/rules_engine/time_frame_comparison.ex
+++ b/lib/mbta_server/alert_processor/rules_engine/time_frame_comparison.ex
@@ -30,6 +30,8 @@ defmodule MbtaServer.AlertProcessor.TimeFrameComparison do
   end
 
   defp range_map(%{start: start_seconds, end: end_seconds}) do
-    MapSet.new(start_seconds..end_seconds)
+    start_minute = Integer.floor_div(start_seconds, 60) * 60
+    end_minute = Integer.floor_div(end_seconds, 60) * 60
+    MapSet.new(Enum.take_every(start_minute..end_minute, 60))
   end
 end


### PR DESCRIPTION
fixed typo for end of day seconds number 85_399 -> 86_399.
update range generation to normalize to minutes and then only create a list with the integers corresponding to minutes since dnd/subscription times will be minute based rather than seconds to cut down list size by 60x.