### PR TITLE
unpack assigns to avoid string.chars not defined errors in production

### DIFF
--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -22,10 +22,10 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
 
   @doc "notification_email/1 takes a notification and builds an email to be sent to user."
   @spec notification_email(Notification.t) :: Elixir.Bamboo.Email.t
-  def notification_email(notification) do
-    unsubscribe_url = MailHelper.unsubscribe_url(notification.user)
+  def notification_email(%Notification{user: user} = notification) do
+    unsubscribe_url = MailHelper.unsubscribe_url(user)
     base_email()
-    |> to(notification.email)
+    |> to(user.email)
     |> subject("MBTA Alert")
     |> html_body(html_email(notification, unsubscribe_url))
     |> text_body(text_email(notification, unsubscribe_url))

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -7,7 +7,7 @@
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     <%= ConciergeSite.Helpers.MailHelper.header() %>
     <div class="notification-content">
-      <h1 class"notification-service-effect">
+      <h1 class="notification-service-effect">
         <span class="notification-logo">
           <img src="<%= ConciergeSite.Helpers.MailHelper.logo_for_alert(notification.alert) %>"
                alt="<%= ConciergeSite.Helpers.MailHelper.alt_text_for_alert(notification.alert) %>">

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -13,7 +13,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
   @email "test@test.com"
 
   @notification %Notification{
-    user: build(:user),
+    user: build(:user, email: @email),
     email: @email,
     service_effect: "Red line delay",
     header: "Red line inbound from Alewife station closure",

--- a/touch_templates.exs
+++ b/touch_templates.exs
@@ -36,7 +36,7 @@ defmodule TouchTemplates do
     File.write!(file, content)
   end
   defp insert_content(file, :notification) do
-    content = "<%= notification %><%= unsubscribe_url %>"
+    content = "<%= notification.header %><%= unsubscribe_url %>"
     File.write!(file, content)
   end
   defp insert_content(file, :footer) do


### PR DESCRIPTION
so this was a weird bug that was popping up. Only occurred when running with `MIX_ENV=prod` but would throw `String.chars` not implemented when passing in the notification and using it within the template. 