### PR TITLE
Add PasswordReset model

### DIFF
--- a/apps/alert_processor/lib/model/password_reset.ex
+++ b/apps/alert_processor/lib/model/password_reset.ex
@@ -18,7 +18,7 @@ defmodule AlertProcessor.Model.PasswordReset do
   @primary_key {:id, :binary_id, autogenerate: true}
 
   schema "password_resets" do
-    belongs_to :user, User, type: :binary_id
+    belongs_to :user, AlertProcessor.Model.User, type: :binary_id
     field :expired_at, :utc_datetime
     field :redeemed_at, :utc_datetime
 
@@ -58,10 +58,10 @@ defmodule AlertProcessor.Model.PasswordReset do
   end
 
   defp validate_not_already_redeemed(changeset) do
-    if is_nil(changeset.data.redeemed_at) do
-      changeset
-    else
+    if get_field(changeset, :redeemed_at, nil) do
       add_error(changeset, :redeemed_at, "Password Reset has already been redeemed.")
+    else
+      changeset
     end
   end
 end

--- a/apps/alert_processor/priv/repo/migrations/20170711152200_add_password_resets_table.exs
+++ b/apps/alert_processor/priv/repo/migrations/20170711152200_add_password_resets_table.exs
@@ -4,11 +4,11 @@ defmodule MbtaServer.Repo.Migrations.AddPasswordResetsTable do
   def change do
     create table(:password_resets, primary_key: false) do
       add :id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()")
-      add :user_id, references(:users, type: :uuid)
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all)
       add :expired_at, :utc_datetime
       add :redeemed_at, :utc_datetime
 
-      timestamps(type: :utc_datetime, default: fragment("now()"))
+      timestamps(type: :utc_datetime)
     end
 
     create index(:password_resets, [:user_id])

--- a/apps/alert_processor/test/alert_processor/model/password_reset_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/password_reset_test.exs
@@ -4,19 +4,8 @@ defmodule AlertProcessor.Model.PasswordResetTest do
   alias AlertProcessor.Model.PasswordReset
   alias Calendar.DateTime
 
-  @base_attrs %{
-    expired_at: DateTime.add!(DateTime.now_utc, 3600),
-    redeemed_at: nil,
-  }
-
-  setup do
-    user = insert(:user)
-    valid_attrs = Map.put(@base_attrs, :user_id, user.id)
-
-    {:ok, user: user, valid_attrs: valid_attrs}
-  end
-
-  test "create_changeset/2 with valid parameters", %{valid_attrs: valid_attrs} do
+  test "create_changeset/2 with valid parameters" do
+    valid_attrs = params_with_assocs(:password_reset)
     changeset = PasswordReset.create_changeset(%PasswordReset{}, valid_attrs)
     assert changeset.valid?
   end
@@ -26,23 +15,23 @@ defmodule AlertProcessor.Model.PasswordResetTest do
     refute changeset.valid?
   end
 
-  test "redeem_changeset/2 with a redeemable PasswordReset", %{user: user} do
-    password_reset = insert(:password_reset, user_id: user.id)
+  test "redeem_changeset/2 with a redeemable PasswordReset" do
+    password_reset = insert(:password_reset)
     changeset = PasswordReset.redeem_changeset(password_reset)
     assert changeset.valid?
   end
 
-  test "redeem_changeset/2 with an expired PasswordReset", %{user: user}  do
+  test "redeem_changeset/2 with an expired PasswordReset" do
     expired_at = DateTime.subtract!(DateTime.now_utc, 3600)
-    password_reset = insert(:password_reset, expired_at: expired_at, user_id: user.id)
+    password_reset = insert(:password_reset, expired_at: expired_at)
     changeset = PasswordReset.redeem_changeset(password_reset)
 
     refute changeset.valid?
   end
 
-  test "redeem_changeset/2 with a redeemed PasswordReset", %{user: user}  do
+  test "redeem_changeset/2 with a redeemed PasswordReset" do
     redeemed_at = DateTime.subtract!(DateTime.now_utc, 3600)
-    password_reset = insert(:password_reset, redeemed_at: redeemed_at, user_id: user.id)
+    password_reset = insert(:password_reset, redeemed_at: redeemed_at)
     changeset = PasswordReset.redeem_changeset(password_reset)
 
     refute changeset.valid?

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -100,7 +100,8 @@ defmodule AlertProcessor.Factory do
   def password_reset_factory do
     %PasswordReset{
       expired_at: DateTime.add!(DateTime.now_utc, 3600),
-      redeemed_at: nil
+      redeemed_at: nil,
+      user: build(:user)
     }
   end
 end


### PR DESCRIPTION
(Part 1 of https://intrepid.atlassian.net/browse/MTC-143 Reset Password via email)

Adds a `PasswordReset` model with changesets for creating (user enters email address) and redeeming (user enters new password after clicking link in email).