### PR TITLE
make facility alerts on or off rather than based on severity

### DIFF
--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -240,8 +240,8 @@ defmodule AlertProcessor.Model.Alert do
     },
     "Facility" => %{
       "Access Issue" => %{
-        minor: 1,
-        moderate: 2,
+        minor: 3,
+        moderate: 3,
         severe: 3
       }
     }


### PR DESCRIPTION
update facility alert severity to always return as severe to always match subscriptions if the entity is matched.