### PR TITLE
Adjusting the .back-link-container position due to footer

### DIFF
--- a/apps/concierge_site/assets/css/_subscription.scss
+++ b/apps/concierge_site/assets/css/_subscription.scss
@@ -295,10 +295,10 @@
 
 .back-link-container {
   position: absolute;
-  bottom: 6rem;
+  bottom: 16rem;
   padding: 0;
   @include media-breakpoint-down(sm) {
-    bottom: 3rem;
+    bottom: 12rem;
   }
 }
 


### PR DESCRIPTION
This PR is associated with [MTC-359](https://intrepid.atlassian.net/browse/MTC-359)

**Description of issue**:
- Footer was hiding the "Go Back" button on pages in the subscription flow
![screen shot 2017-08-02 at 2 09 23 pm](https://user-images.githubusercontent.com/8680734/28887733-456bca38-778c-11e7-9722-b80b02c8c7ef.png)

**Resolved**:
- Adjusted the position of the `back-link-container`
![screen shot 2017-08-02 at 1 57 35 pm](https://user-images.githubusercontent.com/8680734/28887755-5194fe1a-778c-11e7-9077-b65d1576b2b2.png)
