### PR TITLE
Subway Preferences page - Only check if trip is valid when both origin and destination are present

### DIFF
--- a/apps/concierge_site/lib/subscriptions/subway_params.ex
+++ b/apps/concierge_site/lib/subscriptions/subway_params.ex
@@ -47,8 +47,10 @@ defmodule ConciergeSite.Subscriptions.SubwayParams do
     end
   end
 
-  defp validate_station_pair({params, errors}) do
-    case map_station_schedules(params["origin"], params["destination"]) do
+  defp validate_station_pair({params = %{"origin" => ""}, errors}), do: {params, errors}
+  defp validate_station_pair({params = %{"destination" => ""}, errors}), do: {params, errors}
+  defp validate_station_pair({params = %{"origin" => origin, "destination" => destination}, errors}) do
+    case map_station_schedules(origin, destination) do
       {:ok, trips} ->
         [{_, origin_trip_ids}, {_, destination_trip_ids}] = trips
         if MapSet.disjoint?(origin_trip_ids, destination_trip_ids) do

--- a/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
@@ -61,6 +61,44 @@ defmodule ConciergeSite.SubwaySubscriptionControllerTest do
       assert html_response(conn, 200) =~ "Please correct the following errors to proceed"
     end
 
+    test "POST /subscriptions/subway/new/preferences with missing origin", %{conn: conn, user: user} do
+      params = %{"subscription" => %{
+        "departure_start" => "08:45:00",
+        "departure_end" => "09:15:00",
+        "origin" => "",
+        "destination" => "place-buest",
+        "saturday" => "false",
+        "sunday" => "false",
+        "weekday" => "true",
+        "trip_type" => "one_way",
+      }}
+
+      conn = user
+      |> guardian_login(conn)
+      |> post("/subscriptions/subway/new/preferences", params)
+
+      assert html_response(conn, 200) =~ "Origin is invalid"
+    end
+
+    test "POST /subscriptions/subway/new/preferences with missing destination", %{conn: conn, user: user} do
+      params = %{"subscription" => %{
+        "departure_start" => "08:45:00",
+        "departure_end" => "09:15:00",
+        "origin" => "place-buest",
+        "destination" => "",
+        "saturday" => "false",
+        "sunday" => "false",
+        "weekday" => "true",
+        "trip_type" => "one_way",
+      }}
+
+      conn = user
+      |> guardian_login(conn)
+      |> post("/subscriptions/subway/new/preferences", params)
+
+      assert html_response(conn, 200) =~ "Destination is invalid"
+    end
+
     test "POST /subscriptions/subway", %{conn: conn, user: user} do
       params = %{"subscription" => %{
         "alert_priority_type" => "high",


### PR DESCRIPTION
Fixes an issue found by Jeri here - https://intrepid.atlassian.net/browse/MTC-126 - leaving either origin or destination blank would result in an exception due to the API response handling when one of those two fields was empty.

PR changes this to only check whether the pair of stations is a valid trip when both stations are present.