### PR TITLE
add notification log to subscriber details page

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -20,7 +20,7 @@ defmodule AlertProcessor.Model.Notification do
  }
 
   use Ecto.Schema
-  import Ecto.Changeset
+  import Ecto.{Changeset, Query}
   alias AlertProcessor.{Model.User, Repo}
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -67,5 +67,13 @@ defmodule AlertProcessor.Model.Notification do
       {nil, nil} -> add_error(changeset, :dispatch, "Must have email OR phone number")
       _ -> changeset
     end
+  end
+
+  def sent_to_user(user) do
+    Repo.all(
+      from n in __MODULE__,
+      where: n.user_id == ^user.id and n.status == "sent",
+      order_by: [asc: n.inserted_at]
+    )
   end
 end

--- a/apps/alert_processor/test/alert_processor/model/notification_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/notification_test.exs
@@ -99,4 +99,15 @@ defmodule AlertProcessor.Model.NotificationTest do
 
     assert saved_notification.status == :sent
   end
+
+  test "sent_to_user/1 returns sent notifications to user", %{user: user, valid_attrs: valid_attrs} do
+    notification = struct(Notification, Map.put(valid_attrs, :user, user))
+    {:ok, saved_notification_1} = Notification.save(notification, :sent)
+    {:ok, _} = Notification.save(notification, :failed)
+    other_user = insert(:user)
+    other_notification = struct(Notification, Map.merge(valid_attrs, %{user_id: other_user.id, user: other_user}))
+    {:ok, _} = Notification.save(other_notification, :sent)
+    [%Notification{id: returned_notification_id}] = Notification.sent_to_user(user)
+    assert returned_notification_id == saved_notification_1.id
+  end
 end

--- a/apps/concierge_site/assets/css/_admin.scss
+++ b/apps/concierge_site/assets/css/_admin.scss
@@ -55,6 +55,7 @@
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding: 0.5rem;
 }
 
 .admin-detail-table-cell {

--- a/apps/concierge_site/lib/controllers/admin/subscriber_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/subscriber_controller.ex
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.Admin.SubscriberController do
   use ConciergeSite.Web, :controller
   use Guardian.Phoenix.Controller
-  alias AlertProcessor.Model.{Subscription, User}
+  alias AlertProcessor.Model.{Notification, Subscription, User}
   alias AlertProcessor.Subscription.DisplayInfo
   alias ConciergeSite.{TargetedNotification, UserChangelog}
 
@@ -19,11 +19,17 @@ defmodule ConciergeSite.Admin.SubscriberController do
 
   def show(conn, %{"id" => subscriber_id}, user, _claims) do
     subscriber = User.find_by_id(subscriber_id)
+    notifications = Notification.sent_to_user(subscriber)
     subscriptions = Subscription.for_user(subscriber)
     account_changelog = UserChangelog.changelog(subscriber_id)
     {:ok, departure_time_map} = DisplayInfo.departure_times_for_subscriptions(subscriptions)
     User.log_admin_action(:view_subscriber, user, subscriber)
-    render conn, "show.html", subscriber: subscriber, subscriptions: subscriptions, departure_time_map: departure_time_map, account_changelog: account_changelog
+    render conn, "show.html",
+      subscriber: subscriber,
+      subscriptions: subscriptions,
+      departure_time_map: departure_time_map,
+      account_changelog: account_changelog,
+      notifications: notifications
   end
 
   def new_message(conn, %{"subscriber_id" => subscriber_id}, _user, _claims) do

--- a/apps/concierge_site/lib/templates/admin/subscriber/show.html.eex
+++ b/apps/concierge_site/lib/templates/admin/subscriber/show.html.eex
@@ -33,6 +33,27 @@
       <%= link "Send message", to: admin_subscriber_subscriber_path(@conn, :new_message, @subscriber.id), class: "btn btn-outline-primary admin-user-btn" %>
     </div>
     <div class="admin-info-contents">
+    <h2>Received Notifications</h2>
+      <%= if @notifications == [] do %>
+        <p>No Notifications</p>
+      <% else %>
+        <div class="admin-table">
+          <div class="admin-table-header">
+            <div class="admin-table-column">Notification Contents</div>
+            <div class="admin-table-column">Type</div>
+            <div class="admin-table-column">Sent At</div>
+          </div>
+          <div class="admin-table-body">
+            <%= for notification <- @notifications do %>
+              <div class="admin-table-row">
+                <div class="admin-table-cell"><%= notification_info(notification) %></div>
+                <div class="admin-table-cell"><%= notification_type(notification) %></div>
+                <div class="admin-table-cell"><%= notification_timestamp(notification) %></div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
       <h2>Current Subscriptions</h2>
       <%= if @subscriptions == [] do %>
         <p>No Subscriptions</p>

--- a/apps/concierge_site/lib/views/admin/subscriber_view.ex
+++ b/apps/concierge_site/lib/views/admin/subscriber_view.ex
@@ -2,7 +2,7 @@ defmodule ConciergeSite.Admin.SubscriberView do
   use ConciergeSite.Web, :view
 
   alias AlertProcessor.ServiceInfoCache
-  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+  alias AlertProcessor.Model.{InformedEntity, Notification, Subscription, User}
   alias ConciergeSite.TimeHelper
   alias Calendar.Strftime
 
@@ -158,4 +158,17 @@ defmodule ConciergeSite.Admin.SubscriberView do
       TimeHelper.format_time(end_time)
     ]
   end
+
+  def notification_info(%Notification{service_effect: service_effect, header: header, description: description}) do
+    [
+      content_tag(:p, service_effect),
+      content_tag(:p, header),
+      content_tag(:p, description)
+    ]
+  end
+
+  def notification_type(%Notification{phone_number: nil}), do: content_tag(:p, "Email")
+  def notification_type(%Notification{}), do: content_tag(:p, "SMS")
+
+  def notification_timestamp(%Notification{send_after: send_after}), do: content_tag(:p, Strftime.strftime!(send_after, "%F %T"))
 end


### PR DESCRIPTION
add unstyled list of notifications sent to user on subscriber details page.
<img width="857" alt="screen shot 2017-08-23 at 12 59 12 pm" src="https://user-images.githubusercontent.com/526017/29628237-e7deab6a-8802-11e7-96f1-490ae96a5b70.png">
