### PR TITLE
Update titles for Amenity subscription in my-subscriptions and confirm delete page

### DIFF
--- a/apps/concierge_site/lib/templates/subscription/_amenity_subscription_info.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_amenity_subscription_info.html.eex
@@ -1,7 +1,7 @@
 <%= unless Enum.empty?(@subscriptions) do %>
   <div class="amenity-subscriptions">
-    <h6>Station Amenities</h6>
     <%= for subscription <- @subscriptions do %>
+      <h6><%= route_header(subscription) %></h6>
       <%= link(to: amenity_subscription_path(@conn, :edit, subscription), class: "subscription-link") do %>
         <div class="subscription">
           <div class="subscription-icon-container amenity">

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -80,6 +80,7 @@ defmodule ConciergeSite.SubscriptionView do
     end
   end
 
+  def route_header(%{type: :amenity}), do: "Station Amenities"
   def route_header(%{type: :bus} = subscription) do
     [
       content_tag(:span, Route.name(parse_route(subscription))),
@@ -87,6 +88,7 @@ defmodule ConciergeSite.SubscriptionView do
       content_tag(:span, direction_name(subscription))
     ]
   end
+
   def route_header(subscription) do
     case direction_name(subscription) do
       :roaming -> content_tag(:span, "#{subscription.origin} - #{subscription.destination}")


### PR DESCRIPTION
Fixes an issue that resulted in the top title for the confirm delete page for a user's Amenity subscription having only a dash with no text. PR updates the `route_header` function for Amenity subscriptions to make the title of that page match what is displayed in the my-subscriptions list like the other modes of transportation.

![screen shot 2017-08-28 at 2 27 34 pm](https://user-images.githubusercontent.com/2251694/29787587-7ba69256-8bfd-11e7-99d3-c2f897e078cf.png)

![screen shot 2017-08-28 at 2 31 23 pm](https://user-images.githubusercontent.com/2251694/29787625-9a585d56-8bfd-11e7-8cdd-1858d28e5c8b.png)

