### PR TITLE
Add Migration Task

### DIFF
--- a/apps/alert_processor/lib/release_tasks.ex
+++ b/apps/alert_processor/lib/release_tasks.ex
@@ -1,0 +1,20 @@
+defmodule AlertProcessor.ReleaseTasks do
+  @moduledoc "Tasks that need to be available in a release"
+
+  alias AlertProcessor.Repo
+  alias Ecto.Migrator
+
+  @start_apps [
+    :crypto,
+    :ssl,
+    :postgrex,
+    :ecto
+  ]
+
+  def migrate! do
+    Enum.each(@start_apps, &Application.ensure_all_started/1)
+    Migrator.run(Repo, migrations_path(:alert_processor), :up, all: true)
+  end
+
+  defp migrations_path(app), do: Application.app_dir(app, "priv/repo/migrations")
+end


### PR DESCRIPTION
Since Mix isn't available in a release (and Edeliver migrations are not reliable), add the ability to run a migration from the release