### PR TITLE
remove unnecessary time info from vacation time period

### DIFF
--- a/apps/concierge_site/lib/views/admin/subscriber_view.ex
+++ b/apps/concierge_site/lib/views/admin/subscriber_view.ex
@@ -28,9 +28,9 @@ defmodule ConciergeSite.Admin.SubscriberView do
       "N/A"
     else
       [
-        Strftime.strftime!(vacation_start, "%c"),
+        Strftime.strftime!(vacation_start, "%m-%d-%Y"),
         " until ",
-        Strftime.strftime!(vacation_end, "%c")
+        Strftime.strftime!(vacation_end, "%m-%d-%Y")
       ]
     end
   end

--- a/apps/concierge_site/test/web/views/admin/subscriber_view_test.exs
+++ b/apps/concierge_site/test/web/views/admin/subscriber_view_test.exs
@@ -48,7 +48,7 @@ defmodule ConciergeSite.Admin.SubscriberViewTest do
     test "returns timeframe text" do
       user = build(:user, vacation_start: DateTime.from_naive!(~N[2017-08-01 12:00:00], "Etc/UTC"), vacation_end: DateTime.from_naive!(~N[2100-08-01 12:00:00], "Etc/UTC"))
       timeframe_text = SubscriberView.vacation_period(user)
-      assert "Tue Aug  1 12:00:00 2017 until Sun Aug  1 12:00:00 2100" = IO.iodata_to_binary(timeframe_text)
+      assert "08-01-2017 until 08-01-2100" = IO.iodata_to_binary(timeframe_text)
     end
   end
 end


### PR DESCRIPTION
rather than always having the `00:00:00` after the date, just remove from the panel. 
<img width="343" alt="screen shot 2017-08-30 at 11 11 33 am" src="https://user-images.githubusercontent.com/526017/29879798-1ce7c190-8d74-11e7-925b-cd20816d7245.png">
