### PR TITLE
Filter out empty account updates from subscriber activity log

### DIFF
--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -111,6 +111,9 @@ defmodule ConciergeSite.SubscriberDetails do
   defp changelog_item(%{item_type: "User", origin: "admin:impersonate-subscriber"}, acc, _) do
     {[], acc}
   end
+  defp changelog_item(%{item_type: "User", item_changes: item_changes, event: "update"}, acc, _) when item_changes == %{} do
+    {[], acc}
+  end
   defp changelog_item(%{
     inserted_at: inserted_at,
     event: "insert",

--- a/apps/concierge_site/test/web/users/subscriber_details_test.exs
+++ b/apps/concierge_site/test/web/users/subscriber_details_test.exs
@@ -114,6 +114,13 @@ defmodule ConciergeSite.SubscriberDetailsTest do
       changelog = user.id |> SubscriberDetails.changelog()
       assert changelog == []
     end
+
+    test "does not show updates to subscriber account with no changes" do
+      user = insert(:user)
+      User.update_account(user, %{}, user.id)
+      changelog = user.id |> SubscriberDetails.changelog()
+      assert changelog == []
+    end
   end
 
   describe "notification_timeline" do


### PR DESCRIPTION
PR removes empty entries from the subscriber activity log in the admin section of the site resulting from a user updating their account with no changes.

![screen shot 2017-09-05 at 10 12 50 am](https://user-images.githubusercontent.com/2251694/30067515-0b4dc81c-9229-11e7-9d7e-9509d169a990.png)
