### PR TITLE
add sub-creation-form to amenities creation form to disable mutliple submits

### DIFF
--- a/apps/concierge_site/lib/templates/amenity_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/amenity_subscription/new.html.eex
@@ -2,7 +2,7 @@
 <%= flash_error(@conn) %>
 <div class="subscription-step amenities">
   <div class="enter-trip-info">
-    <%= form_for @conn, amenity_subscription_path(@conn, :create), [class: "trip-info-form amenities", as: :subscription], fn f -> %>
+    <%= form_for @conn, amenity_subscription_path(@conn, :create), [class: "sub-creation-form trip-info-form amenities", as: :subscription], fn f -> %>
       <div class="amenity-subscription-form-section">
         <%= render "_amenity_options.html",
             form: f,


### PR DESCRIPTION
add helper class to amenities creation form to avoid multiple form submits when double clicking the submit button.

logic found in form-helpers.js