### PR TITLE
Fix progress link type color

### DIFF
--- a/apps/concierge_site/assets/css/_subscription-progress-bar.scss
+++ b/apps/concierge_site/assets/css/_subscription-progress-bar.scss
@@ -36,11 +36,6 @@
   padding: 0;
 }
 
-.progress-step-name.active-page {
-  color: $black;
-  font-weight: $active-step-font-weight;
-}
-
 .progress-link {
   display: inline-block;
   text-align: center;


### PR DESCRIPTION
This PR is associated with [MTC-159](https://intrepid.atlassian.net/browse/MTC-159) and [MTC-156](https://intrepid.atlassian.net/browse/MTC-156)

**Issue description**:
The links on the progress bar should be clickable (and blue) if those pages have been completed

![screen shot 2017-07-26 at 10 12 49 am](https://user-images.githubusercontent.com/8680734/28628223-1160aaaa-71f2-11e7-970b-a101d9183d82.png)

**Resolved State**:
![screen shot 2017-07-26 at 10 56 57 am](https://user-images.githubusercontent.com/8680734/28628229-14aad2d0-71f2-11e7-8287-3d40cfcc4cd5.png)