### PR TITLE
Prevent already selected station from appearing as a suggestion

### DIFF
--- a/apps/concierge_site/assets/js/select-station.js
+++ b/apps/concierge_site/assets/js/select-station.js
@@ -81,8 +81,12 @@ export default function($) {
     });
 
     if (otherStationHasValidSelection(originDestination)) {
+      const otherStation = oppositeStation(originDestination);
       matchingStations = matchingStations.filter(function(station) {
-        return (stationsOnSelectedLines(originDestination).includes(station.name));
+        return (
+          state[otherStation].selectedName != station.name &&
+          stationsOnSelectedLines(originDestination).includes(station.name)
+        );
       });
     }
 

--- a/apps/concierge_site/assets/test/select-station_test.js
+++ b/apps/concierge_site/assets/test/select-station_test.js
@@ -120,6 +120,22 @@ describe("selectStation", function() {
         assert.lengthOf($suggestions, 1);
         assert.equal(suggestionText, "Kendall/MIT");
       });
+
+      it("does not show the same station as a suggestion even if the text matches", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("Braintree");
+        simulateKeyUp($originInput[0])
+        $(".origin-station-suggestion").first().mousedown();
+
+        const $destinationInput = $("input.subscription-select-destination");
+        $destinationInput.val("Braintree");
+        const $suggestionContainer = $("input.subscription-select-destination + .suggestion-container");
+        simulateKeyUp($destinationInput[0]);
+
+        const $suggestions = $(".destination-station-suggestion");
+
+        assert.lengthOf($suggestions, 0);
+      });
     });
   });
 


### PR DESCRIPTION
PR supplements the suggestion filtering for when one station is already selected-- suggestions will not appear for the same station that has already been selected in the other input.