### PR TITLE
fix dynamic subject for prod emails

### DIFF
--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -40,7 +40,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
 
   def email_subject(notification) do
     alert = notification.alert
-    [email_prefix(alert), notification.service_effect, email_suffix(alert)]
+    IO.iodata_to_binary([email_prefix(alert), notification.service_effect, email_suffix(alert)])
   end
 
   defp email_prefix(%Alert{timeframe: nil}),

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -47,7 +47,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
       notification = %{@notification | alert: alert}
       subject = NotificationEmail.email_subject(notification)
 
-      assert IO.iodata_to_binary(subject) == "Starting September 1: Red line delay on weekends"
+      assert subject == "Starting September 1: Red line delay on weekends"
     end
 
     test "with recurrence" do
@@ -55,7 +55,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
       notification = %{@notification | alert: alert}
       subject = NotificationEmail.email_subject(notification)
 
-      assert IO.iodata_to_binary(subject) == "Red line delay Monday-Tuesday"
+      assert subject == "Red line delay Monday-Tuesday"
     end
 
     test "with timeframe" do
@@ -63,12 +63,12 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
       notification = %{@notification | alert: alert}
       subject = NotificationEmail.email_subject(notification)
 
-      assert IO.iodata_to_binary(subject) == "Starting Monday: Red line delay"
+      assert subject == "Starting Monday: Red line delay"
     end
 
     test "without timeframe or recurrence" do
       subject = NotificationEmail.email_subject(@notification)
-      assert IO.iodata_to_binary(subject) == "Red line delay"
+      assert subject == "Red line delay"
     end
   end
 end


### PR DESCRIPTION
Was running into this error when sending notifications in production. Looks like subject needs to be a string and not iodata. 
```
22 Aug 2017 16:07:58.901 2017-08-22T20:07:58.848 [error] node=concierge_site@52.54.86.224 (elixir) lib/base.ex:278: Base.encode64(["", "3 Subway stops closed", ""], [])
» 22 Aug 2017 16:07:58.901 2017-08-22T20:07:58.848 [error] node=concierge_site@52.54.86.224 (bamboo_smtp) lib/bamboo/adapters/smtp_adapter.ex:149: Bamboo.SMTPAdapter.rfc822_encode/1
» 22 Aug 2017 16:07:58.901 2017-08-22T20:07:58.848 [error] node=concierge_site@52.54.86.224 (bamboo_smtp) lib/bamboo/adapters/smtp_adapter.ex:145: Bamboo.SMTPAdapter.add_subject/2
```