### PR TITLE
Include description for opting into SMS messaging

### DIFF
--- a/apps/concierge_site/lib/templates/account/new.html.eex
+++ b/apps/concierge_site/lib/templates/account/new.html.eex
@@ -24,6 +24,7 @@
     </div>
 
     <h2 class="create-account-header">SMS Messaging</h2>
+    <p>Would you like to receive alerts via SMS? If not, we will send you alerts via the email address you provided. You may always update this preference later.</p>
     <%= radio_button f, :sms_toggle, true, class: "radio toggle_show" %> Yes<br>
     <%= radio_button f, :sms_toggle, false, class: "radio toggle_hide" %> No<br>
 


### PR DESCRIPTION
This PR is associated with [MTC-164](https://intrepid.atlassian.net/browse/MTC-164)

Description:
Adding description text below header "SMS messaging"

![screen shot 2017-07-24 at 3 50 33 pm](https://user-images.githubusercontent.com/8680734/28541689-f1494f3a-7087-11e7-868b-aa351af14280.png)
