### PR TITLE
Don't immediately expire tokens on each request

### DIFF
--- a/apps/concierge_site/lib/plugs/token_refresh.ex
+++ b/apps/concierge_site/lib/plugs/token_refresh.ex
@@ -13,8 +13,9 @@ defmodule ConciergeSite.Plugs.TokenRefresh do
 
   def call(conn, _) do
     with token <- get_session(conn, "guardian_default"),
-         {:ok, %{"typ" => typ} = claims} <- Guardian.decode_and_verify(token),
-         {:ok, new_token, new_claims} <- Guardian.exchange(token, typ, typ) do
+         {:ok, claims} <- Guardian.decode_and_verify(token),
+         true <- token_expires_within_five_minutes?(claims),
+         {:ok, new_token, new_claims} <- Guardian.refresh!(token, claims, %{ttl: {60, :minutes}}) do
       current_user = current_resource(conn)
       new_claims = claims_with_permission(claims, new_claims, current_user)
       key = Map.get(new_claims, :key, :default)
@@ -28,5 +29,11 @@ defmodule ConciergeSite.Plugs.TokenRefresh do
     else
       _ -> conn
     end
+  end
+
+  defp token_expires_within_five_minutes?(%{"exp" => exp}) do
+    now = DateTime.utc_now() |> DateTime.to_unix()
+    five_minutes_from_now = 300 + now
+    exp > now and exp < five_minutes_from_now
   end
 end

--- a/apps/concierge_site/test/lib/plugs/token_refresh_test.exs
+++ b/apps/concierge_site/test/lib/plugs/token_refresh_test.exs
@@ -4,9 +4,9 @@ defmodule ConciergeSite.Plugs.TokenRefreshTest do
 
   alias ConciergeSite.{Auth.Token, Plugs.TokenLogin, Plugs.TokenRefresh}
 
-  test "it refreshes the token in session", %{conn: conn} do
+  test "it refreshes the token if it expires within five minutes", %{conn: conn} do
     user = insert(:user)
-    {:ok, token, _} = Token.issue(user)
+    {:ok, token, _} = Token.issue(user, {4, :minutes})
     conn = init_test_session(%{conn | params: %{"token" => token}}, %{})
     conn =
       conn
@@ -16,13 +16,17 @@ defmodule ConciergeSite.Plugs.TokenRefreshTest do
     refute get_session(refreshed_conn, "guardian_default") == get_session(conn, "guardian_default")
   end
 
-  test "it does not immediately expire the old token", %{conn: conn} do
+  test "it does nothing if the token expires more than five minutes from now", %{conn: conn} do
     user = insert(:user)
-    {:ok, token, _} = Token.issue(user)
+    {:ok, token, _} = Token.issue(user, {6, :minutes})
     conn = init_test_session(%{conn | params: %{"token" => token}}, %{})
-    conn = TokenLogin.call(conn, %{})
-    TokenRefresh.call(conn, %{})
+    conn =
+      conn
+      |> TokenLogin.call(%{})
+    refreshed_conn = TokenRefresh.call(conn, %{})
 
+    assert refreshed_conn == conn
+    assert get_session(refreshed_conn, "guardian_default") == get_session(conn, "guardian_default")
     assert {:ok, _claims} = Guardian.decode_and_verify(token)
   end
 


### PR DESCRIPTION
PR fixes an issue where a user would be immediately signed out with an accidental double click on a link. 

If the double click was fast enough, the first request would create a new token and expire the original token, but the second request would still contain the expired original token and result in a redirect to the sign in screen.

PR updates the `TokenRefresh` plug to exchange the old token for a new one instead of refreshing it, which will leave the old token to expire an hour after issue, rather than immediately.