### PR TITLE
Activate deactivated admin

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -126,8 +126,29 @@ defmodule AlertProcessor.Model.User do
     |> change(vacation_end: DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC"))
   end
 
+  def deactivate_admin(struct) do
+    struct
+    |> deactivate_admin_changeset()
+    |> PaperTrail.update()
+    |> normalize_papertrail_result()
+  end
+
   def deactivate_admin_changeset(struct) do
     change(struct, role: "deactivated_admin")
+  end
+
+  def activate_admin(struct, params) do
+    struct
+    |> activate_admin_changeset(params)
+    |> PaperTrail.update()
+    |> normalize_papertrail_result()
+  end
+
+  def activate_admin_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:role])
+    |> validate_required([:role])
+    |> validate_inclusion(:role, @active_admin_roles)
   end
 
   defp hash_password(changeset) do

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -302,6 +302,39 @@ defmodule AlertProcessor.Model.UserTest do
     end
   end
 
+  describe "deactivate_admin/1" do
+    test "changes a user's role to deactivated_admin" do
+      user = insert(:user, role: "application_administration")
+
+      assert {:ok, %User{role: "deactivated_admin"}} = User.deactivate_admin(user)
+    end
+  end
+
+  describe "activate_admin/2" do
+    test "changes a user's role to the role passed in params" do
+      user = insert(:user, role: "deactivated_admin")
+      params = %{"role" => "customer_support"}
+
+      assert {:ok, %User{role: "customer_support"}} = User.activate_admin(user, params)
+    end
+
+    test "returns an invalid changeset if passed empty role param" do
+      user = insert(:user)
+      invalid_params = %{"role" => ""}
+      {_, changeset} = User.activate_admin(user, invalid_params)
+
+      refute changeset.valid?
+    end
+
+    test "returns an invalid changeset if passed a role other than active admin roles" do
+      user = insert(:user)
+      invalid_params = %{"role" => "deactivated_admin"}
+      {_, changeset} = User.activate_admin(user, invalid_params)
+
+      refute changeset.valid?
+    end
+  end
+
   describe "for_email/1" do
     test "returns a user if present" do
       user = insert(:user)

--- a/apps/concierge_site/lib/policies/admin_user_policy.ex
+++ b/apps/concierge_site/lib/policies/admin_user_policy.ex
@@ -1,15 +1,14 @@
 defmodule ConciergeSite.AdminUserPolicy do
   alias AlertProcessor.Model.User
 
-  def can?(%User{role: "application_administration"}, :list_admin_users), do: true
-  def can?(%User{}, :list_admin_users), do: false
+  @application_admin_only_actions ~w(
+    list_admin_users
+    create_admin_users
+    show_admin_user
+    deactivate_admin_user
+    activate_admin_user
+  )a
 
-  def can?(%User{role: "application_administration"}, :create_admin_users), do: true
-  def can?(%User{}, :create_admin_users), do: false
-
-  def can?(%User{role: "application_administration"}, :show_admin_user), do: true
-  def can?(%User{}, :show_admin_user), do: false
-
-  def can?(%User{role: "application_administration"}, :deactivate_admin_user), do: true
-  def can?(%User{}, :deactivate_admin_user), do: false
+  def can?(%User{role: "application_administration"}, action) when action in @application_admin_only_actions, do: true
+  def can?(%User{}, action) when action in @application_admin_only_actions, do: false
 end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -97,6 +97,7 @@ defmodule ConciergeSite.Router do
 
     resources "/subscribers", Admin.SubscriberController, only: [:index]
     patch "/admin_users/:id/deactivate", Admin.AdminUserController, :deactivate
+    patch "/admin_users/:id/activate", Admin.AdminUserController, :activate
     resources "/admin_users", Admin.AdminUserController, only: [:index, :show, :new, :create]
   end
 

--- a/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
+++ b/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
@@ -1,4 +1,3 @@
 <%= @admin_user.email %>
 <%= display_role(@admin_user) %>
 <%= account_status(@admin_user) %>
-<%= button("Deactivate Admin", to: admin_admin_user_path(@conn, :deactivate, @admin_user), method: "patch", class: "btn") %>

--- a/apps/concierge_site/lib/views/admin/admin_user_view.ex
+++ b/apps/concierge_site/lib/views/admin/admin_user_view.ex
@@ -4,6 +4,7 @@ defmodule ConciergeSite.Admin.AdminUserView do
 
   def display_role(%User{role: "application_administration"}), do: "Application Administration"
   def display_role(%User{role: "customer_support"}), do: "Customer Support"
+  def display_role(%User{role: "deactivated_admin"}), do: "Deactivated Admin"
   def display_role(%User{}), do: "User"
 
   def account_status(%User{role: "deactivated_admin"}), do: "Inactive"

--- a/apps/concierge_site/test/web/policies/admin_user_policy_test.exs
+++ b/apps/concierge_site/test/web/policies/admin_user_policy_test.exs
@@ -68,4 +68,26 @@ defmodule ConciergeSite.AdminUserPolicyTest do
       refute AdminUserPolicy.can?(user, :deactivate_admin_user)
     end
   end
+
+  describe "activate_admin_user" do
+    test "allows users with the application_administration role" do
+      user = insert(:user, role: "application_administration")
+      assert AdminUserPolicy.can?(user, :activate_admin_user)
+    end
+
+    test "denies users with the customer_support role" do
+      user = insert(:user, role: "customer_support")
+      refute AdminUserPolicy.can?(user, :activate_admin_user)
+    end
+
+    test "denies users with the deactivated_admin role" do
+      user = insert(:user, role: "deactivated_admin")
+      refute AdminUserPolicy.can?(user, :activate_admin_user)
+    end
+
+    test "denies regular users" do
+      user = insert(:user, role: "user")
+      refute AdminUserPolicy.can?(user, :activate_admin_user)
+    end
+  end
 end


### PR DESCRIPTION
Adds an endpoint for a user with the `application_administration` role to activate an admin who has previously been deactivated.