### PR TITLE
update subway params to not attempt to set return timestamps for roaming

### DIFF
--- a/apps/concierge_site/lib/subscriptions/subway_params.ex
+++ b/apps/concierge_site/lib/subscriptions/subway_params.ex
@@ -141,8 +141,8 @@ defmodule ConciergeSite.Subscriptions.SubwayParams do
       "roaming" => "true",
       "departure_start" => DateTimeHelper.timestamp_to_utc_datetime(params["departure_start"]),
       "departure_end" => DateTimeHelper.timestamp_to_utc_datetime(params["departure_end"]),
-      "return_start" => DateTimeHelper.timestamp_to_utc_datetime(params["return_start"]),
-      "return_end" => DateTimeHelper.timestamp_to_utc_datetime(params["return_end"]),
+      "return_start" => nil,
+      "return_end" => nil,
       "amenities" => []
     }
 

--- a/apps/concierge_site/test/web/subscriptions/subway_params_test.exs
+++ b/apps/concierge_site/test/web/subscriptions/subway_params_test.exs
@@ -72,8 +72,6 @@ defmodule ConciergeSite.Subscriptions.SubwayParamsTest do
         "departure_start" => "08:45:00",
         "destination" => "place-dwnxg",
         "origin" => "place-chmnl",
-        "return_end" => "17:15:00",
-        "return_start" => "16:45:00",
         "trip_type" => "roaming"
       }
 
@@ -100,6 +98,97 @@ defmodule ConciergeSite.Subscriptions.SubwayParamsTest do
       mapped_params = SubwayParams.prepare_for_mapper(subscription_params)
 
       assert mapped_params["roaming"] == "false"
+    end
+
+    test "it maps params properly for one_way" do
+      subscription_params = %{
+        "weekday" => "false",
+        "saturday" => "true",
+        "sunday" => "false",
+        "alert_priority_type" => "low",
+        "departure_end" => "09:15:00",
+        "departure_start" => "08:45:00",
+        "destination" => "place-dwnxg",
+        "origin" => "place-chmnl",
+        "trip_type" => "one_way"
+      }
+
+      assert %{
+        "amenities" => [],
+        "alert_priority_type" => "low",
+        "departure_start" => ds,
+        "departure_end" => de,
+        "return_start" => nil,
+        "return_end" => nil,
+        "roaming" => "false",
+        "relevant_days" => ["saturday"],
+        "origin" => "place-chmnl",
+        "destination" => "place-dwnxg"
+      } = SubwayParams.prepare_for_mapper(subscription_params)
+      assert DateTime.to_time(ds) == ~T[12:45:00]
+      assert DateTime.to_time(de) == ~T[13:15:00]
+    end
+
+    test "it maps params properly for round_trip" do
+      subscription_params = %{
+        "weekday" => "true",
+        "saturday" => "false",
+        "sunday" => "false",
+        "alert_priority_type" => "low",
+        "departure_end" => "09:15:00",
+        "departure_start" => "08:45:00",
+        "return_end" => "17:15:00",
+        "return_start" => "16:45:00",
+        "destination" => "place-dwnxg",
+        "origin" => "place-chmnl",
+        "trip_type" => "round_trip"
+      }
+
+      assert %{
+        "amenities" => [],
+        "alert_priority_type" => "low",
+        "departure_start" => ds,
+        "departure_end" => de,
+        "return_start" => rs,
+        "return_end" => re,
+        "roaming" => "false",
+        "relevant_days" => ["weekday"],
+        "origin" => "place-chmnl",
+        "destination" => "place-dwnxg"
+      } = SubwayParams.prepare_for_mapper(subscription_params)
+      assert DateTime.to_time(ds) == ~T[12:45:00]
+      assert DateTime.to_time(de) == ~T[13:15:00]
+      assert DateTime.to_time(rs) == ~T[20:45:00]
+      assert DateTime.to_time(re) == ~T[21:15:00]
+    end
+
+    test "it maps params properly for roaming" do
+      subscription_params = %{
+        "weekday" => "false",
+        "saturday" => "false",
+        "sunday" => "true",
+        "alert_priority_type" => "low",
+        "departure_end" => "09:15:00",
+        "departure_start" => "08:45:00",
+        "destination" => "place-dwnxg",
+        "origin" => "place-chmnl",
+        "trip_type" => "roaming"
+      }
+
+      assert %{
+        "amenities" => [],
+        "alert_priority_type" => "low",
+        "departure_start" => ds,
+        "departure_end" => de,
+        "return_start" => nil,
+        "return_end" => nil,
+        "roaming" => "true",
+        "relevant_days" => ["sunday"],
+        "origin" => "place-chmnl",
+        "destination" => "place-dwnxg"
+      } = SubwayParams.prepare_for_mapper(subscription_params)
+      assert DateTime.to_time(ds) == ~T[12:45:00]
+      assert DateTime.to_time(de) == ~T[13:15:00]
     end
   end
 end


### PR DESCRIPTION
bug where roaming subway params were returning return timestamps, but should not be set for a roaming subscription.