### PR TITLE
Fix overlapping elements in subscription edit page header

### DIFF
--- a/apps/concierge_site/lib/templates/subscription/_edit_subscription_header.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_edit_subscription_header.html.eex
@@ -1,5 +1,5 @@
 <h1 class="header-container">
-  <div><%= @title %></div>
+  <div class="header-text"><%= @title %></div>
   <%= link to: subscription_path(ConciergeSite.Endpoint, :confirm_delete, @subscription), class: "header-link" do %>
     Delete Subscription <i class="fa fa-trash-o"></i>
   <% end %>


### PR DESCRIPTION
On subscription edit pages, the "Delete Subscription" link in the header and the title would overlap if the title was long enough. PR adds the css class to the header on this page that other pages with links in the header use to push the link above the header text.

(before)
![screen shot 2017-08-29 at 1 41 40 pm](https://user-images.githubusercontent.com/2251694/29835479-239bd5d0-8cc0-11e7-94b5-50c7e58f2a0a.png)

(fixed)
![screen shot 2017-08-29 at 1 41 06 pm](https://user-images.githubusercontent.com/2251694/29835586-7e007396-8cc0-11e7-969e-b677b3cd1a7d.png)

