### PR TITLE
Update Password Reset valid email regex

### DIFF
--- a/apps/concierge_site/lib/controllers/password_reset_controller.ex
+++ b/apps/concierge_site/lib/controllers/password_reset_controller.ex
@@ -8,8 +8,6 @@ defmodule ConciergeSite.PasswordResetController do
   alias ConciergeSite.SignInHelper
   alias Ecto.Multi
 
-  @email_regex ~r/^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/
-
   def new(conn, _params) do
     changeset = PasswordReset.create_changeset(%PasswordReset{})
     render conn, "new.html", changeset: changeset
@@ -94,7 +92,7 @@ defmodule ConciergeSite.PasswordResetController do
   end
 
   defp handle_unknown_email(conn, changeset, email) do
-    if String.match?(email, @email_regex) do
+    if String.match?(email, ~r/@/) do
       Email.unknown_password_reset_email(email)
       |> Mailer.deliver_later
 

--- a/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
@@ -28,7 +28,7 @@ defmodule ConciergeSite.PasswordResetControllerTest do
   end
 
   test "POST /reset-password/ with a valid but unknown email", %{conn: conn}  do
-    email = "test@example.com"
+    email = "test+123@example.com"
     params = %{"password_reset" => %{"email" => email}}
     conn = post(conn, password_reset_path(conn, :create), params)
 


### PR DESCRIPTION
Fixes an issue that was resulting in valid emails not being allowed through the password reset form-- when the user sign up email format validation was changed to be more permissive, the regex in the password reset controller also needed to be updated.