### PR TITLE
Capitalize first letter of subway trip summaries

### DIFF
--- a/apps/alert_processor/lib/helpers/string_helper.ex
+++ b/apps/alert_processor/lib/helpers/string_helper.ex
@@ -24,6 +24,14 @@ defmodule AlertProcessor.Helpers.StringHelper do
   end
 
   @doc """
+  Takes a string and capitalizes only the first character without doing anything
+  to the remaining characters
+  """
+  @spec capitalize_first(String.t) :: String.t
+  def capitalize_first(<< first_character :: binary-1, rest :: binary >>),
+   do: String.upcase(first_character) <> rest
+
+  @doc """
   split_capitalize takes a string and optional split string and returns
   the string split and joined with a space with each word capitalized.
   """

--- a/apps/alert_processor/test/alert_processor/helpers/string_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/helpers/string_helper_test.exs
@@ -1,0 +1,10 @@
+defmodule AlertProcessor.Helpers.StringHelperTest do
+  use ExUnit.Case
+  alias AlertProcessor.Helpers.StringHelper
+
+  test "capitalize_first/1 capitalizes the first character of a string and does not change the remaining characters" do
+    capitalized = StringHelper.capitalize_first("every Monday from 3 to 5 PM")
+
+    assert capitalized == "Every Monday from 3 to 5 PM"
+  end
+end

--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -1,6 +1,7 @@
 defmodule ConciergeSite.Dissemination.NotificationEmail do
   @moduledoc "Bamboo Mailer interface"
   import Bamboo.Email
+  import AlertProcessor.Helpers.StringHelper, only: [capitalize_first: 1]
   alias AlertProcessor.Model.{Alert, Notification}
   alias AlertProcessor.Helpers.ConfigHelper
   alias ConciergeSite.Helpers.MailHelper
@@ -45,8 +46,8 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
 
   defp email_prefix(%Alert{timeframe: nil}),
     do: ""
-  defp email_prefix(%Alert{timeframe: << first_character :: binary-1, rest :: binary >>}),
-    do: [String.upcase(first_character), rest, ": "]
+  defp email_prefix(%Alert{timeframe: timeframe}),
+    do: [capitalize_first(timeframe), ": "]
 
   defp email_suffix(%Alert{recurrence: nil}), do: ""
   defp email_suffix(%Alert{recurrence: recurrence}), do: [" ", recurrence]

--- a/apps/concierge_site/lib/views/subway_subscription_view.ex
+++ b/apps/concierge_site/lib/views/subway_subscription_view.ex
@@ -1,5 +1,6 @@
 defmodule ConciergeSite.SubwaySubscriptionView do
   use ConciergeSite.Web, :view
+  import AlertProcessor.Helpers.StringHelper, only: [capitalize_first: 1]
   import ConciergeSite.TimeHelper,
     only: [travel_time_options: 0, format_time_string: 1,
            time_option_local_strftime: 1]
@@ -62,7 +63,7 @@ defmodule ConciergeSite.SubwaySubscriptionView do
   end
 
   def trip_summary_title(%{"trip_type" => "roaming"} = params, station_names) do
-    [joined_day_list(params),
+    [params |> joined_day_list() |> capitalize_first(),
      " general travel between ",
      station_names["origin"],
      " and ",

--- a/apps/concierge_site/test/web/views/subway_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subway_subscription_view_test.exs
@@ -45,7 +45,7 @@ defmodule ConciergeSite.SubwaySubscriptionViewTest do
           "destination" => "place-buwst",
           "saturday" => "true",
           "sunday" => "true",
-          "weekday" => "false",
+          "weekday" => "true",
           "trip_type" => "round_trip",
         }
 
@@ -56,7 +56,7 @@ defmodule ConciergeSite.SubwaySubscriptionViewTest do
           |> SubwaySubscriptionView.trip_summary_title(station_names)
           |> IO.iodata_to_binary()
 
-        assert trip_summary_title == "Round trip Saturday or Sunday travel between Boston Univ. East and Boston Univ. West"
+        assert trip_summary_title == "Round trip Saturday, Sunday, or weekday travel between Boston Univ. East and Boston Univ. West"
       end
     end
 
@@ -67,8 +67,8 @@ defmodule ConciergeSite.SubwaySubscriptionViewTest do
           "departure_end" => "23:45:00",
           "origin" => "place-buest",
           "destination" => "place-buwst",
-          "saturday" => "true",
-          "sunday" => "true",
+          "saturday" => "false",
+          "sunday" => "false",
           "weekday" => "true",
           "trip_type" => "roaming",
         }
@@ -80,7 +80,7 @@ defmodule ConciergeSite.SubwaySubscriptionViewTest do
           |> SubwaySubscriptionView.trip_summary_title(station_names)
           |> IO.iodata_to_binary()
 
-        assert trip_summary_title == "Saturday, Sunday, or weekday general travel between Boston Univ. East and Boston Univ. West"
+        assert trip_summary_title == "Weekday general travel between Boston Univ. East and Boston Univ. West"
       end
     end
 


### PR DESCRIPTION
Fixes an issue that would happen with weekday-only general travel subway trips-- the summary would not be capitalized if "weekday" was the first word because "weekday" would never be capitalized.

![screen shot 2017-08-22 at 8 56 34 am](https://user-images.githubusercontent.com/2251694/29566428-de9e9042-8717-11e7-9599-71de0fbea6b4.png)
