### PR TITLE
Remove role changing link in show pages for deactivated admin users

### DIFF
--- a/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
+++ b/apps/concierge_site/lib/templates/admin/admin_user/show.html.eex
@@ -10,8 +10,12 @@
     </div>
     <div class="admin-user-detail-info">
       <label for="role" class="admin-user-label">ROLE:</label>
-      <%= link to: admin_admin_user_path(@conn, :confirm_role_change, @admin_user) do %>
-        <%= display_role(@admin_user) %> <i class="fa fa-angle-down"></i>
+      <%= if @admin_user.role == "deactivated_admin" do %>
+        <div>Deactivated Admin</div>
+      <% else %>
+        <%= link to: admin_admin_user_path(@conn, :confirm_role_change, @admin_user) do %>
+          <%= display_role(@admin_user) %> <i class="fa fa-angle-down"></i>
+        <% end %>
       <% end %>
     </div>
     <div class="admin-user-detail-buttons">


### PR DESCRIPTION
Changes the "ROLE" section in the side menu of admin profile pages to be static text instead of a link to change the role when the admin has been deactivated.

![screen shot 2017-08-29 at 1 21 13 pm](https://user-images.githubusercontent.com/2251694/29834492-fdec290a-8cbc-11e7-94ea-ee1f38f789c7.png)
