### PR TITLE
Set up basic skeleton of DigestSerializer and DigestDispatcher (Digest part 4)

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -19,7 +19,8 @@ config :alert_processor, AlertProcessor.NotificationMailer,
   adapter: Bamboo.LocalAdapter
 
 config :alert_processor, AlertProcessor.DigestMailer,
-  adapter: Bamboo.LocalAdapter
+  adapter: Bamboo.LocalAdapter,
+  from: "faizaan@intrepid.io"
 
 config :alert_processor, AlertProcessor,
   pool_size: 2,

--- a/apps/alert_processor/config/dev.exs
+++ b/apps/alert_processor/config/dev.exs
@@ -12,8 +12,5 @@ config :ex_aws,
 config :alert_processor, AlertProcessor.NotificationMailer,
   adapter: Bamboo.LocalAdapter
 
-config :alert_processor, AlertProcessor.DigestMailer,
-  adapter: Bamboo.LocalAdapter
-
 # Config for ExAws lib
 config :alert_processor, :ex_aws, ExAws

--- a/apps/alert_processor/lib/digest/digest_dispatcher.ex
+++ b/apps/alert_processor/lib/digest/digest_dispatcher.ex
@@ -3,22 +3,18 @@ defmodule AlertProcessor.DigestDispatcher do
   Sends digests to users
   """
   alias AlertProcessor.{DigestMailer, Model}
-  alias Model.Digest
+  alias Model.DigestMessage
 
   @doc """
   Takes a list of digests and dispatches an email for each one
   """
-  @spec send_emails([Digest.t]) :: :ok
-  def send_emails(digests) do
-    digests
-    |> Enum.each(fn(digest) ->
-      send_email(digest)
-    end)
-    :ok
+  @spec send_emails([DigestMessage.t]) :: :ok
+  def send_emails(digest_messages) do
+    Enum.each(digest_messages, &send_email/1)
   end
 
-  defp send_email(digest) do
-    digest
+  defp send_email(digest_message) do
+    digest_message
     |> DigestMailer.digest_email()
     |> DigestMailer.deliver_later
    end

--- a/apps/alert_processor/lib/digest/digest_mailer.ex
+++ b/apps/alert_processor/lib/digest/digest_mailer.ex
@@ -2,28 +2,22 @@ defmodule AlertProcessor.DigestMailer do
   @moduledoc "Digest Mailer interface"
   use Bamboo.Mailer, otp_app: :alert_processor
   import Bamboo.Email
-  alias AlertProcessor.Model.Digest
+  alias AlertProcessor.Model.DigestMessage
+
+  @from Application.get_env(:alert_processor, __MODULE__)[:from]
 
   @doc "digest_email/1 takes a digest and builds a message to a user"
-  @spec digest_email(Digest.t) :: Elixir.Bamboo.Email.t
-  def digest_email(digest) do
+  @spec digest_email(DigestMessage.t) :: Elixir.Bamboo.Email.t
+  def digest_email(digest_message) do
     base_email()
-    |> to(digest.user.email)
+    |> to(digest_message.user.email)
     |> subject("MBTA Alerts Digest")
-    |> html_body(build_message(digest))
-    |> text_body(build_message(digest))
+    |> html_body(digest_message.body)
+    |> text_body(digest_message.body)
   end
 
   @spec base_email() :: Elixir.Bamboo.Email.t
   defp base_email do
-    new_email()
-    |> from("faizaan@intrepid.io")
-  end
-
-  @spec build_message(Digest.t) :: String.t
-  defp build_message(digest) do
-    # TODO: Waiting on spec
-    digest.serialized_alerts
-    |> Enum.join(" ")
+    from(new_email(), @from)
   end
 end

--- a/apps/alert_processor/lib/digest/digest_manager.ex
+++ b/apps/alert_processor/lib/digest/digest_manager.ex
@@ -2,7 +2,7 @@ defmodule AlertProcessor.DigestManager do
   @moduledoc false
   use GenServer
   alias AlertProcessor.{AlertCache, DigestBuilder,
-    DigestSerializer, DigestDispatcher, Helpers}
+    Model.DigestMessage, DigestDispatcher, Helpers}
   alias Helpers.DateTimeHelper
 
   @digest_interval 604_800 # 1 Week in seconds
@@ -27,7 +27,7 @@ defmodule AlertProcessor.DigestManager do
   def handle_info(:send_digests, interval) do
     AlertCache.get_alerts()
     |> DigestBuilder.build_digests()
-    |> DigestSerializer.serialize()
+    |> Enum.map(&DigestMessage.from_digest/1)
     |> DigestDispatcher.send_emails()
     Process.send_after(self(), :send_digests, interval * 1000)
     {:noreply, interval}

--- a/apps/alert_processor/lib/digest/digest_serializer.ex
+++ b/apps/alert_processor/lib/digest/digest_serializer.ex
@@ -2,21 +2,17 @@ defmodule AlertProcessor.DigestSerializer do
   @moduledoc """
   Converts alerts into digest email text
   """
-  alias AlertProcessor.Model.{Alert, Digest, User}
+  alias AlertProcessor.Model.{Alert, Digest}
 
   @doc """
   Takes a Digest and serializes each alert into
   the format it will be presented in an email
   """
-  @spec serialize([Digest.t]) :: [{User.t, [String.t]}]
-  def serialize(digests) do
-    digests
-    |> Enum.map(fn(digest) ->
-      serialized_alerts = Enum.map(digest.alerts, fn(alert) ->
-        serialize_alert(alert)
-      end)
-      Map.put(digest, :serialized_alerts, serialized_alerts)
-    end)
+  @spec serialize([Digest.t]) :: iodata
+  def serialize(digest) do
+    digest.alerts
+    |> Enum.map(&serialize_alert/1)
+    |> Enum.join(" ")
   end
 
   @spec serialize_alert(Alert.t) :: String.t

--- a/apps/alert_processor/lib/model/digest.ex
+++ b/apps/alert_processor/lib/model/digest.ex
@@ -3,11 +3,10 @@ defmodule AlertProcessor.Model.Digest do
   Representation of Digest data
   """
   alias AlertProcessor.{Model.User, Model.Alert}
-  defstruct [:user, :alerts, :serialized_alerts]
+  defstruct [:user, :alerts]
 
   @type t :: %__MODULE__{
     user: User.t,
-    alerts: [Alert.t],
-    serialized_alerts: [String.t]
+    alerts: [Alert.t]
   }
 end

--- a/apps/alert_processor/lib/model/digest_message.ex
+++ b/apps/alert_processor/lib/model/digest_message.ex
@@ -1,0 +1,20 @@
+defmodule AlertProcessor.Model.DigestMessage do
+  @moduledoc """
+  Representation of DigestMessage data
+  """
+  alias AlertProcessor.{Model.User, Model.Digest, DigestSerializer}
+  defstruct [:user, :digest, :body]
+
+  @type t :: %__MODULE__{
+    user: User.t,
+    digest: Digest.t,
+    body: String.t
+  }
+
+  def from_digest(digest) do
+    %__MODULE__{user: digest.user,
+                digest: digest,
+                body: DigestSerializer.serialize(digest)}
+  end
+
+end

--- a/apps/alert_processor/test/alert_processor/digest/digest_dispatcher_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_dispatcher_test.exs
@@ -4,14 +4,15 @@ defmodule AlertProcessor.DigestDispatcherTest do
   use Bamboo.Test, shared: true
 
   alias AlertProcessor.{DigestDispatcher, DigestMailer, Model}
-  alias Model.{Alert, Digest, User}
+  alias Model.{Alert, Digest, DigestMessage, User}
 
   test "send_email/1 sends emails from digest list" do
     user = %User{email: "abc@123.com"}
     alert = %Alert{id: "1", header: "Test"}
-    digest = %Digest{user: user, alerts: [alert], serialized_alerts: ["Test"]}
+    digest = %Digest{user: user, alerts: [alert]}
+    message = DigestMessage.from_digest(digest)
 
-    DigestDispatcher.send_emails([digest])
-    assert_delivered_email DigestMailer.digest_email(digest)
+    DigestDispatcher.send_emails([message])
+    assert_delivered_email DigestMailer.digest_email(message)
   end
 end

--- a/apps/alert_processor/test/alert_processor/digest/digest_mailer_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_mailer_test.exs
@@ -4,13 +4,14 @@ defmodule AlertProcessor.DigestMailerTest do
   use Bamboo.Test, shared: true
 
   alias AlertProcessor.{DigestMailer, Model}
-  alias Model.{Alert, Digest, User}
+  alias Model.{Alert, Digest, DigestMessage, User}
 
   test "what" do
     user = %User{email: "abc@123.com"}
     alert = %Alert{id: "1", header: "Test"}
-    digest = %Digest{user: user, alerts: [alert], serialized_alerts: ["Test"]}
-    email = DigestMailer.digest_email(digest)
+    digest = %Digest{user: user, alerts: [alert]}
+    message = DigestMessage.from_digest(digest)
+    email = DigestMailer.digest_email(message)
 
     assert email.to == user.email
     assert email.html_body == alert.header


### PR DESCRIPTION
Add support for serializing Digests and sending them out to users. 

1. DigestSerializer takes list of digests and adds a serialized version of each alert
2. DigestDispatcher takes list of digests and emails them to use
3. DigestMailer takes a digest and contructs an email

In this PR the implementation of DigestSerializer and DigestMailer is incomplete. Still working out the exact look of emails but still want to get end to end working so I can continue on the other filters.