### PR TITLE
change description field to text to avoid insert errors due to lengh …

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20170622144910_change_description_to_text.exs
+++ b/apps/alert_processor/priv/repo/migrations/20170622144910_change_description_to_text.exs
@@ -1,0 +1,9 @@
+defmodule AlertProcessor.Repo.Migrations.ChangeDescriptionToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications, primary_key: false) do
+      modify :description, :text
+    end
+  end
+end


### PR DESCRIPTION
…exceeding 255 characters
was running into some errors for alerts with long descriptions due to the field's character limit.
`(Postgrex.Error) ERROR 22001 (string_data_right_truncation): value too long for type character varying(255)`