### PR TITLE
clear origin/destination input when losing focus if no valid selection

### DIFF
--- a/apps/concierge_site/assets/js/select-station.js
+++ b/apps/concierge_site/assets/js/select-station.js
@@ -74,6 +74,8 @@ export default function($) {
       $stationInput.attr("data-valid", true);
       $stationInput.attr("data-station-id",  $firstSuggestion.attr("data-station-id"));
       setSelectedStation(originDestination, stationName, $firstSuggestion.attr("data-lines"));
+    } else if (!props.validStationNames.includes($stationInput.val())) {
+      $stationInput.val(null);
     }
 
     unmountStationSuggestions(originDestination);

--- a/apps/concierge_site/assets/test/select-station_test.js
+++ b/apps/concierge_site/assets/test/select-station_test.js
@@ -232,7 +232,7 @@ describe("selectStation", function() {
         assert.equal($destinationInput.attr("data-station-id"), "place-brntn");
       });
 
-      it("does nothing when there are no suggestions in the origin field", () => {
+      it("clears input when there are no suggestions in the origin field", () => {
         const $originInput = $("input.subscription-select-origin");
         $originInput.val("abc123");
         const $suggestionContainer = $("input.subscription-select-origin + .suggestion-container");
@@ -241,11 +241,11 @@ describe("selectStation", function() {
         simulateKeyUp($originInput[0])
         $("input.subscription-select-destination").focus()
 
-        assert.equal($originInput.val(), "abc123");
+        assert.equal($originInput.val(), "");
         assert.equal($originInput.attr("data-station-id"), null);
       });
 
-      it("does nothing when there are no suggestions in the destination", () => {
+      it("clears input when there are no suggestions in the destination", () => {
         const $destinationInput = $("input.subscription-select-destination");
         $destinationInput.val("abc123");
         const $suggestionContainer = $("input.subscription-select-destination + .suggestion-container");
@@ -254,7 +254,7 @@ describe("selectStation", function() {
         simulateKeyUp($destinationInput[0])
         $("input.subscription-select-origin").focus()
 
-        assert.equal($destinationInput.val(), "abc123");
+        assert.equal($destinationInput.val(), "");
         assert.equal($destinationInput.attr("data-station-id"), null);
       });
     });


### PR DESCRIPTION
update to logic on how to handle focusout logic if there is not a valid selection available to auto-select. Clear field entirely rather than leaving in invalid data.