### PR TITLE
add border color for safari to render inputs correctly

### DIFF
--- a/apps/concierge_site/assets/css/_subscription.scss
+++ b/apps/concierge_site/assets/css/_subscription.scss
@@ -226,8 +226,8 @@
   font-family: $font-family-base;
   font-size: $base-font-size-xxl;
   height: 2.25rem;
-  text-align-last: center;
-  width: 6.5rem;
+  width: 7.5rem;
+  border-color: $input-border-color;
 }
 
 .relevant-days-select {


### PR DESCRIPTION
bug with select boxes on safari rendering the default size unless specifically adding a border color.
also expanded the boxes to better fit the time text inside.

before:
<img width="944" alt="screen shot 2017-07-14 at 4 34 07 pm" src="https://user-images.githubusercontent.com/526017/28229852-70aa345c-68b2-11e7-870d-fac625406768.png">
after:
<img width="815" alt="screen shot 2017-07-14 at 4 33 37 pm" src="https://user-images.githubusercontent.com/526017/28229854-766bc84c-68b2-11e7-8e28-5a8f39d5ce73.png">

