### PR TITLE
add custom command to run migrations in production

### DIFF
--- a/apps/alert_processor/lib/release_tasks.ex
+++ b/apps/alert_processor/lib/release_tasks.ex
@@ -11,7 +11,7 @@ defmodule AlertProcessor.ReleaseTasks do
     :ecto
   ]
 
-  def migrate! do
+  def migrate do
     Enum.each(@start_apps, &Application.ensure_all_started/1)
     Migrator.run(Repo, migrations_path(:alert_processor), :up, all: true)
   end

--- a/rel/commands/migrate.sh
+++ b/rel/commands/migrate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bin/alert_processor command Elixir.AlertProcessor.ReleaseTasks migrate

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -37,6 +37,9 @@ release :alert_processor do
   set applications: [
     :alert_processor
   ]
+  set commands: [
+    "migrate": "rel/commands/migrate.sh"
+  ]
   plugin Releases.Plugin.LinkConfig
 end
 


### PR DESCRIPTION
pr adds ability to run migrations via `bin/alert_processor migrate` rather than running in console mode initially then restarting in daemon mode