### PR TITLE
remove stray linebreak char

### DIFF
--- a/apps/concierge_site/lib/templates/subway_subscription/_alert_type_radio_buttons.html.eex
+++ b/apps/concierge_site/lib/templates/subway_subscription/_alert_type_radio_buttons.html.eex
@@ -6,7 +6,7 @@
   <label class="priority-radio-option">
     <%= radio_button @form, :alert_priority_type, "high", checked: (@checked == :high) %>
     <div>
-      <div>High-priority alerts only: </div>
+      <div>High-priority alerts only:</div>
       <div class="form-sub-label">
         Includes severe delays, shuttle buses, and suspension of service
       </div>


### PR DESCRIPTION
github doesn't show it in the diff, but on windows there's a stray line break char that was showing up only on windows chrome.