### PR TITLE
Fix bug with previous permission

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -325,12 +325,9 @@ defmodule AlertProcessor.Model.User do
       prev_claims
       |> Guardian.Permissions.from_claims(:default)
       |> Guardian.Permissions.to_list
-    case prev_perm do
-      [] ->
-        Guardian.Claims.permissions(claims, default: Guardian.Permissions.max)
-      _ ->
-        Guardian.Claims.permissions(claims, default: prev_perm)
-    end
+    default_perms = if prev_perm == [], do: Guardian.Permissions.max, else: prev_perm
+
+    Guardian.Claims.permissions(claims, default: default_perms)
   end
 
   @doc """

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -154,6 +154,15 @@ defmodule AlertProcessor.Model.UserTest do
         |> Guardian.Permissions.to_list()
       assert [:disable_account] == new_claims
     end
+
+    test "replaces empty permissions with default permissions" do
+      user = insert(:user)
+      {:ok, token, _} = Token.issue(user)
+      {:ok, prev_claims} = Guardian.decode_and_verify(token)
+      {:ok, _, refreshed_claims} = Guardian.refresh!(token, prev_claims, %{ttl: {60, :minutes}})
+      %{"pem" => %{"default" => permission_number}} = User.claims_with_permission(Map.put(prev_claims, "pem", %{}), refreshed_claims, user)
+      assert Guardian.Permissions.max == permission_number
+    end
   end
 
   describe "create_account_changeset" do

--- a/apps/concierge_site/lib/helpers/sign_in_helper.ex
+++ b/apps/concierge_site/lib/helpers/sign_in_helper.ex
@@ -23,14 +23,14 @@ defmodule ConciergeSite.SignInHelper do
   end
 
   defp sign_in_user(conn, %User{role: "customer_support"} = user) do
-    Guardian.Plug.sign_in(conn, user, :token, perms: %{
+    Guardian.Plug.sign_in(conn, user, :access, perms: %{
       default: Guardian.Permissions.max,
       admin: [:customer_support]
     })
   end
 
   defp sign_in_user(conn, %User{role: "application_administration"} = user) do
-    Guardian.Plug.sign_in(conn, user, :token,
+    Guardian.Plug.sign_in(conn, user, :access,
       perms: %{
         default: Guardian.Permissions.max,
         admin: [:customer_support, :application_administration]


### PR DESCRIPTION
This was a bug identified from merging in the #317 PR.

**Description**:
- A normal user can log in, but is logged out immediately after their token is refreshed
- Fix: since refreshing token removes permission on the claim, will need to grant the user permission again (unless previous permission was specified)