### PR TITLE
Blue dots to track progress

### DIFF
--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -6,6 +6,7 @@ config :logger, level: :warn
 # Configure your database
 config :alert_processor, AlertProcessor.Repo,
   adapter: Ecto.Adapters.Postgres,
+
   pool: Ecto.Adapters.SQL.Sandbox
 
 # Bamboo

--- a/apps/concierge_site/lib/views/subscription_helper.ex
+++ b/apps/concierge_site/lib/views/subscription_helper.ex
@@ -49,14 +49,12 @@ defmodule ConciergeSite.SubscriptionHelper do
   Provide css classes for the text and circle in progress bar steps
   """
   def progress_step_classes(page, step) do
-    ordered_steps = [{:trip_type, 0}, {:trip_info, 1}, {:train, 2}, {:ferry, 2}, {:preferences, 3}]
+    ordered_steps = %{trip_type: 0, trip_info: 1, train: 2, ferry: 2, preferences: 3}
     if ordered_steps[page] >= ordered_steps[step] do
       %{circle: "active-circle", name: "active-page"}
+    else
+      %{}
     end
-  end
-
-  def progress_step_classes(_page, _step) do
-    %{}
   end
 
   @doc """

--- a/apps/concierge_site/test/web/views/bus_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/bus_subscription_view_test.exs
@@ -30,8 +30,8 @@ defmodule ConciergeSite.BusSubscriptionViewTest do
       assert classes == @active_classes
     end
 
-    test "it returns an empty map when step and page are different" do
-      classes = BusSubscriptionView.progress_step_classes(:preferences, :trip_type)
+    test "it returns an empty map when step is ahead of current page" do
+      classes = BusSubscriptionView.progress_step_classes(:trip_type, :preferences)
       assert classes == %{}
     end
   end

--- a/apps/concierge_site/test/web/views/commuter_rail_subscription_view_text.exs
+++ b/apps/concierge_site/test/web/views/commuter_rail_subscription_view_text.exs
@@ -28,8 +28,8 @@ defmodule ConciergeSite.CommuterRailSubscriptionViewTest do
       assert classes == @active_classes
     end
 
-    test "it returns an empty map when step and page are different" do
-      classes = CommuterRailSubscriptionView.progress_step_classes(:preferences, :trip_type)
+    test "it returns an empty map when step is ahead of current page" do
+      classes = CommuterRailSubscriptionView.progress_step_classes(:trip_type, :preferences)
       assert classes == %{}
     end
   end

--- a/apps/concierge_site/test/web/views/ferry_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/ferry_subscription_view_test.exs
@@ -28,8 +28,8 @@ defmodule ConciergeSite.FerrySubscriptionViewTest do
       assert classes == @active_classes
     end
 
-    test "it returns an empty map when step and page are different" do
-      classes = FerrySubscriptionView.progress_step_classes(:preferences, :trip_type)
+    test "it returns an empty map when step is ahead of current page" do
+      classes = FerrySubscriptionView.progress_step_classes(:trip_type, :preferences)
       assert classes == %{}
     end
   end

--- a/apps/concierge_site/test/web/views/subway_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subway_subscription_view_test.exs
@@ -29,8 +29,8 @@ defmodule ConciergeSite.SubwaySubscriptionViewTest do
       assert classes == @active_classes
     end
 
-    test "it returns an empty map when step and page are different" do
-      classes = SubwaySubscriptionView.progress_step_classes(:preferences, :trip_type)
+    test "it returns an empty map when step is ahead of current page" do
+      classes = SubwaySubscriptionView.progress_step_classes(:trip_type, :preferences)
       assert classes == %{}
     end
   end


### PR DESCRIPTION
This PR is associated with [MTC-334](https://intrepid.atlassian.net/browse/MTC-334)

**Description of issue**:
The progress bar only has one blue dot on the current page

**Resolved state**:
<img width="717" alt="screen shot 2017-07-25 at 4 33 27 pm" src="https://user-images.githubusercontent.com/8680734/28592543-581744cc-7157-11e7-899a-f6befb2b0c36.png">
