### PR TITLE
Fix Notification.save

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -23,11 +23,6 @@ defmodule AlertProcessor.Model.Notification do
   import Ecto.Changeset
   alias AlertProcessor.{Model.User, Repo}
 
-  @spec save(__MODULE__.t, atom) :: {:ok, __MODULE__.t} | {:error, Ecto.Changeset.t}
-  def save(notification, status) do
-    Repo.insert(__MODULE__.create_changeset(%{notification | status: status}))
-  end
-
   @primary_key {:id, :binary_id, autogenerate: true}
 
   schema "notifications" do
@@ -45,6 +40,11 @@ defmodule AlertProcessor.Model.Notification do
     field :alert, :string, virtual: true
 
     timestamps()
+  end
+
+  @spec save(__MODULE__.t, atom) :: {:ok, __MODULE__.t} | {:error, Ecto.Changeset.t}
+  def save(notification, status) do
+    Repo.insert(__MODULE__.create_changeset(%{notification | status: status, user_id: notification.user.id}))
   end
 
   @permitted_fields ~w(alert_id user_id send_after description service_effect header phone_number email status last_push_notification)a

--- a/apps/alert_processor/test/alert_processor/model/notification_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/notification_test.exs
@@ -93,8 +93,8 @@ defmodule AlertProcessor.Model.NotificationTest do
     refute invalid_changeset.valid?
   end
 
-  test "save/2 saves notification with given status", %{valid_attrs: valid_attrs} do
-    notification = struct(Notification, valid_attrs)
+  test "save/2 saves notification with given status", %{user: user, valid_attrs: valid_attrs} do
+    notification = struct(Notification, Map.put(valid_attrs, :user, user))
     {:ok, saved_notification} = Notification.save(notification, :sent)
 
     assert saved_notification.status == :sent


### PR DESCRIPTION
Notifications were not able to be saved correctly, this PR fixes that and updates notification worker tests to be end-to-end not just to confirm that the message was sent