### PR TITLE
Subscribe to entire mode of transportation - front end

### DIFF
--- a/apps/concierge_site/assets/css/_admin.scss
+++ b/apps/concierge_site/assets/css/_admin.scss
@@ -195,3 +195,20 @@
 
   width: 100%;
 }
+
+.mode-checkbox-label {
+  display: block;
+}
+
+.mode-checkbox {
+  margin-right: 1rem;
+}
+
+.mode-subscription-section {
+  border-bottom: 1px solid $pale-grey;
+  margin-bottom: 1.5rem;
+}
+
+.admin-account-section {
+  padding-bottom: 1.5rem;
+}

--- a/apps/concierge_site/lib/controllers/admin/my_account_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/my_account_controller.ex
@@ -6,7 +6,9 @@ defmodule ConciergeSite.Admin.MyAccountController do
 
   def edit(conn, _params, user, _claims) do
     changeset = User.update_account_changeset(user)
-    render conn, "edit.html", user: user, changeset: changeset
+    mode_subscriptions =
+      Subscription.full_mode_subscription_types_for_user(user)
+    render conn, "edit.html", user: user, changeset: changeset, mode_subscriptions: mode_subscriptions
   end
 
   def update(conn, %{"user" => user_params} = params, user, _claims) do
@@ -20,10 +22,14 @@ defmodule ConciergeSite.Admin.MyAccountController do
       |> redirect(to: admin_my_account_path(conn, :edit))
     else
       {:error, changeset} ->
+        mode_subscriptions =
+          Subscription.full_mode_subscription_types_for_user(user)
+
         conn
         |> put_flash(:error, "Account could not be updated. Please see errors below.")
         |> assign(:user, user)
         |> assign(:changeset, changeset)
+        |> assign(:mode_subscriptions, mode_subscriptions)
         |> render("edit.html")
     end
   end

--- a/apps/concierge_site/lib/templates/admin/my_account/_mode_subscription_checkboxes.html.eex
+++ b/apps/concierge_site/lib/templates/admin/my_account/_mode_subscription_checkboxes.html.eex
@@ -1,0 +1,28 @@
+<div class="mode-subscription-section admin-account-section">
+  <div class="form-label">
+    Send me notifications for the following services:
+  </div>
+  <label class="mode-checkbox-label">
+    <%= checkbox :mode_subscriptions, :commuter_rail, class: "mode-checkbox",
+      checked: Enum.member?(@mode_subscriptions, :commuter_rail) %>
+    Commuter Rail
+  </label>
+
+  <label class="mode-checkbox-label">
+    <%= checkbox :mode_subscriptions, :subway, class: "mode-checkbox",
+      checked: Enum.member?(@mode_subscriptions, :subway) %>
+    Subway
+  </label>
+
+  <label class="mode-checkbox-label">
+    <%= checkbox :mode_subscriptions, :bus, class: "mode-checkbox",
+      checked: Enum.member?(@mode_subscriptions, :bus) %>
+    Bus
+  </label>
+
+  <label class="mode-checkbox-label">
+    <%= checkbox :mode_subscriptions, :ferry, class: "mode-checkbox",
+      checked: Enum.member?(@mode_subscriptions, :ferry) %>
+    Ferries
+  </label>
+</div>

--- a/apps/concierge_site/lib/templates/admin/my_account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/admin/my_account/edit.html.eex
@@ -3,14 +3,20 @@
 <%= flash_info(@conn) %>
 <div class="my-account-container">
   <%= form_for @changeset, admin_my_account_path(@conn, :update), fn f -> %>
-    <div class="form-label">
-      How would you like to receive alerts?
+    <%= if @current_user.role == "application_administration" do %>
+      <%= render("_mode_subscription_checkboxes.html",
+        mode_subscriptions: @mode_subscriptions) %>
+    <% end %>
+    <div class="admin-account-section">
+      <div class="form-label">
+        How would you like to receive alerts?
+      </div>
+      <%= radio_button f, :sms_toggle, "false", checked: !sms_messaging_checked?(@user), class: "my-account-radio-button" %>
+      <label for="user_sms_toggle_false" class="my-account-radio-label">Email Only</label>
+      <%= radio_button f, :sms_toggle, "true", checked: sms_messaging_checked?(@user), class: "my-account-radio-button" %>
+      <label for="user_sms_toggle_true" class="my-account-radio-label">SMS</label>
     </div>
-    <%= radio_button f, :sms_toggle, "false", checked: !sms_messaging_checked?(@user), class: "my-account-radio-button" %>
-    <label for="user_sms_toggle_false" class="my-account-radio-label">Email Only</label>
-    <%= radio_button f, :sms_toggle, "true", checked: sms_messaging_checked?(@user), class: "my-account-radio-button" %>
-    <label for="user_sms_toggle_true" class="my-account-radio-label">SMS</label>
-    <div class="wireless-number-section">
+    <div class="admin-account-section">
       <label for="user_phone_number" class="form-label">Wireless Number</label>
       <%= telephone_input f, :phone_number, placeholder: "###-###-####", class: "large-input", value: @user.phone_number %>
     </div>


### PR DESCRIPTION
Adds a checkbox for each mode of transportation to the admin my account page for users with the `application_administration` role.


![screen shot 2017-08-15 at 4 28 40 pm](https://user-images.githubusercontent.com/2251694/29334887-f062cf50-81d6-11e7-8b9d-df30c742b0ec.png)
