### PR TITLE
report coverage status to github

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,7 @@
 codecov:
   bot: mbtace
+coverage:
+  status:
+    changes: false
+    patch: true
+    project: true


### PR DESCRIPTION
Updates `codecov.yml` to report the coverage info as a GitHub status.