### PR TITLE
Remove left property on bus-icon img

### DIFF
--- a/apps/concierge_site/assets/css/_subscription.scss
+++ b/apps/concierge_site/assets/css/_subscription.scss
@@ -63,6 +63,9 @@
 
 .subway-icon {
   background-color: $brand-subway;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   img {
     height: 1rem;
@@ -71,35 +74,44 @@
 
 .commuter-rail-icon {
   background-color: $brand-commuter-rail;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   img {
-    bottom: .03125rem;
-    height: 1.125rem;
+    height: 1rem;
   }
 }
 
 .bus-icon {
   background-color: $brand-bus;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   img {
-    bottom: .0725rem;
-    height: .925rem;
+    height: 1rem;
   }
 }
 
 .ferry-icon {
   background-color: $brand-ferry;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   img {
-    bottom: .0625rem;
     height: 1rem;
   }
 }
 
 .mbta-icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   img {
-    bottom: .1875rem;
+    height: 1.5rem;
   }
 }
 


### PR DESCRIPTION
This PR is associated with [MTC-296](https://intrepid.atlassian.net/browse/MTC-296)

Description:
The bus icon on the "Select Service" page is slightly off centered to the right. The fix resolves this issue by removing the `left` property on the `bus-icon img` and making the icon image smaller

**Bug state**
![screen shot 2017-07-18 at 1 13 26 pm](https://user-images.githubusercontent.com/8680734/28330349-3e8b30c8-6bbb-11e7-8cc7-5c921c6fe90c.png)

**Resolved state**
<img width="919" alt="screen shot 2017-07-20 at 11 32 39 am" src="https://user-images.githubusercontent.com/8680734/28425872-8a8997f0-6d3f-11e7-9505-544cee1b3944.png">
