### PR TITLE
updates to alert severity mappings

### DIFF
--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -43,212 +43,50 @@ defmodule AlertProcessor.Model.Alert do
 
   @severity_map %{
     "Subway" => %{
-      "Delay" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Extra Service" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Schedule Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Service Change" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Shuttle" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Station Closure" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Station Issue" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Suspension" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      }
+      "Extra Service" => 2,
+      "Schedule Change" => 3,
+      "Shuttle" => 3,
+      "Station Closure" => 3,
+      "Suspension" => 3
     },
     "Commuter Rail" => %{
-      "Cancellation" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Delay" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Extra Service" => %{
-        severe: 3
-      },
-      "Schedule Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Service Change" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Shuttle" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Station Closure" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Suspension" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Track Change" => %{
-        minor: 1
-      }
+      "Cancellation" => 3,
+      "Delay" => 2,
+      "Extra Service" => 1,
+      "Schedule Change" => 3,
+      "Shuttle" => 3,
+      "Station Closure" => 3,
+      "Suspension" => 3,
+      "Track Change" => 1
     },
     "Bus" => %{
-      "Delay" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Detour" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Extra Service" => %{
-        severe: 3
-      },
-      "Schedule Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Service Change" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Snow Route" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Stop Closure" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Stop Move" => %{
-        severe: 3
-      },
-      "Suspension" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      }
+      "Detour" => 3,
+      "Extra Service" => 1,
+      "Schedule Change" => 3,
+      "Snow Route" => 3,
+      "Stop Closure" => 2,
+      "Stop Move" => 1,
+      "Suspension" => 3
     },
     "Ferry" => %{
-      "Cancellation" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Delay" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Dock Closure" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Dock Issue" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Extra Service" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Schedule Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Service Change" => %{
-        minor: 1,
-        moderate: 2,
-        severe: 3
-      },
-      "Shuttle" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Suspension" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
+      "Cancellation" => 3,
+      "Delay" => 2,
+      "Dock Closure" => 3,
+      "Extra Service" => 2,
+      "Schedule Change" => 2,
+      "Shuttle" => 3,
+      "Suspension" => 3,
     },
     "Systemwide" => %{
-      "Delay" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Extra Service" => %{
-        moderate: 3,
-        severe: 3
-      },
-      "Policy Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Service Change" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Suspension" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      },
-      "Amber Alert" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      }
+      "Delay" => 3,
+      "Extra Service" => 2,
+      "Policy Change" => 3,
+      "Service Change" => 3,
+      "Suspension" => 3,
+      "Amber Alert" => 3
     },
     "Facility" => %{
-      "Access Issue" => %{
-        minor: 3,
-        moderate: 3,
-        severe: 3
-      }
+      "Access Issue" => 3
     }
   }
 
@@ -328,6 +166,10 @@ defmodule AlertProcessor.Model.Alert do
 
   @spec priority_value(String.t, String.t, atom) :: integer
   defp priority_value(route_type, effect_name, severity) do
-    @severity_map[route_type][effect_name][severity] || 0
+    @severity_map[route_type][effect_name] || default_severity_value(severity)
   end
+
+  defp default_severity_value(:minor), do: 1
+  defp default_severity_value(:moderate), do: 2
+  defp default_severity_value(:severe), do: 3
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/severity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/severity_filter_test.exs
@@ -26,7 +26,7 @@ defmodule AlertProcessor.SeverityFilterTest do
     sub2 = insert(:subscription, alert_priority_type: :medium, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
     sub3 = insert(:subscription, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
 
-    assert [] == SeverityFilter.filter([sub1, sub2, sub3], alert: alert)
+    assert [sub1, sub2] == SeverityFilter.filter([sub1, sub2, sub3], alert: alert)
   end
 
   test "will send systemwide alerts" do
@@ -42,7 +42,7 @@ defmodule AlertProcessor.SeverityFilterTest do
     sub2 = insert(:subscription, alert_priority_type: :medium, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
     sub3 = insert(:subscription, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
 
-    assert [] == SeverityFilter.filter([sub1, sub2, sub3], alert: alert)
+    assert [sub1, sub2] == SeverityFilter.filter([sub1, sub2, sub3], alert: alert)
   end
 
   test "will send facility alerts regardless of severity" do
@@ -59,5 +59,14 @@ defmodule AlertProcessor.SeverityFilterTest do
     sub = insert(:subscription, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
 
     assert [sub] == SeverityFilter.filter([sub], alert: alert)
+  end
+
+  test "will default to alert severity value if effect name does not have specific remapping" do
+    alert = %Alert{informed_entities: [%InformedEntity{route_type: 1, route: "Red"}], severity: :moderate, effect_name: "Random Effect"}
+    sub1 = insert(:subscription, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
+    sub2 = insert(:subscription, alert_priority_type: :medium, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
+    sub3 = insert(:subscription, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 1, route: "Red"}])
+
+    assert [sub1, sub2] == SeverityFilter.filter([sub1, sub2, sub3], alert: alert)
   end
 end


### PR DESCRIPTION
update all alert severity mappings based on https://docs.google.com/spreadsheets/d/1MpfilBjt_4KO0eoO2f6HPcswC1iO4olSv004Nl8Ob4I/edit#gid=0

3 2 1 effectively means use provided severity value, so don't need to specifically map. 
<blank> yes yes means only medium/high and low/medium/high subscriptions should receive regardless of severity tied to alert.
Otherwise default to alert provided value.