### PR TITLE
Add 'My Account' link to create new subscription page

### DIFF
--- a/apps/concierge_site/lib/templates/subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/new.html.eex
@@ -1,4 +1,10 @@
-<h1>Create New Subscription</h1>
+<h1 class="header-container">
+  <div class="header-text">Create New Subscription</div>
+  <%= link to: my_account_path(@conn, :edit), class: "header-link" do %>
+    My Account <i class="fa fa-gear"></i>
+  <% end %>
+</h1>
+
 <div class="subscription-step select-service">
   <h2 class="select-service-header">Select a service:</h2>
   <p class="select-service-subheader">What mode of transportation do you take?</p>


### PR DESCRIPTION
This PR is associated with [MTC-342](https://intrepid.atlassian.net/browse/MTC-342)

**Description of issue**:
- Users are unable to access 'My Account' page until they create a subscription and land on 'My Subscriptions' page

**Resolved**:
- Added link to 'My Account' page on 'Select a Service'  page

![screen shot 2017-08-07 at 2 12 56 pm](https://user-images.githubusercontent.com/8680734/29040125-f41f9b0c-7b7b-11e7-8345-232c37d585ed.png)
