### PR TITLE
handle for nil active_period.end for digests

### DIFF
--- a/apps/alert_processor/lib/digest/digest_date_helper.ex
+++ b/apps/alert_processor/lib/digest/digest_date_helper.ex
@@ -63,6 +63,9 @@ defmodule AlertProcessor.DigestDateHelper do
   end
 
   @spec active_period_within?(map, {DateTime.t, DateTime.t}) :: boolean()
+  defp active_period_within?(%{start: aps, end: nil}, {dgs, _dge}) do
+    not DT.after?(aps, dgs)
+  end
   defp active_period_within?(%{start: aps, end: ape}, {dgs, dge}) do
     not DT.before?(dge, aps) and not DT.before?(ape, dgs)
   end

--- a/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
@@ -36,6 +36,13 @@ defmodule AlertProcessor.DigestDateHelperTest do
     }
   ]
 
+  @ap5 [
+    %{
+      start: DT.from_erl!({{2017, 05, 27}, {1, 0, 1}}, "America/New_York"),
+      end: nil
+    }
+  ]
+
 
   @alert1 %Alert{
     id: "1",
@@ -59,6 +66,12 @@ defmodule AlertProcessor.DigestDateHelperTest do
     id: "4",
     header: "test4",
     active_period: @ap4
+  }
+
+  @alert5 %Alert{
+    id: "5",
+    header: "test5",
+    active_period: @ap5
   }
 
   test "calculate_date_groups/1 adds date group array to each alert" do
@@ -92,5 +105,29 @@ defmodule AlertProcessor.DigestDateHelperTest do
     assert u_week == upcoming_week
     assert n_weekend == next_weekend
     assert fut == future
+  end
+
+  test "handle for nil active_period.end" do
+    alerts = [@alert5]
+
+    assert {_alerts, digest_date_group} = DigestDateHelper.calculate_date_groups(alerts, @thursday)
+    assert %DigestDateGroup{
+     upcoming_weekend: %{
+        timeframe: _u_weekend,
+        alert_ids: []
+      },
+     upcoming_week: %{
+        timeframe: _u_week,
+        alert_ids: ["5"]
+      },
+      next_weekend: %{
+        timeframe: _n_weekend,
+        alert_ids: ["5"]
+      },
+      future: %{
+        timeframe: _fut,
+        alert_ids: ["5"]
+      }
+    } = digest_date_group
   end
 end


### PR DESCRIPTION
The Digests weren't handling an active_period with no end, this PR fixes that