### PR TITLE
dont display view-subscriber or impersonate-subscriber admin actions

### DIFF
--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -105,6 +105,9 @@ defmodule ConciergeSite.SubscriberDetails do
   defp changelog_item(%{item_type: "User", origin: "admin:view-subscriber"}, acc, _) do
     {[], acc}
   end
+  defp changelog_item(%{item_type: "User", origin: "admin:message-subscriber"}, acc, _) do
+    {[], acc}
+  end
   defp changelog_item(%{item_type: "User", origin: "admin:impersonate-subscriber"}, acc, _) do
     {[], acc}
   end

--- a/apps/concierge_site/test/web/users/subscriber_details_test.exs
+++ b/apps/concierge_site/test/web/users/subscriber_details_test.exs
@@ -90,6 +90,30 @@ defmodule ConciergeSite.SubscriberDetailsTest do
       changelog = user.id |> SubscriberDetails.changelog() |> changelog_to_binary()
       assert changelog =~ "#{user.email} deleted commuter_rail subscription #{subscription.id} between #{subscription.origin} and #{subscription.destination}"
     end
+
+    test "does not show admin:view-subscriber" do
+      user = insert(:user)
+      admin_user = insert(:user, role: "application_administration")
+      User.log_admin_action(:view_subscriber, admin_user, user)
+      changelog = user.id |> SubscriberDetails.changelog()
+      assert changelog == []
+    end
+
+    test "does not show admin:message-subscriber" do
+      user = insert(:user)
+      admin_user = insert(:user, role: "application_administration")
+      User.log_admin_action(:view_subscriber, admin_user, user)
+      changelog = user.id |> SubscriberDetails.changelog()
+      assert changelog == []
+    end
+
+    test "does not show admin:impersonate-subscriber" do
+      user = insert(:user)
+      admin_user = insert(:user, role: "application_administration")
+      User.log_admin_action(:view_subscriber, admin_user, user)
+      changelog = user.id |> SubscriberDetails.changelog()
+      assert changelog == []
+    end
   end
 
   describe "notification_timeline" do


### PR DESCRIPTION
Since the action of viewing a subscriber/impersonating a subscriber is actually tied to the subscriber, we filter out the actions when displaying the timeline since the action is relevant to the admin's actions rather than the subscriber account. Any actions taken by the admin while impersonating the subscriber are still shown.