### PR TITLE
Change vacation banner content for users on indefinite vacation

### DIFF
--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -220,6 +220,9 @@ defmodule ConciergeSite.SubscriptionView do
     end
   end
 
+  def vacation_banner_content(_, %DateTime{year: 9999}),
+    do: "Your alerts have been paused."
+
   def vacation_banner_content(vacation_start, vacation_end) do
     if on_vacation?(vacation_start, vacation_end) do
       [

--- a/apps/concierge_site/test/web/views/subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subscription_view_test.exs
@@ -74,6 +74,14 @@ defmodule ConciergeSite.SubscriptionViewTest do
       assert IO.iodata_to_binary(SubscriptionView.vacation_banner_content(~N[2017-07-10 00:00:00], ~N[2117-07-10 00:00:00])) == "Your alerts have been paused until July 10, 2117."
     end
 
+    test "message when alerts are paused indefinitely" do
+      vacation_start = DateTime.utc_now()
+      vacation_end = DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC")
+      banner_content = SubscriptionView.vacation_banner_content(vacation_start, vacation_end)
+      
+      assert banner_content == "Your alerts have been paused."
+    end
+
     test "message when alerts are not paused" do
       assert IO.iodata_to_binary(SubscriptionView.vacation_banner_content(nil, nil)) == "Don't need updates right now?"
     end


### PR DESCRIPTION
Changes the text in the vacation banner to not list the date for users who regain access to their accounts after disabling.

![screen shot 2017-08-21 at 2 50 07 pm](https://user-images.githubusercontent.com/2251694/29533485-173f9c36-8680-11e7-9ee4-9ae4bba9d6a1.png)
