### PR TITLE
update amenities subscriptions to default to low alert_priority_type

### DIFF
--- a/apps/alert_processor/lib/subscription/amenities_mapper.ex
+++ b/apps/alert_processor/lib/subscription/amenities_mapper.ex
@@ -78,7 +78,7 @@ defmodule AlertProcessor.Subscription.AmenitiesMapper do
   end
 
   defp set_alert_priority(params) do
-    Map.put(params, "alert_priority_type", "high")
+    Map.put(params, "alert_priority_type", "low")
   end
 
   defp remove_empty_strings(params) do

--- a/apps/alert_processor/test/alert_processor/subscription/amenities_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/amenities_mapper_test.exs
@@ -12,9 +12,9 @@ defmodule AlertProcessor.Subscription.AmenitiesMapperTest do
   }
 
   describe "elevator only" do
-    test "constructs subscription with high severity" do
+    test "constructs subscription with low severity" do
       {:ok, [{subscription, _ie}]} = AmenitiesMapper.map_subscriptions(@params)
-      assert subscription.alert_priority_type == :high
+      assert subscription.alert_priority_type == :low
     end
 
     test "constructs subscription with type" do
@@ -60,9 +60,9 @@ defmodule AlertProcessor.Subscription.AmenitiesMapperTest do
   end
 
   describe "elevator and escalator" do
-    test "constructs subscription with high severity" do
+    test "constructs subscription with low severity" do
       {:ok, [{subscription, _ie}]} = AmenitiesMapper.map_subscriptions(Map.merge(@params, %{"amenities" => ["elevator", "escalator"]}))
-      assert subscription.alert_priority_type == :high
+      assert subscription.alert_priority_type == :low
     end
 
     test "constructs subscription with type" do

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -118,6 +118,7 @@ defmodule AlertProcessor.Factory do
 
   def amenity_subscription(%Subscription{} = subscription) do
     %{subscription |
+      alert_priority_type: :low,
       type: :amenity
      }
   end


### PR DESCRIPTION
default severity level should be low instead of high for amenities subscriptions.