### PR TITLE
Schedule Digests Part 1

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_cache.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_cache.ex
@@ -21,10 +21,21 @@ defmodule AlertProcessor.AlertCache do
     GenServer.call(name, {:update_cache, alerts})
   end
 
+  @doc """
+  Return list of alerts in cache
+  """
+  @spec get_alerts(atom) :: [map]
+  def get_alerts(name \\ __MODULE__) do
+    GenServer.call(name, :get_alerts)
+  end
+
   def init(_) do
     {:ok, %{alerts: %{}}}
   end
 
+  def handle_call(:get_alerts, _from, state) do
+    {:reply, Map.values(state.alerts), state}
+  end
   def handle_call({:update_cache, new_alerts}, _from, %{alerts: old_alerts}) do
     removed_alert_ids =  Map.keys(old_alerts) -- Map.keys(new_alerts)
     updated_alert_ids = get_updated_ids(new_alerts, old_alerts)

--- a/apps/alert_processor/lib/digest/digest_builder.ex
+++ b/apps/alert_processor/lib/digest/digest_builder.ex
@@ -1,0 +1,19 @@
+defmodule AlertProcessor.DigestBuilder do
+  @moduledoc """
+  Generates digests for all users/alerts in the system
+  """
+
+  @doc """
+  1. Fetch all digests
+  2. For each user, filter the digests they should receive
+  3. Disseminate
+  """
+  @spec send_digests() :: :ok
+  def send_digests do
+    # TODO:
+    # alerts = AlertCache.get_alerts()
+    # filter for each user by informed entity
+    # build digest for each user for all relevant alerts
+    :ok
+  end
+end

--- a/apps/alert_processor/lib/digest/digest_manager.ex
+++ b/apps/alert_processor/lib/digest/digest_manager.ex
@@ -1,0 +1,31 @@
+defmodule AlertProcessor.DigestManager do
+  @moduledoc false
+  use GenServer
+  alias AlertProcessor.{DigestBuilder, Helpers}
+  alias Helpers.DateTimeHelper
+
+  @digest_interval 604_800 # 1 Week in seconds
+  @digest_day 7
+  @digest_time ~T[21:00:00]
+
+  def start_link do
+    GenServer.start_link(__MODULE__, @digest_interval, [name: __MODULE__])
+  end
+
+  def init(state) do
+    next_digest_ms = DateTimeHelper.seconds_until_next_digest(
+      @digest_interval,
+      @digest_day,
+      @digest_time,
+      {Date.utc_today(), Time.utc_now()}) * 1000
+
+    Process.send_after(self(), :send_digests, next_digest_ms)
+    {:ok, state}
+  end
+
+  def handle_info(:send_digests, interval) do
+    DigestBuilder.send_digests()
+    Process.send_after(self(), :send_digests, interval * 1000)
+    {:noreply, interval}
+  end
+end

--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -3,8 +3,10 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
   Module containing reusable datetime helpers for
   multi-step datetime functions.
   """
+  @seconds_in_a_week 86_400
 
   alias Calendar.DateTime, as: DT
+  alias Calendar.Time, as: T
 
   @spec datetime_to_date_and_time(DateTime.t) :: {Date.t, Time.t}
   def datetime_to_date_and_time(datetime) do
@@ -42,5 +44,37 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
   def seconds_of_day(timestamp) do
     {hour, minute, second} = Time.to_erl(timestamp)
     (hour * 3600) + (minute * 60) + second
+  end
+
+
+  @doc """
+  Takes 4 arguments:
+  1. The interval length in seconds (1 week)
+  2. The day of the week the digest goes out
+  3. The time of day the digest goes out
+  4. {current_date, current_time}
+
+  It then calculates the number of seconds to the next Date/Time the digest would go out.
+  Accounts for negative days (current day of week is > day of week digest goes out)
+  Accounts for negative time (current time is > time of day digest goes out)
+  """
+  @spec seconds_until_next_digest(integer, integer, Time.t, {Date.t, Time.t}) :: integer
+  def seconds_until_next_digest(interval, day_of_week, time_of_day, {date, time}) do
+    difference = difference_in_days_as_seconds(day_of_week, date) +
+                 difference_in_time_as_seconds(time_of_day, time)
+    if difference >= 0 do
+      difference
+    else
+      interval - difference
+    end
+  end
+
+  defp difference_in_days_as_seconds(day_of_week, today) do
+    current_day_of_week = today |> Date.day_of_week
+    (day_of_week - current_day_of_week) * @seconds_in_a_week
+  end
+
+  defp difference_in_time_as_seconds(time_of_day, time_now) do
+    T.diff(time_of_day, time_now)
   end
 end

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -8,6 +8,7 @@ defmodule AlertProcessor.Supervisor do
   alias AlertProcessor.{
     AlertCache,
     AlertWorker,
+    DigestManager,
     HoldingQueue,
     SendingQueue,
     NotificationWorker,
@@ -36,6 +37,7 @@ defmodule AlertProcessor.Supervisor do
       supervisor(AlertProcessor.Repo, []),
       worker(AlertWorker, []),
       worker(AlertCache, []),
+      worker(DigestManager, []),
       worker(HoldingQueue, []),
       worker(SendingQueue, []),
       worker(QueueWorker, []),

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_cache_test.exs
@@ -35,4 +35,11 @@ defmodule AlertProcessor.AlertCacheTest do
     assert {[%{id: "1"}, %{id: "2"}, %{id: "3"}], []} == AlertCache.update_cache(pid, old_alerts)
     assert {[%{id: "1"}, updated_alert], ["3", updated_alert.id]} == AlertCache.update_cache(pid, updated_alerts)
   end
+
+  test "get_alerts/0 returns list of alerts in the cache", %{pid: pid} do
+    alerts = %{"1" => %{id: "1"}, "2" => %{id: "2"}, "3" => %{id: "3"}}
+    AlertCache.update_cache(pid, alerts)
+
+    assert [%{id: "1"}, %{id: "2"}, %{id: "3"}] == AlertCache.get_alerts(pid)
+  end
 end

--- a/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
@@ -1,0 +1,38 @@
+defmodule AlertProcessor.Helpers.DateTimeHelperTest do
+  use ExUnit.Case
+  alias AlertProcessor.Helpers.DateTimeHelper, as: DTH
+
+  @interval 604_800 # 1 Week in seconds
+  @sunday 7
+  @time_of_day ~T[21:00:00]
+
+  test "seconds_until_next_digest/3 returns seconds between now and a specific day/time" do
+    tuesday_8pm_utc = {~D[2017-05-16], ~T[20:00:00]}
+    seconds = DTH.seconds_until_next_digest(@interval,
+                                            @sunday,
+                                            @time_of_day,
+                                            tuesday_8pm_utc)
+
+    assert seconds == 435_600
+  end
+
+  test "seconds_until_next_digest/3 handles day of week before current day of week" do
+    sunday_8pm_utc = {~D[2017-05-21], ~T[20:00:00]}
+    seconds = DTH.seconds_until_next_digest(@interval,
+                                            6,
+                                            @time_of_day,
+                                            sunday_8pm_utc)
+
+    assert seconds == 687_600
+  end
+
+  test "seconds_until_next_digest/3 handles time of day earlier than current" do
+    tuesday_8pm_utc = {~D[2017-05-16], ~T[20:00:00]}
+    seconds = DTH.seconds_until_next_digest(@interval,
+                                            @sunday,
+                                            ~T[12:00:00],
+                                            tuesday_8pm_utc)
+
+    assert seconds == 403_200
+  end
+end


### PR DESCRIPTION
In the interest of manageable PRs, I'll be breaking up digest sending in a few parts. In part 1 we have:

1. A genserver that schedules the sending of digests
2. Some time helpers to help calculate intervals for [1]
3. Update to the AlertCache to be able to fetch alerts for sending.

The DigestBuilder is a placeholder for now so our DigestManager has a function to call. It will handle the filtering of alerts by subscription and the construction of digests for each user in a subsequent PR