### PR TITLE
do not send both email and text, favor text when phone number present

### DIFF
--- a/apps/alert_processor/lib/dissemination/dispatcher.ex
+++ b/apps/alert_processor/lib/dissemination/dispatcher.ex
@@ -33,23 +33,14 @@ defmodule AlertProcessor.Dispatcher do
     {:error, "no contact information"}
   end
 
-  defp do_send_notification(nil, phone_number, notification) do
-    notification
-    |> NotificationSmser.notification_sms(phone_number)
-    |> @ex_aws.request([])
-  end
-
-  defp do_send_notification(email, nil, notification) do
+ defp do_send_notification(email, nil, notification) do
     email = notification
     |> NotificationMailer.notification_email(email)
     |> NotificationMailer.deliver_later
     {:ok, email}
   end
 
-  defp do_send_notification(email, phone_number, notification) do
-    notification
-    |> NotificationMailer.notification_email(email)
-    |> NotificationMailer.deliver_later
+  defp do_send_notification(_email, phone_number, notification) do
     notification
     |> NotificationSmser.notification_sms(phone_number)
     |> @ex_aws.request([])

--- a/apps/alert_processor/test/alert_processor/dissemination/dispatcher_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/dispatcher_test.exs
@@ -51,14 +51,14 @@ defmodule AlertProcessor.DispatcherTest do
     assert_delivered_email NotificationMailer.notification_email(@body, @email)
   end
 
-  test "notification_email/1 can send sms and email" do
+  test "notification_email/1 cannot send both sms and email" do
     notification = %Notification{
       message: @body,
       email: @email,
       phone_number: @phone_number
     }
     {:ok, _} = Dispatcher.send_notification(notification)
-    assert_delivered_email NotificationMailer.notification_email(@body, @email)
+    refute_delivered_email NotificationMailer.notification_email(@body, @email)
     assert_received :publish
   end
 end

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
@@ -8,13 +8,12 @@ defmodule AlertProcessor.NotificationWorkerTest do
     email = "test@example.com"
     body = "This is a test alert"
     body_2 = "Another alert"
-    phone_number = "5555551234"
     status = "unsent"
 
     notification = %Notification{
       message: body,
       email: email,
-      phone_number: phone_number,
+      phone_number: nil,
       send_after: DateTime.utc_now(),
       status: status
     }
@@ -22,7 +21,7 @@ defmodule AlertProcessor.NotificationWorkerTest do
     notification_2 = %Notification{
       message: body_2,
       email: email,
-      phone_number: phone_number,
+      phone_number: nil,
       send_after: DateTime.utc_now(),
       status: status
     }


### PR DESCRIPTION
If a use has a phone number, we want to send texts rather than email. We do not want to send both. 