### PR TITLE
Update change password and reset password form sub-labels to match account creation

### DIFF
--- a/apps/concierge_site/lib/templates/account/new.html.eex
+++ b/apps/concierge_site/lib/templates/account/new.html.eex
@@ -9,20 +9,7 @@
       <%= email_input f, :email, placeholder: "your@email.com", class: "form-control form-control-success form-control-danger", required: true  %>
       <span></span>
     </div>
-    <div class="form-group <%= if :password in @errors, do: "has-danger" %>">
-      <%= label f, :password, "Password", class: "form-label" %>
-      <%= label f, :password, "Your password must be at least 6 characters, with one number or special character (? & % $ # !, etc)", class: "form-sub-label" %>
-      <%= error_tag f, :password %>
-      <%= password_input f, :password, placeholder: "Please enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-      <span></span>
-    </div>
-    <div class="form-group <%= if :password_confirmation in @errors, do: "has-danger" %>">
-      <%= label f, :password_confirmation, "Confirm Password", class: "form-label" %>
-      <%= error_tag f, :password_confirmation %>
-      <%= password_input f, :password_confirmation, placeholder: "Please re-enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-      <span></span>
-    </div>
-
+    <%= render ConciergeSite.PasswordView, "_password_entry_form_section.html", f: f, changeset: @account_changeset %>
     <h2 class="create-account-header">SMS Messaging</h2>
     <p>Would you like to receive alerts via SMS? If not, we will send you alerts via the email address you provided. You may always update this preference later.</p>
     <%= radio_button f, :sms_toggle, true, class: "radio toggle_show" %> Yes<br>

--- a/apps/concierge_site/lib/templates/password/_password_entry_form_section.html.eex
+++ b/apps/concierge_site/lib/templates/password/_password_entry_form_section.html.eex
@@ -1,0 +1,14 @@
+<div class="form-group <%= if :password in @changeset.errors, do: "has-danger" %>">
+  <%= label @f, :password, "New password", class: "form-label" %>
+  <%= label @f, :password, "Your new password must be at least 6 characters, with one number or special character (? & % $ # !, etc)", class: "form-sub-label" %>
+  <%= error_tag @f, :password %>
+  <%= password_input @f, :password, placeholder: "Please enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
+  <span></span>
+</div>
+
+<div class="form-group <%= if :password_confirmation in @changeset.errors, do: "has-danger" %>">
+  <%= label @f, :password_confirmation, "Re-enter new password", class: "form-label" %>
+  <%= error_tag @f, :password_confirmation %>
+  <%= password_input @f, :password_confirmation, placeholder: "Please re-enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
+  <span></span>
+</div>

--- a/apps/concierge_site/lib/templates/password/edit.html.eex
+++ b/apps/concierge_site/lib/templates/password/edit.html.eex
@@ -16,23 +16,8 @@
         <%= password_input f, :current_password, placeholder: "Enter your current password", class: "form-control", pattern: password_regex_string(), required: true %>
         <span></span>
       </div>
-
-      <div class="form-group <%= if :password in @changeset.errors, do: "has-danger" %>">
-        <%= label f, :password, "New password", class: "form-label" %>
-        <%= label f, :password, "Your new password must be at least 6 characters, with one number or special character (? & % $ # !, etc)", class: "form-sub-label" %>
-        <%= error_tag f, :password %>
-        <%= password_input f, :password, placeholder: "Please enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-        <span></span>
-      </div>
-
-      <div class="form-group <%= if :password_confirmation in @changeset.errors, do: "has-danger" %>">
-        <%= label f, :password_confirmation, "Re-enter new password", class: "form-label" %>
-        <%= error_tag f, :password_confirmation %>
-        <%= password_input f, :password_confirmation, placeholder: "Please re-enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-        <span></span>
-      </div>
+      <%= render "_password_entry_form_section.html", f: f, changeset: @changeset %>
     </div>
-
     <div class="update-password-footer">
       <%= submit "Save Changes", class: "btn btn-primary btn-wide" %>
       <div class="password-cancel-link">

--- a/apps/concierge_site/lib/templates/password_reset/edit.html.eex
+++ b/apps/concierge_site/lib/templates/password_reset/edit.html.eex
@@ -6,22 +6,8 @@
 
   <%= form_for @changeset, password_reset_path(@conn, :update, @password_reset), [{:method, :patch}], fn f -> %>
     <div class="update-password-section">
-      <div class="form-group <%= if :password in @changeset.errors, do: "has-danger" %>">
-        <%= label f, :password, "New password", class: "form-label" %>
-        <%= label f, :password, "Your new password must be at least 6 characters, with one number or special character (? & % $ # !, etc)", class: "form-sub-label" %>
-        <%= error_tag f, :password %>
-        <%= password_input f, :password, placeholder: "Please enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-        <span></span>
-      </div>
-
-      <div class="form-group <%= if :password_confirmation in @changeset.errors, do: "has-danger" %>">
-        <%= label f, :password_confirmation, "Re-enter new password", class: "form-label" %>
-        <%= error_tag f, :password_confirmation %>
-        <%= password_input f, :password_confirmation, placeholder: "Please re-enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
-        <span></span>
-      </div>
+      <%= render ConciergeSite.PasswordView, "_password_entry_form_section.html", f: f, changeset: @changeset %>
     </div>
-
     <div class="update-password-footer">
       <%= submit "Reset Password", class: "btn btn-primary btn-wide" %>
     </div>

--- a/apps/concierge_site/lib/views/account_view.ex
+++ b/apps/concierge_site/lib/views/account_view.ex
@@ -1,4 +1,3 @@
 defmodule ConciergeSite.AccountView do
   use ConciergeSite.Web, :view
-  import ConciergeSite.PasswordHelper, only: [password_regex_string: 0]
 end

--- a/apps/concierge_site/lib/views/password_reset_view.ex
+++ b/apps/concierge_site/lib/views/password_reset_view.ex
@@ -1,4 +1,3 @@
 defmodule ConciergeSite.PasswordResetView do
   use ConciergeSite.Web, :view
-  import ConciergeSite.PasswordHelper, only: [password_regex_string: 0]
 end


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/MTC-337

Adds missing helper text explaining password requirements to the change password and reset password forms.