### PR TITLE
Use form_for instead of link for enabling logout without javascript

### DIFF
--- a/apps/concierge_site/lib/templates/my_account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/my_account/edit.html.eex
@@ -102,6 +102,8 @@
   <%= end %>
 
   <div class="log-out-link">
-    <%= link("Log Out", to: "/login", method: "delete") %>
+    <%= form_for @conn, session_path(@conn, :delete), [method: "delete", as: :custom_delete, _csrf_token: get_csrf_token()], fn _ -> %>
+      <%= submit "Log Out", class: "btn btn-primary" %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
This PR is associated with [MTC-345](https://intrepid.atlassian.net/browse/MTC-345)

**Description of issue**:
- Without Javascript, user clicking on the "Log Out" page cannot sign out and the page simply refreshes

**Resolve**:
- `link` has a [JS dependency](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Link.html) when it is not `:get` method. Changing it to use `form_for` instead

![screen shot 2017-07-31 at 11 40 03 am](https://user-images.githubusercontent.com/8680734/28785663-09a45e00-75e5-11e7-83b9-0019fef43472.png)
