### PR TITLE
Fix Amenity subscription descriptions

### DIFF
--- a/apps/concierge_site/lib/views/amenity_subscription_view.ex
+++ b/apps/concierge_site/lib/views/amenity_subscription_view.ex
@@ -42,6 +42,7 @@ defmodule ConciergeSite.AmenitySubscriptionView do
 
   defp pretty_station_count(subscription) do
     case count = number_of_stations(subscription) do
+      0 -> ""
       1 -> "#{count} station + "
       _ -> "#{count} stations + "
     end

--- a/apps/concierge_site/test/web/views/amenity_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/amenity_subscription_view_test.exs
@@ -53,5 +53,19 @@ defmodule ConciergeSite.AmenitySubscriptionViewTest do
 
       assert result == "2 stations + Green Line on Saturdays, Weekdays"
     end
+
+    test "it omits text about stations if there are none" do
+      subscription = %Subscription{
+        informed_entities: [%InformedEntity{facility_type: :elevator, route: "Green"}],
+        relevant_days: [:saturday]
+      }
+
+      result =
+        subscription
+        |> AmenitySubscriptionView.amenity_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "Green Line on Saturdays"  
+    end
   end
 end


### PR DESCRIPTION
PR changes text on the my-subscriptions screen for Amenity subscriptions to display just the whole line information in the description instead of "0 Stations +" when there are no stations for amenity subscription.

![screen shot 2017-08-29 at 11 30 14 am](https://user-images.githubusercontent.com/2251694/29829521-a635c5b8-8cad-11e7-9fab-2b45be0a58f1.png)
