### PR TITLE
enable commuter rail subscription link and add trip type selector

### DIFF
--- a/apps/concierge_site/assets/css/_subscription-progress-bar.scss
+++ b/apps/concierge_site/assets/css/_subscription-progress-bar.scss
@@ -30,6 +30,7 @@
 .progress-link {
   display: inline-block;
   text-align: center;
+  min-width: 30%;
 }
 
 .disabled-progress-link {
@@ -39,11 +40,13 @@
 .progress-step-trip-type {
   position: absolute;
   left: -1.75rem;
+  min-width: 0%;
 }
 
 .progress-step-preferences {
   position: absolute;
   right: -1.75rem;
+  min-width: 0%;
 }
 
 .progress-circle {

--- a/apps/concierge_site/lib/controllers/commuter_rail_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/commuter_rail_subscription_controller.ex
@@ -1,0 +1,15 @@
+defmodule ConciergeSite.CommuterRailSubscriptionController do
+  use ConciergeSite.Web, :controller
+  use Guardian.Phoenix.Controller
+  alias ConciergeSite.Subscriptions.TemporaryState
+
+  def new(conn, _params, _user, _claims) do
+    render conn, "new.html"
+  end
+
+  def info(conn, params, user, _claims) do
+    subscription_params = Map.merge(params, %{user_id: user.id, route_type: 2})
+    token = TemporaryState.encode(subscription_params)
+    render conn, "info.html", token: token, subscription_params: subscription_params
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -38,6 +38,8 @@ defmodule ConciergeSite.Router do
     post "/subway/new/preferences", SubwaySubscriptionController, :preferences
     resources "/bus", BusSubscriptionController, only: [:new]
     get "/bus/new/info", BusSubscriptionController, :info
+    resources "/commuter_rail", CommuterRailSubscriptionController, only: [:new]
+    get "/commuter_rail/new/info", CommuterRailSubscriptionController, :info
   end
 
   if Mix.env == :dev do

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/_progress_bar.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/_progress_bar.html.eex
@@ -1,0 +1,26 @@
+<div class="progress-bar"></div>
+<div class="progress-container">
+  <%= render "_progress_bar_item.html",
+             link_to: commuter_rail_subscription_path(@conn, :new),
+             link_class: "progress-step-trip-type #{progress_link_class(@current_page, :trip_type)}",
+             step_classes:  progress_step_classes(@current_page, :trip_type),
+             name: "Trip Type" %>
+
+  <%= render "_progress_bar_item.html",
+             link_to: commuter_rail_subscription_path(@conn, :info),
+             link_class: progress_link_class(@current_page, :trip_info),
+             step_classes:  progress_step_classes(@current_page, :trip_info),
+             name: "Trip Info" %>
+
+  <%= render "_progress_bar_item.html",
+             link_to: "#",
+             link_class: progress_link_class(@current_page, :train),
+             step_classes:  progress_step_classes(@current_page, :train),
+             name: "Train" %>
+
+  <%= render "_progress_bar_item.html",
+             link_to: "#",
+             link_class: "progress-step-preferences #{progress_link_class(@current_page, :preferences)}",
+             step_classes:  progress_step_classes(@current_page, :preferences),
+             name: "Preferences" %>
+ </div>

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/_progress_bar_item.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/_progress_bar_item.html.eex
@@ -1,0 +1,6 @@
+<%= link to: @link_to, class: "progress-link #{@link_class}" do %>
+  <div class="progress-circle <%= @step_classes[:circle] %>"></div>
+  <div class="progress-step-name <%= @step_classes[:name] %>">
+    <%= @name %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/_trip_type_option.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/_trip_type_option.html.eex
@@ -1,0 +1,3 @@
+<%= link to: @link_to, class: "trip-type-option" do %>
+  <div><%= @name %></div>
+<% end %>

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/info.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/info.html.eex
@@ -1,0 +1,5 @@
+<h1>Create New Subscription</h1>
+
+<%= render "_progress_bar.html", current_page: :trip_info, conn: @conn %>
+
+Trip Info

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/new.html.eex
@@ -1,0 +1,21 @@
+<h1>Create New Subscription</h1>
+
+<%= render "_progress_bar.html", current_page: :trip_type, conn: @conn %>
+
+<div class="select-trip-type">
+  <h2 class="select-trip-type-header">What type of trip do you take?</h2>
+
+  <div class="trip-type-options-container">
+    <%= render "_trip_type_option.html",
+               link_to: commuter_rail_subscription_path(@conn, :info, trip_type: "one-way"),
+               name: "One Way" %>
+
+    <%= render "_trip_type_option.html",
+               link_to: commuter_rail_subscription_path(@conn, :info, trip_type: "round-trip"),
+               name: "Round Trip" %>
+  </div>
+
+  <%= link to: subscription_path(@conn, :new), class: "subscription-back-link" do %>
+    <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
+  <% end %>
+</div>

--- a/apps/concierge_site/lib/templates/subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/new.html.eex
@@ -11,7 +11,7 @@
                name: "Subway" %>
 
     <%= render "_service_option.html",
-               link_to: "#",
+               link_to: commuter_rail_subscription_path(@conn, :new),
                icon_class: "commuter-rail-icon",
                icon_src: static_url(@conn, "/images/commuter-rail.svg"),
                name: "Commuter Rail" %>

--- a/apps/concierge_site/lib/views/commuter_rail_subscription_view.ex
+++ b/apps/concierge_site/lib/views/commuter_rail_subscription_view.ex
@@ -1,0 +1,30 @@
+defmodule ConciergeSite.CommuterRailSubscriptionView do
+  use ConciergeSite.Web, :view
+
+  @disabled_progress_bar_links %{trip_info: [:trip_info, :train, :preferences],
+  train: [:train, :preferences],
+  preferences: [:preferences]}
+
+  @doc """
+  Provide css class to disable links within the subscription flow progress
+  bar
+  """
+  def progress_link_class(:trip_type, _step), do: "disabled-progress-link"
+
+  def progress_link_class(page, step) do
+    if @disabled_progress_bar_links |> Map.get(page) |> Enum.member?(step) do
+      "disabled-progress-link"
+    end
+  end
+
+  @doc """
+  Provide css classes for the text and circle in progress bar steps
+  """
+  def progress_step_classes(page, step) when (page == step) do
+    %{circle: "active-circle", name: "active-page"}
+  end
+
+  def progress_step_classes(_page, _step) do
+    %{}
+  end
+end

--- a/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule ConciergeSite.CommuterRailSubscriptionControllerTest do
+  use ConciergeSite.ConnCase
+
+  @password "password1"
+  @encrypted_password Comeonin.Bcrypt.hashpwsalt(@password)
+
+  alias AlertProcessor.{Model.User, Repo}
+
+  describe "authorized" do
+    test "GET /subscriptions/commuter_rail/new", %{conn: conn}  do
+      user = Repo.insert!(%User{email: "test@email.com",
+                                role: "user",
+                                encrypted_password: @encrypted_password})
+      conn = user
+      |> guardian_login(conn)
+      |> get("/subscriptions/commuter_rail/new")
+
+      assert html_response(conn, 200) =~ "What type of trip do you take?"
+    end
+
+    test "GET /subscriptions/commuter_rail/new/info", %{conn: conn}  do
+      user = Repo.insert!(%User{email: "test@email.com",
+                                role: "user",
+                                encrypted_password: @encrypted_password})
+      conn = user
+      |> guardian_login(conn)
+      |> get("/subscriptions/commuter_rail/new/info")
+
+      assert html_response(conn, 200) =~ "Info"
+    end
+  end
+
+  describe "unauthorized" do
+    test "GET /subscriptions/commuter_rail/new", %{conn: conn} do
+      conn = get(conn, "/subscriptions/commuter_rail/new")
+      assert html_response(conn, 302) =~ "/login"
+    end
+
+    test "GET /subscriptions/commuter_rail/new/info", %{conn: conn} do
+      conn = get(conn, "/subscriptions/commuter_rail/new/info")
+      assert html_response(conn, 302) =~ "/login"
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/commuter_rail_subscription_view_text.exs
+++ b/apps/concierge_site/test/web/views/commuter_rail_subscription_view_text.exs
@@ -1,0 +1,36 @@
+defmodule ConciergeSite.CommuterRailSubscriptionViewTest do
+  use ExUnit.Case
+  alias ConciergeSite.CommuterRailSubscriptionView
+
+  describe "progress_link_class" do
+    test "it returns the disabled class when the page is trip_type" do
+      class = CommuterRailSubscriptionView.progress_link_class(:trip_type, :trip_info)
+      assert class == "disabled-progress-link"
+    end
+
+    test "it returns the disabled class when the page/step are included in disabled_progress_bar_links" do
+      class = CommuterRailSubscriptionView.progress_link_class(:trip_info, :preferences)
+      assert class == "disabled-progress-link"
+    end
+
+    test "it returns nil otherwise" do
+      class = CommuterRailSubscriptionView.progress_link_class(:trip_info, :trip_type)
+      assert class == nil
+    end
+  end
+
+  describe "progress_step_classes" do
+
+    @active_classes %{circle: "active-circle", name: "active-page"}
+
+    test "it returns a map of active classes when step and page are equal" do
+      classes = CommuterRailSubscriptionView.progress_step_classes(:trip_info, :trip_info)
+      assert classes == @active_classes
+    end
+
+    test "it returns an empty map when step and page are different" do
+      classes = CommuterRailSubscriptionView.progress_step_classes(:preferences, :trip_type)
+      assert classes == %{}
+    end
+  end
+end


### PR DESCRIPTION
begin commuter rail subscription flow.
enable link to begin commuter rail subscription flow
add trip type page

<img width="1235" alt="screen shot 2017-06-20 at 5 07 05 pm" src="https://user-images.githubusercontent.com/526017/27356081-33dd058e-55db-11e7-833e-9d529e33bbf9.png">
