### PR TITLE
Add hidden field for Subway trip_type from previous page

### DIFF
--- a/apps/concierge_site/lib/templates/subway_subscription/info.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/info.html.eex
@@ -52,6 +52,11 @@
       </div>
       <%= render "_travel_time_select_lists.html", trip_type: @subscription_params["trip_type"] %>
     </div>
+
+    <%= text_input :subscription,
+                   :trip_type,
+                   value: @subscription_params["trip_type"],
+                   hidden: true %>
   </form>
 </div>
 


### PR DESCRIPTION
PR adds the final field to the Trip Info page in the flow for creating a new Subway subscription. The flow for creating a subscription spans multiple pages and requests, so the `trip_type` selection from the previous page will be passed forward to the Preferences page as a hidden text input.