### PR TITLE
Change fixed size email styles to support mobile clients

### DIFF
--- a/apps/concierge_site/lib/mail_templates/styles/_global_styles.css
+++ b/apps/concierge_site/lib/mail_templates/styles/_global_styles.css
@@ -1,6 +1,6 @@
 /* Client-specific Styles */
 #outlook a { padding:0; } /* Force Outlook to provide a "view in browser" button. */
-body { width:800px !important; }
+body { max-width: 800px !important; }
 .ReadMsgBody { width:100%; }
 .ExternalClass { width:100%; } /* Force Hotmail to display emails at full width */
 body { -webkit-text-size-adjust:none; } /* Prevent Webkit platforms from changing default text sizes. */
@@ -8,7 +8,7 @@ body { -webkit-text-size-adjust:none; } /* Prevent Webkit platforms from changin
 
 /* Reset Styles */
 body {
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
 }
 
@@ -46,7 +46,6 @@ a:hover { text-decoration: none; color: #67a0d1; }
 
 body {
   font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
-  width: 600px;
   padding: 0px 10px;
   overflow-y: scroll;
 }

--- a/apps/concierge_site/lib/mail_templates/styles/default_styles.css
+++ b/apps/concierge_site/lib/mail_templates/styles/default_styles.css
@@ -8,7 +8,7 @@ p {
 
 .footer {
   background-color: #092e4d;
-  height: 8rem;
+  padding-bottom: 1rem;
   width: 100%;
   overflow: hidden;
 }
@@ -22,7 +22,7 @@ p {
 }
 
 .footer-link {
-  font-size: 15px;
+  font-size: .75rem;
   line-height: 1.6;
   text-align: center;
   color: #67a0d1;
@@ -39,4 +39,8 @@ p {
   width: 5px;
   border-radius: 100%;
   background-color: #ffffff;
+}
+
+.footer-links {
+  margin-top: 1rem;
 }


### PR DESCRIPTION
(iOS Mail top)
![image uploaded from ios 1](https://user-images.githubusercontent.com/2251694/29930843-95363298-8e3d-11e7-97d2-b24060687a9a.jpg)


(iOS Mail bottom)
![image uploaded from ios](https://user-images.githubusercontent.com/2251694/29930807-712be9b0-8e3d-11e7-85fd-0fd0bd7ccf30.jpg)

(Gmail in Chrome Desktop)
![screen shot 2017-08-31 at 11 10 39 am](https://user-images.githubusercontent.com/2251694/29930989-f1635e74-8e3d-11e7-86b7-e227ce0c08a6.png)


