### PR TITLE
Fix bug subscription text does not fit in subscription-info div

### DIFF
--- a/apps/concierge_site/assets/css/_my-subscriptions.scss
+++ b/apps/concierge_site/assets/css/_my-subscriptions.scss
@@ -81,7 +81,7 @@
   font-weight: bold;
   text-align: left;
   margin-bottom: 0.2rem;
-  flex-basis: auto;
+  flex: 1 0 auto;
   align-items: center;
 
   i {
@@ -92,7 +92,7 @@
 .subscription-details {
   text-align: left;
   font-size: 0.85rem;
-  flex-basis: auto;
+  flex: 1 0 auto;
 
   p {
     margin-bottom: 0.4rem;


### PR DESCRIPTION
This PR is associated with [MTC-292](https://intrepid.atlassian.net/browse/MTC-292), [MTC-295](https://intrepid.atlassian.net/browse/MTC-295), [MTC-287](https://intrepid.atlassian.net/browse/MTC-287), and [MTC-324](https://intrepid.atlassian.net/browse/MTC-324)

Description:
This is a bug identified in [Flexbugs](https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored) on Safari. Suggested workaround was using `flex-basis` with value of `auto`. Fixes bug associated with text not fitting inside the div for subscriptions

**Bug States**
1. Text spills over the container
![pasted image at 2017_07_07 05_03 pm](https://user-images.githubusercontent.com/8680734/28289131-7cabb424-6b0f-11e7-8d47-889e7cd5edfc.png)
2. Text is not left aligned if the text is too long
![screen shot 2017-07-18 at 9 56 44 am](https://user-images.githubusercontent.com/8680734/28320920-db8eefd4-6b9f-11e7-8272-c4f06556216d.png)
3. Edit subscription buttons have different sizes
![screen shot 2017-07-18 at 3 46 35 pm](https://user-images.githubusercontent.com/8680734/28336623-b2ad87f2-6bd0-11e7-9ee3-b843d8faafdc.png)


**Screen Shot of Fixed State** 
1. Text fits inside the container (on Safari)
![screen shot 2017-07-18 at 9 48 56 am](https://user-images.githubusercontent.com/8680734/28320348-5b471442-6b9e-11e7-84da-3acf754fc00d.png)
Text fits inside the container (on IE11 as well)
<img width="1137" alt="ie11_my_subscriptions" src="https://user-images.githubusercontent.com/8680734/28382264-8a589466-6c8b-11e7-9bc5-c00d04021209.png">

2. Text is left aligned when the text is long
![screen shot 2017-07-18 at 3 38 01 pm](https://user-images.githubusercontent.com/8680734/28336237-22fd89d2-6bcf-11e7-831f-3370ad46b354.png)
3. Edit subscription buttons are uniform
![screen shot 2017-07-18 at 3 48 25 pm](https://user-images.githubusercontent.com/8680734/28336633-be83526e-6bd0-11e7-9d26-5c0fc7079bd9.png)




