### PR TITLE
update subway and bus flows back links

### DIFF
--- a/apps/concierge_site/assets/css/_subscription.scss
+++ b/apps/concierge_site/assets/css/_subscription.scss
@@ -279,6 +279,7 @@
 }
 
 .subscription-info-back-link {
+  font-size: $base-font-size;
   color: $link-color;
   padding: 0;
   cursor: pointer;

--- a/apps/concierge_site/assets/js/select-bus-route.js
+++ b/apps/concierge_site/assets/js/select-bus-route.js
@@ -12,15 +12,21 @@ export default function($) {
     props.allRoutes = generateRoutes();
     props.allRouteNames = generateRouteNames();
     attachSuggestionInput();
+    validateRouteInput();
   }
 
   function attachSuggestionInput() {
-    $("label[for='route']").after(renderRouteInput());
+    const preselectedValue = $(`select[name="subscription[route]"]`).find("option:selected").first();
+    if (preselectedValue && preselectedValue.val()) {
+      $("label[for='route']").after(renderRouteInput(preselectedValue.text()));
+    } else {
+      $("label[for='route']").after(renderRouteInput(""));
+    }
   }
 
-  function renderRouteInput() {
+  function renderRouteInput(preselectedValue) {
     return `
-      <input type="text" name="route" placeholder="Enter your bus number" class="subscription-select subscription-select-route station-input" data-valid="false" autocomplete="off"/>
+      <input type="text" name="route" value="${preselectedValue}" placeholder="Enter your bus number" class="subscription-select subscription-select-route station-input" data-valid="false" autocomplete="off"/>
       <div class="suggestion-container"></div>
       <i class="fa fa-check-circle valid-checkmark-icon"></i>
     `

--- a/apps/concierge_site/lib/templates/bus_subscription/_progress_bar.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/_progress_bar.html.eex
@@ -7,7 +7,7 @@
               name: "Trip Type" %>
 
   <%= render "_progress_bar_item.html",
-              link_to: bus_subscription_path(@conn, :info),
+              link_to: bus_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)),
               link_class: progress_link_class(@current_page, :trip_info),
               step_classes:  progress_step_classes(@current_page, :trip_info),
               name: "Trip Info" %>

--- a/apps/concierge_site/lib/templates/bus_subscription/_travel_time_select_lists.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/_travel_time_select_lists.html.eex
@@ -2,22 +2,22 @@
   <label for="subscription_departure_start" class="travel-time-label">
     Departure Trip:
   </label>
-  <%= select @f, :departure_start, travel_time_options(), class: "travel-time-select", selected: "08:45:00" %>
+  <%= select @f, :departure_start, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_start"] || "08:45:00" %>
   <label for="subscription_departure_end" class="travel-time-connector">
     to
   </label>
-  <%= select @f, :departure_end, travel_time_options(), class: "travel-time-select", selected: "09:15:00" %>
+  <%= select @f, :departure_end, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_end"] || "09:15:00" %>
 </div>
 
-<%= if @trip_type == "round_trip" do %>
+<%= if @subscription_params["trip_type"] == "round_trip" do %>
   <div class="travel-time-select-section">
     <label for="subscription_return_start" class="travel-time-label">
       Return Trip:
     </label>
-    <%= select @f, :return_start, travel_time_options(), class: "travel-time-select", selected: "16:45:00" %>
+    <%= select @f, :return_start, travel_time_options(), class: "travel-time-select", selected: @subscription_params["return_start"] || "16:45:00" %>
     <label for="subscription_return_end" class="travel-time-connector">
       to
     </label>
-    <%= select @f, :return_end, travel_time_options(), class: "travel-time-select", selected: "15:15:00" %>
+    <%= select @f, :return_end, travel_time_options(), class: "travel-time-select", selected: @subscription_params["return_end"] || "17:15:00" %>
   </div>
 <%= end %>

--- a/apps/concierge_site/lib/templates/bus_subscription/info.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/info.html.eex
@@ -1,6 +1,6 @@
 <h1>Create New Subscription</h1>
 
-<%= render "_progress_bar.html", current_page: :trip_info, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :trip_info, subscription_params: @subscription_params, conn: @conn %>
 
 <div class="enter-trip-info">
   <h2 class="trip-info-header bus">Enter your trip info</h2>
@@ -13,12 +13,13 @@
                :route,
                @route_list_select_options,
                class: "subscription-select subscription-select-route no-js",
-               prompt: "Enter your bus number" %>
+               prompt: "Enter your bus number",
+               selected: @subscription_params["route"] %>
     </div>
 
     <%= render "_travel_days_checkboxes.html",
                form: f,
-               checked: [],
+               checked: selected_relevant_days(@subscription_params),
                action: "new" %>
 
     <div class="form-group travel-times">
@@ -27,7 +28,7 @@
         We will send you notifications for any service alerts that occur during
         your planned travel time.
       </div>
-      <%= render "_travel_time_select_lists.html", trip_type: @subscription_params["trip_type"], f: f %>
+      <%= render "_travel_time_select_lists.html", subscription_params: @subscription_params, f: f %>
     </div>
 
     <%= text_input f,
@@ -36,12 +37,14 @@
                    hidden: true %>
 
     <div class="trip-info-footer">
-      <%= link to: bus_subscription_path(@conn, :new), class: "subscription-info-back-link" do %>
-        <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
-      <% end %>
       <%= submit "Next", class: "btn btn-primary btn-subscription-next" %>
     </div>
-  <%= end %>
+  <% end %>
+  <div class="back-link-container">
+    <%= link to: bus_subscription_path(@conn, :new), class: "subscription-info-back-link" do %>
+      <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
+    <% end %>
+  </div>
 </div>
 
 

--- a/apps/concierge_site/lib/templates/bus_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/new.html.eex
@@ -1,6 +1,6 @@
 <h1>Create New Subscription</h1>
 
-<%= render "_progress_bar.html", current_page: :trip_type, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :trip_type, subscription_params: nil, conn: @conn %>
 
 <div class="subscription-step select-trip-type">
   <h2 class="select-trip-type-header">What type of trip do you take?</h2>

--- a/apps/concierge_site/lib/templates/bus_subscription/preferences.html.eex
+++ b/apps/concierge_site/lib/templates/bus_subscription/preferences.html.eex
@@ -1,6 +1,6 @@
 <h1>Create New Subscription</h1>
 
-<%= render "_progress_bar.html", current_page: :preferences, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :preferences, subscription_params: @subscription_params, conn: @conn %>
 
 <div class="subscription-step trip-preferences">
   <h2 class="preferences-subtitle">Set your preferences for your trip:</h2>
@@ -25,10 +25,12 @@
     <%= end %>
 
     <div class="trip-info-footer">
-      <%= link to: bus_subscription_path(@conn, :info, trip_type: @subscription_params["trip_type"]), class: "subscription-info-back-link" do %>
-        <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
-      <% end %>
       <%= submit "Create Subscription", class: "btn btn-primary btn-subscription-next" %>
     </div>
-  <%= end %>
+  <% end %>
+  <div class="back-link-container">
+    <%= link to: bus_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)), class: "subscription-info-back-link" do %>
+      <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
+    <% end %>
+  </div>
 </div>

--- a/apps/concierge_site/lib/templates/commuter_rail_subscription/train.html.eex
+++ b/apps/concierge_site/lib/templates/commuter_rail_subscription/train.html.eex
@@ -20,7 +20,7 @@
     </div>
   <% end %>
   <div class="back-link-container">
-    <%= link to: commuter_rail_subscription_path(@conn, :info, trip_type: @subscription_params["trip_type"]), class: "subscription-info-back-link" do %>
+    <%= link to: commuter_rail_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)), class: "subscription-info-back-link" do %>
       <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
     <% end %>
   </div>

--- a/apps/concierge_site/lib/templates/ferry_subscription/ferry.html.eex
+++ b/apps/concierge_site/lib/templates/ferry_subscription/ferry.html.eex
@@ -20,7 +20,7 @@
     </div>
   <% end %>
   <div class="back-link-container">
-    <%= link to: ferry_subscription_path(@conn, :info, trip_type: @subscription_params["trip_type"]), class: "subscription-info-back-link" do %>
+    <%= link to: ferry_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)), class: "subscription-info-back-link" do %>
       <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
     <% end %>
   </div>

--- a/apps/concierge_site/lib/templates/subway_subscription/_progress_bar.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/_progress_bar.html.eex
@@ -7,7 +7,7 @@
               name: "Trip Type" %>
 
   <%= render "_progress_bar_item.html",
-              link_to: subway_subscription_path(@conn, :info),
+              link_to: subway_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)),
               link_class: progress_link_class(@current_page, :trip_info),
               step_classes:  progress_step_classes(@current_page, :trip_info),
               name: "Trip Info" %>

--- a/apps/concierge_site/lib/templates/subway_subscription/_travel_time_select_lists.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/_travel_time_select_lists.html.eex
@@ -1,37 +1,37 @@
-<%= case @trip_type do %>
+<%= case @subscription_params["trip_type"] do %>
   <%= "roaming" -> %>
     <div class="travel-time-select-section">
       <label for="subscription_departure_start" class="travel-time-label">
         Traveling Between:
       </label>
-      <%= select @form, :departure_start, travel_time_options(), class: "travel-time-select", selected: "10:30:00" %>
+      <%= select @form, :departure_start, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_start"] || "10:30:00" %>
       <label for="subscription_roaming_end" class="travel-time-connector">
         and
       </label>
-      <%= select @form, :departure_end, travel_time_options(), class: "travel-time-select", selected: "14:30:00" %>
+      <%= select @form, :departure_end, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_end"] || "14:30:00" %>
     </div>
   <%= _ -> %>
     <div class="travel-time-select-section">
       <label for="subscription_departure_start" class="travel-time-label">
         Departure Trip:
       </label>
-      <%= select @form, :departure_start, travel_time_options(), class: "travel-time-select", selected: "08:45:00" %>
+      <%= select @form, :departure_start, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_start"] || "08:45:00" %>
       <label for="subscription_departure_end" class="travel-time-connector">
         to
       </label>
-      <%= select @form, :departure_end, travel_time_options(), class: "travel-time-select", selected: "09:15:00" %>
+      <%= select @form, :departure_end, travel_time_options(), class: "travel-time-select", selected: @subscription_params["departure_end"] || "09:15:00" %>
     </div>
 <%= end %>
 
-<%= if @trip_type == "round_trip" do %>
+<%= if @subscription_params["trip_type"] == "round_trip" do %>
   <div class="travel-time-select-section">
     <label for="subscription_return_start" class="travel-time-label">
       Return Trip:
     </label>
-    <%= select @form, :return_start, travel_time_options(), class: "travel-time-select", selected: "16:45:00" %>
+    <%= select @form, :return_start, travel_time_options(), class: "travel-time-select", selected: @subscription_params["return_start"] || "16:45:00" %>
     <label for="subscription_return_end" class="travel-time-connector">
       to
     </label>
-    <%= select @form, :return_end, travel_time_options(), class: "travel-time-select", selected: "17:15:00" %>
+    <%= select @form, :return_end, travel_time_options(), class: "travel-time-select", selected: @subscription_params["return_end"] || "17:15:00" %>
   </div>
 <%= end %>

--- a/apps/concierge_site/lib/templates/subway_subscription/info.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/info.html.eex
@@ -1,5 +1,5 @@
 <h1>Create New Subscription</h1>
-<%= render "_progress_bar.html", current_page: :trip_info, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :trip_info, subscription_params: @subscription_params, conn: @conn %>
 
 <div class="subscription-step enter-trip-info">
   <h2>Enter your trip info</h2>
@@ -33,7 +33,7 @@
     </div>
     <%= render "_travel_days_checkboxes.html",
                form: f,
-               checked: [],
+               checked: selected_relevant_days(@subscription_params),
                action: "new" %>
 
     <div class="form-group travel-times">
@@ -43,7 +43,7 @@
         your planned travel time.
       </div>
       <%= render "_travel_time_select_lists.html",
-                 trip_type: @subscription_params["trip_type"],
+                 subscription_params: @subscription_params,
                  form: f %>
     </div>
 
@@ -52,11 +52,13 @@
                    value: @subscription_params["trip_type"],
                    hidden: true %>
 
-  <div class="trip-info-footer">
+    <div class="trip-info-footer">
+      <%= submit "Next", class: "btn btn-primary btn-subscription-next" %>
+    </div>
+  <% end %>
+  <div class="back-link-container">
     <%= link to: subway_subscription_path(@conn, :new), class: "subscription-info-back-link" do %>
       <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
     <% end %>
-    <%= submit "Next", class: "btn btn-primary btn-subscription-next" %>
   </div>
-  <%= end %>
 </div>

--- a/apps/concierge_site/lib/templates/subway_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/new.html.eex
@@ -2,7 +2,7 @@
 
 <%= flash_error(@conn) %>
 
-<%= render "_progress_bar.html", current_page: :trip_type, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :trip_type, subscription_params: nil, conn: @conn %>
 
 <div class="subscription-step select-trip-type">
   <h2 class="select-trip-type-header">What type of trip do you take?</h2>

--- a/apps/concierge_site/lib/templates/subway_subscription/preferences.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/preferences.html.eex
@@ -1,6 +1,6 @@
 <h1>Create New Subscription</h1>
 
-<%= render "_progress_bar.html", current_page: :preferences, conn: @conn %>
+<%= render "_progress_bar.html", current_page: :preferences, subscription_params: @subscription_params, conn: @conn %>
 
 <div class="subscription-step trip-preferences">
   <h2 class="preferences-subtitle">Set your preferences for your trip:</h2>
@@ -25,10 +25,12 @@
     <% end %>
 
     <div class="trip-info-footer">
-      <%= link to: subway_subscription_path(@conn, :info, trip_type: @subscription_params["trip_type"]), class: "subscription-info-back-link" do %>
-        <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
-      <% end %>
       <%= submit "Create Subscription", class: "btn btn-primary btn-subscription-next" %>
     </div>
-  <%= end %>
+  <% end %>
+  <div class="back-link-container">
+    <%= link to: subway_subscription_path(@conn, :info, query_string_params(:trip_info, @subscription_params)), class: "subscription-info-back-link" do %>
+      <i class="fa fa-arrow-left" aria-hidden="true"></i> Go Back
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
This pr continues work done previously in https://github.com/mbta/alerts_concierge/pull/160 for the bus and subway flows.
- fix styling for go back links in subway and bus flows.
- update select route js to populate route field is route id is passed into the template.
- add query params to maintain state for go back/progress bar links for subway and bus flows.

old
![screen shot 2017-07-20 at 3 40 11 pm](https://user-images.githubusercontent.com/526017/28439877-e78f8be4-6d71-11e7-899c-bdd5cb782822.png)
new
<img width="740" alt="screen shot 2017-07-20 at 5 36 12 pm" src="https://user-images.githubusercontent.com/526017/28439891-f8a94410-6d71-11e7-85f6-d59759a1f72e.png">
