### PR TITLE
Case insensitivity for user email

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -56,6 +56,7 @@ defmodule AlertProcessor.Model.User do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @permitted_fields)
+    |> update_change(:email, &String.downcase/1)
     |> validate_required(@required_fields)
   end
 

--- a/apps/concierge_site/test/web/controllers/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/account_controller_test.exs
@@ -67,5 +67,24 @@ defmodule ConciergeSite.AccountControllerTest do
       assert response =~ "Password and password confirmation did not match."
       assert response =~ "can&#39;t be blank"
     end
+
+    test "user cannot create an account using email that has already been taken", %{conn: conn} do
+      insert(:user, email: "test@example.com")
+
+      params = %{"user" => %{
+        "email" => "TEST@example.com",
+        "password" => "password1",
+        "password_confirmation" => "password1",
+        "do_not_disturb_start" => "16:30:00",
+        "do_not_disturb_end" => "18:30:00",
+        "phone_number" => "5551234567",
+        "amber_alert_opt_in" => "false"
+      }}
+
+      conn = post(conn, "/account", params)
+      response = html_response(conn, 200)
+
+      assert response =~ "Sorry, that email has already been taken."
+    end
   end
 end


### PR DESCRIPTION
This PR is associated with [MTC-389](https://intrepid.atlassian.net/browse/MTC-389)

**Description**:
User cannot create an account with email (case insensitive) that has already been taken 