### PR TITLE
Set width of icon div to fix alignment issue in email

### DIFF
--- a/apps/alert_processor/lib/mail_templates/styles/digest_styles.css
+++ b/apps/alert_processor/lib/mail_templates/styles/digest_styles.css
@@ -31,6 +31,7 @@
   vertical-align: top;
   padding-left: 16px;
   padding-right: 12px;
+  width: 5%;
 }
 
 .alert-details {


### PR DESCRIPTION
This PR is associated with [MTC-284](https://intrepid.atlassian.net/browse/MTC-284)

Bug Description:
In the digest email, icons and texts were not aligned and some of the alerts were idented

**Bug State**:
<img width="886" alt="screen shot 2017-06-22 at 2 59 53 pm" src="https://user-images.githubusercontent.com/8680734/28480829-79a4c706-6e30-11e7-894f-7936c2175003.png">

**Resolved State**:
<img width="970" alt="screen shot 2017-07-21 at 4 13 43 pm" src="https://user-images.githubusercontent.com/8680734/28480782-4f36d6f8-6e30-11e7-8152-4064bfdcc230.png">

Inside Gmail:
<img width="804" alt="screen shot 2017-07-21 at 4 15 05 pm" src="https://user-images.githubusercontent.com/8680734/28480781-4e005a7a-6e30-11e7-9a7b-eb5a4b72ec35.png">

Screenshot on Gmail mobile:
![image uploaded from ios](https://user-images.githubusercontent.com/8680734/28480799-605bf06c-6e30-11e7-8b4f-a3f2ce76a498.jpg)
