### PR TITLE
Flex wrap for 'My Account' and gear icon

### DIFF
--- a/apps/concierge_site/assets/css/_header.scss
+++ b/apps/concierge_site/assets/css/_header.scss
@@ -11,4 +11,12 @@
   font-size: $base-font-size-xxl;
   font-weight: normal;
   margin-left: auto;
+  @include media-breakpoint-down(xs) {
+    position: absolute;
+    right: 1rem;
+  }
+}
+
+.header-text {
+  padding-top: 1.5rem;
 }

--- a/apps/concierge_site/lib/templates/subscription/index.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/index.html.eex
@@ -1,5 +1,5 @@
 <h1 class="header-container">
-  <div>My Subscriptions</div>
+  <div class="header-text">My Subscriptions</div>
   <%= link to: my_account_path(@conn, :edit), class: "header-link" do %>
     My Account <i class="fa fa-gear"></i>
   <% end %>


### PR DESCRIPTION
This PR is associated with [MTC-323](https://intrepid.atlassian.net/browse/MTC-323)

Description:
Bug: As you make the screen smaller, the "My Account" text and gear icon do not align. Moreover, they remain above the bar.

**Bug State**:
![screen shot 2017-07-18 at 2 33 58 pm](https://user-images.githubusercontent.com/8680734/28341551-45c7a4ee-6be2-11e7-9f96-7d1e1339274c.png)
**Resolved State**:


![screen shot 2017-07-18 at 5 53 02 pm](https://user-images.githubusercontent.com/8680734/28341531-2f28d0fa-6be2-11e7-8f78-9d2285547fef.png)
 