### PR TITLE
update holding and sending queue to not accept duplicate notifications

### DIFF
--- a/lib/mbta_server/alert_processor/dissemination/holding_queue.ex
+++ b/lib/mbta_server/alert_processor/dissemination/holding_queue.ex
@@ -10,7 +10,7 @@ defmodule MbtaServer.AlertProcessor.HoldingQueue do
 
   @doc false
   def start_link(notifications \\ []) do
-    GenServer.start_link(__MODULE__, notifications, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, Enum.uniq(notifications), [name: __MODULE__])
   end
 
   @doc """
@@ -74,7 +74,7 @@ defmodule MbtaServer.AlertProcessor.HoldingQueue do
   end
   def handle_call({:push, notification}, _from, notifications) do
     newstate = [notification | notifications]
-    {:reply, :ok, newstate}
+    {:reply, :ok, Enum.uniq(newstate)}
   end
   def handle_call({:remove, removed_alert_ids}, _from, notifications) do
     newstate = Enum.reject(notifications, &Enum.member?(removed_alert_ids, &1.alert_id))

--- a/lib/mbta_server/alert_processor/dissemination/sending_queue.ex
+++ b/lib/mbta_server/alert_processor/dissemination/sending_queue.ex
@@ -41,7 +41,7 @@ defmodule MbtaServer.AlertProcessor.SendingQueue do
   @doc false
   def handle_call({:push, notification}, _from, notifications) do
     newstate = [notification | notifications]
-    {:reply, :ok, newstate}
+    {:reply, :ok, Enum.uniq(newstate)}
   end
 
   @doc false

--- a/test/alert_processor/dissemination/holding_queue_test.exs
+++ b/test/alert_processor/dissemination/holding_queue_test.exs
@@ -86,4 +86,17 @@ defmodule MbtaServer.AlertProcessor.HoldingQueueTest do
     assert HoldingQueue.pop == {:ok, notification}
     assert HoldingQueue.pop == :error
   end
+
+  test "Duplicate notifications are not enqueued" do
+    notification1 = %Notification{alert_id: "1", user_id: "1"}
+    notification2 = %Notification{alert_id: "1", user_id: "1"}
+    HoldingQueue.start_link()
+    HoldingQueue.enqueue(notification1)
+    HoldingQueue.enqueue(notification2)
+
+    {:ok, notification} = HoldingQueue.pop()
+    assert notification == notification1
+    assert notification == notification2
+    assert :error = HoldingQueue.pop()
+  end
 end

--- a/test/alert_processor/dissemination/sending_queue_test.exs
+++ b/test/alert_processor/dissemination/sending_queue_test.exs
@@ -21,4 +21,17 @@ defmodule MbtaServer.AlertProcessor.SendingQueueTest do
     assert SendingQueue.pop == {:ok, notification}
     assert SendingQueue.pop == :error
   end
+
+  test "Duplicate notifications are not enqueued" do
+    notification1 = %Notification{alert_id: "1", user_id: "1"}
+    notification2 = %Notification{alert_id: "1", user_id: "1"}
+    SendingQueue.start_link()
+    SendingQueue.enqueue(notification1)
+    SendingQueue.enqueue(notification2)
+
+    {:ok, notification} = SendingQueue.pop()
+    assert notification == notification1
+    assert notification == notification2
+    assert :error = SendingQueue.pop()
+  end
 end


### PR DESCRIPTION
convert holding and sending queues to `MapSet` temporarily on enqueue to avoid enqueueing duplicate notifications.