### PR TITLE
Fix text overlap on header

### DIFF
--- a/apps/concierge_site/assets/css/_header.scss
+++ b/apps/concierge_site/assets/css/_header.scss
@@ -18,7 +18,7 @@
 }
 
 .header-text {
-  padding-top: 1.5rem;
+  padding-top: 1.75rem;
   @include media-breakpoint-down(xs) {
     font-size: $font-size-h1;
   }

--- a/apps/concierge_site/lib/templates/my_account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/my_account/edit.html.eex
@@ -1,5 +1,5 @@
 <h1 class="header-container">
-  <div>My Account</div>
+  <div class="header-text">My Account</div>
   <%= link to: my_account_path(@conn, :confirm_delete), class: "header-link" do %>
     Delete Account <i class="fa fa-trash-o"></i>
   <% end %>


### PR DESCRIPTION
This PR is associated with [MTC-162](https://intrepid.atlassian.net/browse/MTC-162)

Issue description:
The delete account link collides with "My Account" title, so it requires more padding above the title.

<img width="306" alt="screen shot 2017-07-26 at 9 39 54 am" src="https://user-images.githubusercontent.com/8680734/28624562-7b2e8e58-71e7-11e7-8b4e-3690f12ed14f.png">

**Resolved state**:
![screen shot 2017-07-26 at 9 46 27 am](https://user-images.githubusercontent.com/8680734/28624577-822f3ca2-71e7-11e7-97bc-d5fc12912569.png)

