### PR TITLE
Update "Log in as user" button to match admin profile button

### DIFF
--- a/apps/concierge_site/assets/css/_admin.scss
+++ b/apps/concierge_site/assets/css/_admin.scss
@@ -248,14 +248,6 @@
   padding-bottom: 1.5rem;
 }
 
-.admin-profile-button {
-  border: 1px solid $brand-primary;
-  border-radius: 5px;
-  display: block;
-  padding: 0.5rem;
-  text-align: center;
-}
-
 .confirmation-page {
   text-align: center;
 }

--- a/apps/concierge_site/lib/templates/admin/subscriber/show.html.eex
+++ b/apps/concierge_site/lib/templates/admin/subscriber/show.html.eex
@@ -25,7 +25,10 @@
       </div>
 
       <%= if not User.is_admin?(@subscriber) do %>
-          <%= link "Log in as user", to: admin_impersonate_session_path(@conn, :create, %{"user_id" => @subscriber.id}), class: "admin-profile-button", method: :post %>
+          <%= link "Log in as user",
+                   to: admin_impersonate_session_path(@conn, :create, %{"user_id" => @subscriber.id}),
+                   class: "btn btn-outline-primary admin-user-btn", 
+                   method: :post %>
       <% end %>
     </div>
     <div class="admin-info-contents">


### PR DESCRIPTION
Updates the "Log in as user" button on the subscriber profile page to use the same classes as the analogous "Deactivate Admin"/"Activate Admin" button on the admin profile page.

![screen shot 2017-08-21 at 11 33 43 am](https://user-images.githubusercontent.com/2251694/29526754-a95e9908-8664-11e7-97ad-aefdfe77f1c1.png)

Hover state:


![screen shot 2017-08-21 at 11 34 18 am](https://user-images.githubusercontent.com/2251694/29526769-b3e3f8be-8664-11e7-8938-43e6ee264f60.png)
