### PR TITLE
ensure atoms needed for String.to_existing_atom are loaded 

### DIFF
--- a/lib/mbta_server/alert_processor/model/alert.ex
+++ b/lib/mbta_server/alert_processor/model/alert.ex
@@ -2,16 +2,27 @@ defmodule MbtaServer.AlertProcessor.Model.Alert do
   @moduledoc """
   Representation of alert received from MBTA /alerts endpoint
   """
-  alias MbtaServer.AlertProcessor.{Model.Subscription, Helpers.DateTimeHelper, TimeFrameComparison}
+  alias MbtaServer.AlertProcessor.{Model.InformedEntity, Model.Subscription, Helpers.DateTimeHelper, TimeFrameComparison}
 
   defstruct [:active_period, :effect_name, :id, :header, :informed_entities, :severity, :last_push_notification]
+
+  @type informed_entity :: [
+    %{
+      optional(:direction_id) => integer,
+      optional(:facility_type) => InformedEntity.facility_type,
+      optional(:route) => String.t,
+      optional(:route_type) => integer,
+      optional(:stop) => String.t,
+      optional(:trip) => String.t
+    }
+  ]
 
   @type t :: %__MODULE__{
     active_period: [%{start: DateTime.t, end: DateTime.t | nil}],
     effect_name: String.t,
     header: String.t,
     id: String.t,
-    informed_entities: [map],
+    informed_entities: [informed_entity],
     severity: atom,
     active_period: [map],
     last_push_notification: DateTime.t

--- a/lib/mbta_server/alert_processor/model/informed_entity.ex
+++ b/lib/mbta_server/alert_processor/model/informed_entity.ex
@@ -6,9 +6,11 @@ defmodule MbtaServer.AlertProcessor.Model.InformedEntity do
 
   alias MbtaServer.AlertProcessor.Model.Subscription
 
+  @type facility_type :: :elevator | :escalator
+
   @type t :: %__MODULE__{
     direction_id: integer,
-    facility_type: :elevator | :escalator,
+    facility_type: facility_type,
     route: String.t,
     route_type: integer,
     subscription_id: String.t,


### PR DESCRIPTION
running into intermittent errors where the atoms from `InformedEntity` aren't loaded yet when trying to parse the alerts and transform the string representations of the facility type into an atom.