### PR TITLE
make sure subscriptions are uniqued by user_id 

### DIFF
--- a/apps/alert_processor/lib/rules_engine/active_period_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/active_period_filter.ex
@@ -19,14 +19,11 @@ defmodule AlertProcessor.ActivePeriodFilter do
   end
 
   defp do_filter(subscriptions, alert) do
-    subscription_timeframe_maps = for x <- subscriptions, into: %{} do
-      {x.id, Subscription.timeframe_map(x)}
-    end
     active_period_timeframe_maps = Alert.timeframe_maps(alert)
 
     for sub <- subscriptions,
-      active_period_timeframe_map <- active_period_timeframe_maps,
-      TimeFrameComparison.match?(active_period_timeframe_map,  Map.get(subscription_timeframe_maps, sub.id)) do
+      sub_map = Subscription.timeframe_map(sub),
+      Enum.any?(active_period_timeframe_maps, &TimeFrameComparison.match?(&1, sub_map)) do
       sub
     end
   end

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -42,6 +42,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
     |> InformedEntityFilter.filter(alert: alert)
     |> SeverityFilter.filter(alert: alert)
     |> ActivePeriodFilter.filter(alert: alert)
+    |> Enum.uniq_by(& &1.user_id)
     |> Scheduler.schedule_notifications(alert)
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/active_period_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/active_period_filter_test.exs
@@ -53,7 +53,14 @@ defmodule AlertProcessor.ActivePeriodFilterTest do
       ]
     }
 
-    {:ok, alert1: alert1, alert2: alert2, alert3: alert3, alert4: alert4, alert5: alert5, alert6: alert6, alert7: alert7}
+    alert8 = %Alert{
+      active_period: [
+        %{start: datetime_from_native(~N[2017-04-26 09:00:00]), end: datetime_from_native(~N[2017-04-26 19:00:00])},
+        %{start: datetime_from_native(~N[2017-04-27 09:00:00]), end: datetime_from_native(~N[2017-04-27 19:00:00])}
+      ]
+    }
+
+    {:ok, alert1: alert1, alert2: alert2, alert3: alert3, alert4: alert4, alert5: alert5, alert6: alert6, alert7: alert7, alert8: alert8}
   end
 
   describe "active period with end date" do
@@ -100,6 +107,14 @@ defmodule AlertProcessor.ActivePeriodFilterTest do
 
       assert [sunday_subscription] ==
         ActivePeriodFilter.filter([subscription, sunday_subscription], alert: alert6)
+    end
+
+    test "matches mutliple active periods but only returns subscription once", %{alert8: alert8} do
+      user = insert(:user)
+      subscription = :subscription |> build(user: user) |> weekday_subscription |> insert
+
+      assert [subscription] ==
+        ActivePeriodFilter.filter([subscription], alert: alert8)
     end
   end
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -5,8 +5,9 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
 
   setup_all do
     {:ok, start_time} = DateTime.from_naive(~N[2017-04-26 09:00:00], "Etc/UTC")
+    {:ok, start_time2} = DateTime.from_naive(~N[2017-08-01 09:00:00], "Etc/UTC")
     alert = %Alert{
-      active_period: [%{start: start_time, end: nil}],
+      active_period: [%{start: start_time, end: nil}, %{start: start_time2, end: nil}],
       effect_name: "Delay",
       header: "This is a test message",
       id: "1",
@@ -41,7 +42,25 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
 
     result = SubscriptionFilterEngine.process_alert(alert, [s1, s2, s3, s4], [])
 
-    assert {:ok, [%Notification{email: email}]} = result
+    assert {:ok, [%Notification{email: email}, %Notification{email: email}]} = result
+    assert email == user.email
+  end
+
+  test "process_alert/1 when multiple matching subscriptions for user only sends 1 notification per active period", %{alert: alert} do
+    user = insert(:user, phone_number: nil)
+
+    s1 = :subscription
+    |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1}])
+    |> weekday_subscription
+    |> insert
+    s2 = :subscription
+    |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1}])
+    |> weekday_subscription
+    |> insert
+
+    result = SubscriptionFilterEngine.process_alert(alert, [s1, s2], [])
+
+    assert {:ok, [%Notification{email: email}, %Notification{email: email}]} = result
     assert email == user.email
   end
 end


### PR DESCRIPTION
make sure subscriptions are unique by user id after passing through the active period filter. Was previously handled with a `distinct: true` on the end of the query before the refactor. 