### PR TITLE
show bus route name on edit page

### DIFF
--- a/apps/concierge_site/lib/controllers/bus_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/bus_subscription_controller.ex
@@ -9,7 +9,7 @@ defmodule ConciergeSite.BusSubscriptionController do
   end
 
   def edit(conn, %{"id" => id}, user, _claims) do
-    subscription = Subscription.one_for_user!(id, user.id)
+    subscription = Subscription.one_for_user!(id, user.id, true)
     changeset = Subscription.create_changeset(subscription)
     render conn, "edit.html", subscription: subscription, changeset: changeset
   end

--- a/apps/concierge_site/lib/templates/bus_subscription/edit.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/edit.html.eex
@@ -1,4 +1,4 @@
-<h1>Route Name</h1>
+<h1><%= route_name(@subscription) %></h1>
 
 <div class="edit-subscription subscription-step">
   <h2>Edit Subscription</h2>

--- a/apps/concierge_site/lib/views/bus_subscription_view.ex
+++ b/apps/concierge_site/lib/views/bus_subscription_view.ex
@@ -5,6 +5,8 @@ defmodule ConciergeSite.BusSubscriptionView do
   import ConciergeSite.TimeHelper,
     only: [travel_time_options: 0, time_option_local_strftime: 1,
            format_time: 1]
+  import ConciergeSite.SubscriptionView,
+    only: [parse_route: 1]
 
   @disabled_progress_bar_links %{trip_info: [:trip_info, :preferences],
     preferences: [:preferences]}
@@ -12,6 +14,24 @@ defmodule ConciergeSite.BusSubscriptionView do
   defdelegate progress_step_classes(page, step), to: ConciergeSite.SubscriptionHelper
 
   def progress_link_class(page, step), do: progress_link_class(page, step, @disabled_progress_bar_links)
+
+  @doc """
+  Returns a route's full name, example: "Route 57A Inbound"
+  """
+  @spec route_name(Subscription.t) :: iodata
+  def route_name(subscription) do
+    route = parse_route(subscription)
+    direction = direction_name(subscription)
+    ["Route ", route.long_name, " ", direction]
+  end
+
+  defp direction_name(subscription) do
+    subscription.informed_entities
+    |> Enum.filter_map(&(!is_nil(&1.direction_id)), &(&1.direction_id))
+    |> List.first()
+    |> Integer.to_string()
+    |> named_direction()
+  end
 
   @doc """
   Returns a summary of a subscription's associated trip days, times, and stops

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -172,7 +172,7 @@ defmodule ConciergeSite.SubscriptionView do
     route
   end
 
-  defp parse_route(subscription) do
+  def parse_route(subscription) do
     {:ok, route} = subscription |> parse_route_id() |> ServiceInfoCache.get_route()
     route
   end

--- a/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
@@ -125,6 +125,7 @@ defmodule ConciergeSite.BusSubscriptionControllerTest do
       factory =
         subscription_factory()
         |> bus_subscription()
+        |> Map.put(:informed_entities, bus_subscription_entities())
         |> Map.merge(%{user: user})
       subscription = insert(factory)
 

--- a/apps/concierge_site/test/web/views/bus_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/bus_subscription_view_test.exs
@@ -1,6 +1,7 @@
 defmodule ConciergeSite.BusSubscriptionViewTest do
   use ExUnit.Case
   alias ConciergeSite.BusSubscriptionView
+  import AlertProcessor.Factory
 
   describe "progress_link_class" do
     test "it returns the disabled class when the page is trip_type" do
@@ -81,6 +82,17 @@ defmodule ConciergeSite.BusSubscriptionViewTest do
       routes = BusSubscriptionView.trip_summary_routes(params)
 
       assert routes == [["08:45 AM", " - ", "09:15 AM", " | ", "Inbound"], ["04:45 PM", " - ", "05:15 PM", " | ", "Outbound"]]
+    end
+  end
+
+  describe "route_name/1" do
+    test "returns full route name with direction" do
+      subscription =
+        subscription_factory()
+        |> bus_subscription()
+        |> Map.put(:informed_entities, bus_subscription_entities())
+
+      assert "Route 57A Outbound" == BusSubscriptionView.route_name(subscription) |> IO.iodata_to_binary()
     end
   end
 end

--- a/apps/concierge_site/test/web/views/subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subscription_view_test.exs
@@ -1,7 +1,8 @@
 defmodule ConciergeSite.SubscriptionViewTest do
   use ExUnit.Case
   alias ConciergeSite.SubscriptionView
-  alias AlertProcessor.Model.{InformedEntity, Subscription}
+  alias AlertProcessor.Model.{InformedEntity, Route, Subscription}
+  import AlertProcessor.Factory
 
   describe "sorted_subscription/1" do
     test "sorted_subscriptions groups subscriptions by mode" do
@@ -37,6 +38,17 @@ defmodule ConciergeSite.SubscriptionViewTest do
       sub5 = %Subscription{origin: "Davis", destination: "Park Street", type: :subway, start_time: ~T[14:00:00], end_time: ~T[15:00:00], informed_entities: [%InformedEntity{route: "Red", route_type: 1}], relevant_days: [:weekday, :saturday]}
       sub6 = %Subscription{origin: "Davis", destination: "Park Street", type: :subway, start_time: ~T[14:00:00], end_time: ~T[15:00:00], informed_entities: [%InformedEntity{route: "Red", route_type: 1}], relevant_days: [:weekday, :sunday]}
       assert %{amenity: [], ferry: [], bus: [], commuter_rail: [], subway: [^sub4, ^sub5, ^sub6, ^sub1, ^sub2, ^sub3]} = SubscriptionView.sorted_subscriptions(Enum.shuffle([sub1, sub2, sub3, sub4, sub5, sub6]))
+    end
+  end
+
+  describe "parse_route/1" do
+    test "returns the route for a given subscription" do
+      subscription =
+        subscription_factory()
+        |> bus_subscription()
+        |> Map.put(:informed_entities, bus_subscription_entities())
+
+      assert %Route{route_id: "57A"} = SubscriptionView.parse_route(subscription)
     end
   end
 end


### PR DESCRIPTION
- [x] make `SubscriptionView.parse_route/1` public + tests
- [x] Add method to build a bus route name for a subscription