### PR TITLE
filter out country code when searching users by phone number

### DIFF
--- a/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
+++ b/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
@@ -62,9 +62,11 @@ defmodule AlertProcessor.SmsOptOutWorker do
       |> list_phone_numbers_opted_out_query()
       |> AwsClient.request()
 
+    normalized_phone_numbers = Enum.map(phone_numbers, &String.replace_leading(&1, "+1", ""))
+
     case body[:next_token] do
-      nil -> opted_out_list ++ phone_numbers
-      nt -> fetch_opted_out_list(nt, opted_out_list ++ phone_numbers)
+      nil -> opted_out_list ++ normalized_phone_numbers
+      nt -> fetch_opted_out_list(nt, opted_out_list ++ normalized_phone_numbers)
     end
   end
 

--- a/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
@@ -26,6 +26,6 @@ defmodule AlertProcessor.SmsOptOutWorkerTest do
     assert_received :list_phone_numbers_opted_out
     reloaded_user = Repo.one(from u in User, where: u.id == ^user.id)
     assert :eq = DateTime.compare(reloaded_user.vacation_end, DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC"))
-    assert new_state == ["9999999999"]
+    assert new_state == ["9999999999", "5555555555"]
   end
 end

--- a/apps/alert_processor/test/support/mocks/ex_aws_mock.ex
+++ b/apps/alert_processor/test/support/mocks/ex_aws_mock.ex
@@ -20,13 +20,24 @@ defmodule ExAws.Mock do
           }
         }}
       :list_phone_numbers_opted_out ->
-        {:ok, %{
-          body: %{
-            phone_numbers: ["9999999999"],
-            next_token: nil,
-            request_id: "123"
-          }
-        }}
+        case operation.params["NextToken"] do
+          nil ->
+            {:ok, %{
+              body: %{
+                phone_numbers: ["+19999999999"],
+                next_token: "this_is_a_token",
+                request_id: "123"
+              }
+            }}
+          _ ->
+            {:ok, %{
+              body: %{
+                phone_numbers: ["+15555555555"],
+                next_token: nil,
+                request_id: "456"
+              }
+            }}
+        end
       :opt_in_phone_number ->
         {:ok, %{
           body: %{


### PR DESCRIPTION
list of opted out phone numbers returned from aws includes country code, need to strip that out to match on users in database which are stored without.