### PR TITLE
Deactivate Admin Users

### DIFF
--- a/apps/concierge_site/lib/controllers/admin/session_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/session_controller.ex
@@ -23,6 +23,11 @@ defmodule ConciergeSite.Admin.SessionController do
             admin: [:customer_support, :application_administration]
           })
         |> redirect(to: admin_subscriber_path(conn, :index))
+      :deactivated ->
+        changeset = User.login_changeset(%User{})
+        conn
+        |> put_flash(:error, "Sorry, your account has been deactivated. Please contact an administrator.")
+        |> render("new.html", login_changeset: changeset)
       :unauthorized ->
         conn
         |> put_status(403)

--- a/apps/concierge_site/lib/policies/admin_user_policy.ex
+++ b/apps/concierge_site/lib/policies/admin_user_policy.ex
@@ -6,4 +6,10 @@ defmodule ConciergeSite.AdminUserPolicy do
 
   def can?(%User{role: "application_administration"}, :create_admin_users), do: true
   def can?(%User{}, :create_admin_users), do: false
+
+  def can?(%User{role: "application_administration"}, :show_admin_user), do: true
+  def can?(%User{}, :show_admin_user), do: false
+
+  def can?(%User{role: "application_administration"}, :deactivate_admin_user), do: true
+  def can?(%User{}, :deactivate_admin_user), do: false
 end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -96,7 +96,8 @@ defmodule ConciergeSite.Router do
     pipe_through [:browser, :browser_auth, :admin_auth]
 
     resources "/subscribers", Admin.SubscriberController, only: [:index]
-    resources "/admin_users", Admin.AdminUserController, only: [:index, :new, :create]
+    patch "/admin_users/:id/deactivate", Admin.AdminUserController, :deactivate
+    resources "/admin_users", Admin.AdminUserController, only: [:index, :show, :new, :create]
   end
 
   if Mix.env == :dev do

--- a/apps/concierge_site/lib/templates/admin/admin_user/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/admin_user/index.html.eex
@@ -8,12 +8,14 @@
   <div class="admin-table-header">
     <div class="admin-table-column">Admin Email</div>
     <div class="admin-table-column">Role</div>
+    <div class="admin-table-column">Account Status</div>
   </div>
   <div class="admin-table-body">
     <%= for user <- @admin_users do %>
       <div class="admin-table-row">
-        <div class="admin-table-cell"><%= user.email %></div>
+        <div class="admin-table-cell"><%= link(user.email, to: admin_admin_user_path(@conn, :show, user)) %></div>
         <div class="admin-table-cell"><%= display_role(user) %></div>
+        <div class="admin-table-cell"><%= account_status(user) %></div>
       </div>
     <% end %>
   </div>

--- a/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
+++ b/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
@@ -1,0 +1,4 @@
+<%= @admin_user.email %>
+<%= display_role(@admin_user) %>
+<%= account_status(@admin_user) %>
+<%= button("Deactivate Admin", to: admin_admin_user_path(@conn, :deactivate, @admin_user), method: "patch", class: "btn") %>

--- a/apps/concierge_site/lib/views/admin/admin_user_view.ex
+++ b/apps/concierge_site/lib/views/admin/admin_user_view.ex
@@ -5,4 +5,7 @@ defmodule ConciergeSite.Admin.AdminUserView do
   def display_role(%User{role: "application_administration"}), do: "Application Administration"
   def display_role(%User{role: "customer_support"}), do: "Customer Support"
   def display_role(%User{}), do: "User"
+
+  def account_status(%User{role: "deactivated_admin"}), do: "Inactive"
+  def account_status(%User{}), do: "Active"
 end

--- a/apps/concierge_site/test/web/controllers/admin/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/session_controller_test.exs
@@ -32,6 +32,23 @@ defmodule ConciergeSite.Admin.SessionControllerTest do
     assert html_response(conn, 302) =~ "/admin/subscribers"
   end
 
+  test "POST /login with a deactivated_admin user", %{conn: conn} do
+    user = insert(:user,
+      role: "application_administration",
+      encrypted_password: @encrypted_password,
+      role: "deactivated_admin"
+    )
+
+    params = %{"user" => %{
+      "email" => user.email,
+      "password" => @password
+    }}
+
+    conn = post(conn, admin_session_path(conn, :create), params)
+
+    assert html_response(conn, 200) =~ "Sorry, your account has been deactivated"
+  end
+
   test "POST /login with a regular user", %{conn: conn} do
     user = insert(:user, role: "user", encrypted_password: @encrypted_password)
     params = %{"user" => %{

--- a/apps/concierge_site/test/web/policies/admin_user_policy_test.exs
+++ b/apps/concierge_site/test/web/policies/admin_user_policy_test.exs
@@ -14,9 +14,58 @@ defmodule ConciergeSite.AdminUserPolicyTest do
       refute AdminUserPolicy.can?(user, :list_admin_users)
     end
 
+    test "denies users with the deactivated_admin role" do
+      user = insert(:user, role: "deactivated_admin")
+      refute AdminUserPolicy.can?(user, :list_admin_users)
+    end
+
     test "denies regular users" do
       user = insert(:user, role: "user")
       refute AdminUserPolicy.can?(user, :list_admin_users)
+    end
+  end
+
+  describe "show_admin_user" do
+    test "allows users with the application_administration role" do
+      user = insert(:user, role: "application_administration")
+      assert AdminUserPolicy.can?(user, :show_admin_user)
+    end
+
+    test "denies users with the customer_support role" do
+      user = insert(:user, role: "customer_support")
+      refute AdminUserPolicy.can?(user, :show_admin_user)
+    end
+
+    test "denies users with the deactivated_admin role" do
+      user = insert(:user, role: "deactivated_admin")
+      refute AdminUserPolicy.can?(user, :show_admin_user)
+    end
+
+    test "denies regular users" do
+      user = insert(:user, role: "user")
+      refute AdminUserPolicy.can?(user, :show_admin_user)
+    end
+  end
+
+  describe "deactivate_admin_user" do
+    test "allows users with the application_administration role" do
+      user = insert(:user, role: "application_administration")
+      assert AdminUserPolicy.can?(user, :deactivate_admin_user)
+    end
+
+    test "denies users with the customer_support role" do
+      user = insert(:user, role: "customer_support")
+      refute AdminUserPolicy.can?(user, :deactivate_admin_user)
+    end
+
+    test "denies users with the deactivated_admin role" do
+      user = insert(:user, role: "deactivated_admin")
+      refute AdminUserPolicy.can?(user, :deactivate_admin_user)
+    end
+
+    test "denies regular users" do
+      user = insert(:user, role: "user")
+      refute AdminUserPolicy.can?(user, :deactivate_admin_user)
     end
   end
 end

--- a/apps/concierge_site/test/web/views/admin/admin_user_view_test.exs
+++ b/apps/concierge_site/test/web/views/admin/admin_user_view_test.exs
@@ -1,0 +1,19 @@
+defmodule ConciergeSite.Admin.AdminUserViewTest do
+  use ExUnit.Case
+  alias ConciergeSite.Admin.AdminUserView
+  alias AlertProcessor.Model.User
+
+  describe "account_status/1" do
+    test "returns Active when the admin is not deactivated" do
+      account_status = AdminUserView.account_status(%User{role: "customer_support"})
+
+      assert account_status == "Active"
+    end
+
+    test "returns Inactive when the admin is deactivated" do
+      account_status = AdminUserView.account_status(%User{role: "deactivated_admin"})
+
+      assert account_status == "Inactive"
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability for a user with the `application_administration` role to deactivate the account of another admin user. Deactivated admins will not be able to log into the Admin section of the site. Deactivated admins will only be able to regain access by having an application admin re-activate their account (coming in next PR). They will not be able to regain access to their accounts by resetting their passwords like disabled users.

PR also adds the "Account Status" column to the Admin user index page now that Active/Inactive can be determined, and the temporary start of the admin user show page where the "Deactivate Admin" button will be.