### PR TITLE
update concierge_site css compilation step to be separate task rather than compiler task

### DIFF
--- a/apps/concierge_site/mix.exs
+++ b/apps/concierge_site/mix.exs
@@ -10,7 +10,7 @@ defmodule ConciergeSite.Mixfile do
      lockfile: "../../mix.lock",
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
-     compilers: [:phoenix, :gettext, :yecc, :leex, :erlang, :elixir, :xref, :alert_mail, :app],
+     compilers: [:phoenix, :gettext, :yecc, :leex, :erlang, :elixir, :xref, :app],
      preferred_cli_env: [coveralls: :test, "coveralls.json": :test],
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
replaced the step of running `elixir touch_templates.exs` which was only creating placeholder templates and moved the `alert_mail` logic into that file to be run before compilation. On a fresh compile (`rm -rf _build/`) the compiled templates would not be properly compiled when using the `function_from_file` calls in various email modules. This issue was masked due to the fact we normally would only recompile the app instead of a fresh compile from scratch. 

This also has the added benefit of removing the intermediate step of placeholder template -> compiled template and just creates the compiled template up front.