### PR TITLE
Stringify vacation times after invalid submission

### DIFF
--- a/apps/concierge_site/lib/templates/vacation/edit.html.eex
+++ b/apps/concierge_site/lib/templates/vacation/edit.html.eex
@@ -11,14 +11,18 @@
       <div class="form-group vacation-date-form-section">
         <%= label f, :vacation_start, "Start Date:", class: "form-label vacation-form-label" %>
         <%= error_tag f, :vacation_start %>
-        <%= text_input f, :vacation_start, required: true, class: "vacation-input", pattern: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}", placeholder: "MM/DD/YYYY" %>
+        <%= text_input f, :vacation_start, required: true, class: "vacation-input",
+          pattern: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}", placeholder: "MM/DD/YYYY",
+          value: Map.get(@changeset.params, "vacation_start") |> format_vacation_time() %>
         <i class="fa fa-calendar vacation-calendar-icon vacation-start-icon" role=button data-datepicker="#user_vacation_start"></i>
       </div>
 
       <div class="form-group vacation-date-form-section">
         <%= label f, :vacation_end, "End Date:", class: "form-label vacation-form-label" %>
         <%= error_tag f, :vacation_end %>
-        <%= text_input f, :vacation_end, required: true, class: "vacation-input", pattern: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}", placeholder: "MM/DD/YYYY" %>
+        <%= text_input f, :vacation_end, required: true, class: "vacation-input",
+          pattern: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}", placeholder: "MM/DD/YYYY",
+          value: Map.get(@changeset.params, "vacation_end") |> format_vacation_time() %>
         <i class="fa fa-calendar vacation-calendar-icon vacation-end-icon" role=button data-datepicker="#user_vacation_end"></i>
       </div>
     </div>

--- a/apps/concierge_site/lib/views/vacation_view.ex
+++ b/apps/concierge_site/lib/views/vacation_view.ex
@@ -1,3 +1,17 @@
 defmodule ConciergeSite.VacationView do
   use ConciergeSite.Web, :view
+  alias Calendar.Strftime
+
+  @doc """
+  Stringify User changeset vacation_start or vacation_end DateTime into
+  MM/DD/YYYY format
+  """
+  def format_vacation_time(nil), do: nil
+  def format_vacation_time(time) when is_binary(time), do: time
+  def format_vacation_time(%DateTime{} = time) do
+    case Strftime.strftime(time, "%m/%d/%Y") do
+      {:ok, datetime_string} -> datetime_string
+      {:error, _} -> nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue on the page to set a vacation period that would result in the date being displayed as a full timestamp instead of what was originally submitted.

The `format_vacation_time/1` function handles the two error scenarios in the `VacationController`:
1. One or both submitted times were not a real date and could not be cast (eg 10/51/2017), so the same value submitted from the form is displayed again
2. The submitted times were cast, but the end date was before the start date, so the times have to be stringified again to be displayed