### PR TITLE
convert nil to empty string for notification log to avoid invalid arg error

### DIFF
--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -197,11 +197,11 @@ defmodule ConciergeSite.SubscriberDetails do
            " sent to: ",
            notification_contact(notification),
            " -- ",
-           service_effect,
+           to_string(service_effect),
            " ",
-           header,
+           to_string(header),
            " ",
-           description
+           to_string(description)
           ]}
        end)
     |> Enum.group_by(fn({date, _, _}) -> date end, fn({_, time, message}) -> {time, message} end)


### PR DESCRIPTION
was seeing some 500 errors due to viewing notification logs where description was nil and breaking when converting iolist to string in template.