### PR TITLE
Admin can search all versions of a subscription by date

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -282,4 +282,18 @@ defmodule AlertProcessor.Model.Subscription do
 
   defp normalize_papertrail_result({:ok, %{model: subscription}}), do: {:ok, subscription}
   defp normalize_papertrail_result(result), do: result
+
+  def get_versions_by_date(user, date) do
+    for_user(user)
+    |> Enum.map(&(get_version_for_date(&1, date)))
+    |> List.flatten
+  end
+
+  defp get_version_for_date(sub, date) do
+    sub
+    |> PaperTrail.get_versions()
+    |> Enum.filter(fn(version) ->
+      Date.compare(version.inserted_at, date) != :gt
+    end)
+  end
 end

--- a/apps/alert_processor/lib/service_info/service_info_cache.ex
+++ b/apps/alert_processor/lib/service_info/service_info_cache.ex
@@ -260,6 +260,7 @@ defmodule AlertProcessor.ServiceInfoCache do
   defp parse_time_of_week([6]), do: "saturday"
   defp parse_time_of_week([7]), do: "sunday"
   defp parse_time_of_week([6, 7]), do: "weekend"
+  defp parse_time_of_week(_), do: "weekday"
 
   defp do_fetch_service_info(route_types) do
     {:ok, routes} = ApiClient.routes(route_types)

--- a/apps/alert_processor/test/alert_processor/model/subscription_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/subscription_test.exs
@@ -335,4 +335,43 @@ defmodule AlertProcessor.Model.SubscriptionTest do
       assert nil == Repo.get(Subscription, subscription.id)
     end
   end
+
+  describe "get_versions_by_date/2" do
+    test "returns latest version that existed on the given date" do
+      subscriber = insert(:user)
+      {:ok, future_date} = NaiveDateTime.from_iso8601("2118-01-01T01:01:01")
+      {:ok, date} = NaiveDateTime.from_iso8601("2017-07-11T01:01:01")
+      {:ok, past_date} = NaiveDateTime.from_iso8601("2017-01-11T01:01:01")
+      sub_params = params_for(
+        :subscription,
+        user: subscriber,
+        updated_at: past_date,
+        inserted_at: past_date,
+        relevant_days: [:sunday]
+      )
+      create_changeset = Subscription.create_changeset(%Subscription{}, sub_params)
+      inserted_sub = PaperTrail.insert!(create_changeset)
+      {:ok, updated_sub} = Subscription.update_subscription(inserted_sub, %{
+        updated_at: date
+      })
+      {:ok, future_updated_sub} = Subscription.update_subscription(updated_sub, %{
+        updated_at: future_date
+      })
+
+      # update papertrail version dates
+      [original_version, updated_version, future_version] = PaperTrail.get_versions(future_updated_sub)
+      insert_changeset = Ecto.Changeset.cast(original_version, %{inserted_at: past_date}, [:inserted_at])
+      update_changeset = Ecto.Changeset.cast(updated_version, %{inserted_at: date}, [:inserted_at])
+      future_changeset = Ecto.Changeset.cast(future_version, %{inserted_at: future_date}, [:inserted_at])
+
+      Repo.update!(insert_changeset)
+      Repo.update!(update_changeset)
+      Repo.update!(future_changeset)
+
+      [original, updated] = Subscription.get_versions_by_date(subscriber, date)
+
+      assert original.id == original_version.id
+      assert updated.id == updated_version.id
+    end
+  end
 end

--- a/apps/concierge_site/lib/controllers/admin/subscription_search_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/subscription_search_controller.ex
@@ -1,0 +1,68 @@
+defmodule ConciergeSite.Admin.SubscriptionSearchController do
+  use ConciergeSite.Web, :controller
+  use Guardian.Phoenix.Controller
+  alias ConciergeSite.AdminUserPolicy
+  alias AlertProcessor.{Model, Repo}
+  alias Model.{Subscription, User}
+
+  def create(conn, %{"user_id" => user_id, "search" => search_params}, admin, _claims) do
+    with true <- AdminUserPolicy.can?(admin, :show_user_subscriptions),
+      {:ok, user} <- get_user(user_id),
+      {:ok, versions} <- get_subscription_versions(user, search_params) do
+        render conn, :new, user: user, versions: versions
+    else
+      {:error, :no_user} ->
+        conn
+        |> put_flash(:error, "That user does not exist")
+        |> redirect(to: "/admin_users")
+      {:error, :invalid_params, user} ->
+        conn
+        |> put_flash(:error, "Please provide a valid alert id and date")
+        |> render(conn, :new, user: user, versions: [])
+      {:error, user} ->
+        conn
+        |> put_flash(:error, "There was an error with the search, please try again")
+        |> render(conn, :new, user: user, versions: [])
+      false ->
+        handle_unauthorized(conn)
+    end
+  end
+
+  defp get_user(id) do
+    case Repo.get_by(User, id: id) do
+      %User{} = user -> {:ok, user}
+      _ -> {:error, :no_user}
+    end
+  end
+
+  defp get_subscription_versions(user, params) do
+    date_params = params["alert_date"]
+    get_date = Date.new(
+     String.to_integer(date_params["year"]),
+     String.to_integer(date_params["month"]),
+     String.to_integer(date_params["day"])
+    )
+    if {:ok, date} = get_date do
+      {:ok, Subscription.get_versions_by_date(user, date)}
+    else
+      {:error, user}
+    end
+  end
+
+  def new(conn, %{"user_id" => user_id}, _admin, _claims) do
+    case Repo.get_by(User, id: user_id) do
+      %User{} = user ->
+        render conn, :new, user: user, versions: []
+      _ ->
+        conn
+        |> put_flash(:error, "That user does not exist")
+        |> redirect(to: "/admin_users")
+    end
+  end
+
+  defp handle_unauthorized(conn) do
+    conn
+    |> put_status(403)
+    |> render(ConciergeSite.ErrorView, "403.html")
+  end
+end

--- a/apps/concierge_site/lib/policies/admin_user_policy.ex
+++ b/apps/concierge_site/lib/policies/admin_user_policy.ex
@@ -9,6 +9,14 @@ defmodule ConciergeSite.AdminUserPolicy do
     activate_admin_user
   )a
 
+  @customer_service_actions ~w(
+    show_user_subscriptions
+  )a
+
   def can?(%User{role: "application_administration"}, action) when action in @application_admin_only_actions, do: true
+  def can?(%User{role: "application_administration"}, action) when action in @customer_service_actions, do: true
   def can?(%User{}, action) when action in @application_admin_only_actions, do: false
+
+  def can?(%User{role: "customer_support"}, action) when action in @customer_service_actions, do: true
+  def can?(%User{}, action) when action in @customer_service_actions, do: false
 end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -97,6 +97,7 @@ defmodule ConciergeSite.Router do
   scope "/admin", ConciergeSite, as: :admin do
     pipe_through [:browser, :browser_auth, :admin_auth]
 
+    resources "/subscription_search/:user_id", Admin.SubscriptionSearchController, only: [:new, :create]
     resources "/subscribers", Admin.SubscriberController, only: [:index]
     patch "/admin_users/:id/deactivate", Admin.AdminUserController, :deactivate
     patch "/admin_users/:id/activate", Admin.AdminUserController, :activate

--- a/apps/concierge_site/lib/templates/admin/subscription_search/new.html.eex
+++ b/apps/concierge_site/lib/templates/admin/subscription_search/new.html.eex
@@ -1,0 +1,31 @@
+<h1>Search by Alert</h1>
+<%= flash_error(@conn) %>
+<div class="login-container">
+  <%= form_for @conn, admin_subscription_search_path(@conn, :create, @user.id), [as: :search], fn f -> %>
+    <div class="form-group">
+      <%= label f, :alert_id, "Alert ID", class: "form-label" %>
+      <%= text_input f, :alert_id, class: "form-control", placeholder: "Enter Alert ID" %>
+    </div>
+
+    <div class="form-group">
+      <%= label f, :alert_date, "Alert date", class: "form-label" %>
+      <%= date_select f, :alert_date, class: "form-control", placeholder: "Enter Alert Date" %>
+    </div>
+
+    <%= submit "Search", class: "btn btn-primary" %>
+  <% end %>
+</div>
+
+<div class="search-results-container">
+  <%= if Enum.empty?(@versions) do %>
+    <p>
+      No Results
+    </p>
+  <% else %>
+    <%= for subscription_version <- @versions do %>
+      <p>
+        # TODO <%= subscription_version.item_id %>
+      </p>
+    <% end %>
+  <% end %>
+</div>

--- a/apps/concierge_site/lib/views/admin/subscription_search_view.ex
+++ b/apps/concierge_site/lib/views/admin/subscription_search_view.ex
@@ -1,0 +1,3 @@
+defmodule ConciergeSite.Admin.SubscriptionSearchView do
+  use ConciergeSite.Web, :view
+end

--- a/apps/concierge_site/test/web/controllers/admin/subscription_search_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/subscription_search_controller_test.exs
@@ -1,0 +1,106 @@
+defmodule ConciergeSite.Admin.SubscriptionSearchControllerTest do
+  use ConciergeSite.ConnCase
+
+  alias AlertProcessor.{Model.Subscription, Repo}
+
+  setup do
+    subscriber = insert(:user, email: "this@email.com", phone_number: "5551231234")
+    {:ok, subscriber: subscriber}
+  end
+
+  describe "authorized" do
+    setup :create_and_login_user
+
+    test "GET /admin/subscription_search/:id/new loads search page for admin", %{conn: conn, subscriber: subscriber} do
+      conn = get(conn, admin_subscription_search_path(conn, :new, subscriber.id))
+
+      assert html_response(conn, 200) =~ "Search by Alert"
+    end
+
+    test "GET /admin/subscription_search/:id/new with invalid user_id", %{conn: conn} do
+      conn = get(conn, admin_subscription_search_path(conn, :new, "70d2b710-5a86-40e3-a5b4-ebd14e7866fc"))
+
+      assert html_response(conn, 302) =~ "/admin_users"
+    end
+
+    test "POST /admin/subscription_search/:id returns all subscriptions for a given date", %{conn: conn, subscriber: subscriber} do
+      {:ok, future_date} = NaiveDateTime.from_iso8601("2118-01-01T01:01:01")
+      {:ok, date} = NaiveDateTime.from_iso8601("2017-07-11T01:01:01")
+      sub_params = params_for(
+        :subscription,
+        user: subscriber,
+        updated_at: date,
+        inserted_at: date,
+        relevant_days: [:sunday]
+      )
+      create_changeset = Subscription.create_changeset(%Subscription{}, sub_params)
+      inserted_sub = PaperTrail.insert!(create_changeset)
+      {:ok, _updated_sub} = Subscription.update_subscription(inserted_sub, %{
+        updated_at: future_date
+      })
+
+      # update papertrail version dates
+      [insert_version, update_version] = PaperTrail.get_versions(inserted_sub)
+      insert_changeset = Ecto.Changeset.cast(insert_version, %{inserted_at: date}, [:inserted_at])
+      update_changeset = Ecto.Changeset.cast(update_version, %{inserted_at: future_date}, [:inserted_at])
+
+      Repo.update!(insert_changeset)
+      Repo.update!(update_changeset)
+
+      params = %{
+        "search" => %{
+          "alert_id" => "70d2b710-5a86-40e3-a5b4-ebd14e7866fc",
+          "alert_date" => %{
+            "year" => "2017",
+            "month" => "07",
+            "day" => "11"
+          }
+        }
+      }
+
+      conn = post(conn, admin_subscription_search_path(conn, :create, subscriber.id), params)
+      response = html_response(conn, 200)
+
+      # TODO: Need to update this once we know what is actually rendered for each sub
+      assert response =~ inserted_sub.id
+    end
+  end
+
+  describe "unauthorized" do
+    test "GET /admin/subscription_search/:id/new without admin role", %{subscriber: subscriber} do
+      conn = build_conn()
+      conn = guardian_login(subscriber, conn, :token)
+      conn = get(conn, admin_subscription_search_path(conn, :new, subscriber.id))
+
+      assert html_response(conn, 403)
+    end
+
+    test "POST /admin/subscription_search/:id without admin role", %{subscriber: subscriber} do
+      conn = build_conn()
+      conn = guardian_login(subscriber, conn, :token)
+      conn = post(conn, admin_subscription_search_path(conn, :create, subscriber.id))
+
+      assert html_response(conn, 403)
+    end
+  end
+
+  describe "unauthenticated" do
+    test "GET /admin/subscription_search/:id/new without auth", %{subscriber: subscriber} do
+      conn = build_conn()
+      conn = get(conn, admin_subscription_search_path(conn, :new, subscriber.id))
+      assert html_response(conn, 302)
+    end
+
+    test "POST /admin/subscription_search/:id without auth", %{subscriber: subscriber} do
+      conn = build_conn()
+      conn = post(conn, admin_subscription_search_path(conn, :create, subscriber.id))
+      assert html_response(conn, 302)
+    end
+  end
+
+  defp create_and_login_user(%{conn: conn}) do
+    user = insert(:user, role: "customer_support")
+    conn = guardian_login(user, conn, :token, %{default: Guardian.Permissions.max, admin: [:customer_support]})
+    {:ok, [conn: conn, user: user]}
+  end
+end


### PR DESCRIPTION
Part 1/2 of admin diagnostic tool. In this PR, an admin can search all versions of a subscription that existed on a given date. This is the first part of being able to see why an alert was sent or not on a given date. Subsequent PR will format results so currently we just return unstyled IDs