### PR TITLE
Allow admin to log in to both rider app and admin app

### DIFF
--- a/apps/concierge_site/lib/controllers/session_controller.ex
+++ b/apps/concierge_site/lib/controllers/session_controller.ex
@@ -18,7 +18,7 @@ defmodule ConciergeSite.SessionController do
         if User.is_admin?(user) do
           conn
           |> admin_guardian_sign_in(user)
-          |> redirect(to: "/my-subscriptions")
+          |> redirect(to: admin_subscriber_path(conn, :index))
         else
           conn
           |> Guardian.Plug.sign_in(user, :access, perms: %{default: Guardian.Permissions.max})

--- a/apps/concierge_site/test/web/controllers/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/session_controller_test.exs
@@ -25,6 +25,20 @@ defmodule ConciergeSite.SessionControllerTest do
     assert html_response(conn, 302) =~ "<a href=\"/my-subscriptions\">"
   end
 
+  test "POST /login when the user is an admin can access admin tools", %{conn: conn} do
+    user = Repo.insert!(%User{email: "test@email.com",
+                              role: "customer_support",
+                              encrypted_password: @encrypted_password})
+
+    params = %{"user" => %{
+      "email" => user.email,
+      "password" => @password
+    }}
+
+    conn = post(conn, "/login", params)
+    assert html_response(conn, 302) =~ "/admin/subscribers"
+  end
+
   test "POST /login when the user's account is disabled", %{conn: conn} do
     user = Repo.insert!(%User{email: "test@email.com",
                               role: "user",


### PR DESCRIPTION
This PR is associated with [MTC-380](https://intrepid.atlassian.net/browse/MTC-380) and [MTC-407](https://intrepid.atlassian.net/browse/MTC-407)

**Description**:
- As an admin, I can log in from either the rider app or the admin app and have access to both