### PR TITLE
update login redirects to be based on origin rather than user role

### DIFF
--- a/apps/concierge_site/lib/controllers/admin/session_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/session_controller.ex
@@ -13,7 +13,7 @@ defmodule ConciergeSite.Admin.SessionController do
   def create(conn, %{"user" => login_params}) do
     case User.authenticate_admin(login_params) do
       {:ok, user} ->
-        SignInHelper.sign_in(conn, user, redirect: :default)
+        SignInHelper.sign_in(conn, user, redirect: :admin_default)
       :deactivated ->
         changeset = User.login_changeset(%User{})
         conn

--- a/apps/concierge_site/lib/controllers/impersonate_session_controller.ex
+++ b/apps/concierge_site/lib/controllers/impersonate_session_controller.ex
@@ -13,7 +13,7 @@ defmodule ConciergeSite.ImpersonateSessionController do
     if User.is_admin?(admin_user) do
       conn
         |> put_flash(:info, "Successfully signed out of account for user #{user.email}.")
-        |> SignInHelper.sign_in(admin_user, redirect: :default)
+        |> SignInHelper.sign_in(admin_user, redirect: :admin_default)
     else
       render_unauthorized(conn)
     end

--- a/apps/concierge_site/lib/helpers/sign_in_helper.ex
+++ b/apps/concierge_site/lib/helpers/sign_in_helper.ex
@@ -11,9 +11,12 @@ defmodule ConciergeSite.SignInHelper do
 
   @doc """
   Signs in a user with Guardian and redirects based on the user's role and the
-  route specified in options. Valid redirect options are :my_account and
-  :default. By default admin users are redirected to the list of subscribers,
-  and regular users are redirected to my subscriptions.
+  route specified in options. Valid redirect options are :my_account, :default,
+  and :admin_default. When logging in via /admin/login/new
+  users are redirected to the list of subscribers,
+  and when logging in via /login/new users are redirected to my subscriptions.
+  When resetting password, admin users are redirected to admin my-account page
+  and normal users are redirected to the base my-account page.
   """
   @spec sign_in(Plug.Conn.t, User.t, [redirect: atom]) :: Plug.Conn.t
   def sign_in(conn, user, opts) do
@@ -42,12 +45,12 @@ defmodule ConciergeSite.SignInHelper do
       perms: %{default: Guardian.Permissions.max})
   end
 
-  defp redirect_path(user, :default) do
-    if User.is_admin?(user) do
-      admin_subscriber_path(@endpoint, :index)
-    else
-      subscription_path(@endpoint, :index)
-    end
+  defp redirect_path(_user, :admin_default) do
+    admin_subscriber_path(@endpoint, :index)
+  end
+
+  defp redirect_path(_user, :default) do
+    subscription_path(@endpoint, :index)
   end
 
   defp redirect_path(user, :my_account) do

--- a/apps/concierge_site/test/web/controllers/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/session_controller_test.exs
@@ -36,7 +36,7 @@ defmodule ConciergeSite.SessionControllerTest do
     }}
 
     conn = post(conn, "/login", params)
-    assert html_response(conn, 302) =~ "/admin/subscribers"
+    assert html_response(conn, 302) =~ "/my-subscriptions"
   end
 
   test "POST /login when the user's account is disabled", %{conn: conn} do


### PR DESCRIPTION
change logic of login redirects to be based on the origin of the login specifically if an admin logs in via the normal `/login/new` path they are taken to the `my-subscriptions` page rather than to the `/admin/subscribers` page.