### PR TITLE
Obscure password changes in subscriber account activity log

### DIFF
--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -133,6 +133,34 @@ defmodule ConciergeSite.SubscriberDetails do
     inserted_at: inserted_at,
     event: "update",
     originator_id: id,
+    item_changes: %{"encrypted_password" => ""} = item_changes,
+    item_id: item_id,
+    item_type: "User"
+    }, acc, originating_user_email_map) do
+      old_version = Map.get(acc, item_id, %{})
+      new_state = Map.merge(old_version, item_changes)
+      {date, time} = date_and_time_values(inserted_at)
+      originator = originating_user_email_map[id] || "Unknown"
+      {[{date, time, [originator, " disabled their account"]}], Map.put(acc, item_id, new_state)}
+  end
+  defp changelog_item(%{
+    inserted_at: inserted_at,
+    event: "update",
+    originator_id: id,
+    item_changes: %{"encrypted_password" => _} = item_changes,
+    item_id: item_id,
+    item_type: "User"
+    }, acc, originating_user_email_map) do
+      old_version = Map.get(acc, item_id, %{})
+      new_state = Map.merge(old_version, item_changes)
+      {date, time} = date_and_time_values(inserted_at)
+      originator = originating_user_email_map[id] || "Unknown"
+      {[{date, time, [originator, " updated their password"]}], Map.put(acc, item_id, new_state)}
+  end
+  defp changelog_item(%{
+    inserted_at: inserted_at,
+    event: "update",
+    originator_id: id,
     item_changes: item_changes,
     item_id: item_id,
     item_type: "User"

--- a/apps/concierge_site/test/web/users/subscriber_details_test.exs
+++ b/apps/concierge_site/test/web/users/subscriber_details_test.exs
@@ -38,6 +38,18 @@ defmodule ConciergeSite.SubscriberDetailsTest do
       changelog = user.id |> SubscriberDetails.changelog() |> changelog_to_binary()
       assert changelog =~ "#{user.email} updated do_not_disturb_end from 07:00:00 to N/A, do_not_disturb_start from 22:00:00 to N/A, phone_number from N/A to 5551231234"
     end
+
+    test "maps updating password", %{user: user} do
+      User.update_password(user, %{"password" => "newp4assword1", "password_confirmation" => "newp4assword1"}, user)
+      changelog = user.id |> SubscriberDetails.changelog() |> changelog_to_binary()
+      assert changelog =~ "#{user.email} updated their password"
+    end
+
+    test "maps disabling account", %{user: user} do
+      User.disable_account(user, user)
+      changelog = user.id |> SubscriberDetails.changelog() |> changelog_to_binary()
+      assert changelog =~ "#{user.email} disabled their account"
+    end
   end
 
   describe "subscription" do


### PR DESCRIPTION
Previously the subscriber activity log was displaying all user record changes word for word, including changes to the encrypted password ("User changed attribute from X to Y"). PR updates the subscriber details to not show the previous encrypted password when it is updated via a password change or account disabling.

![screen shot 2017-09-06 at 3 46 14 pm](https://user-images.githubusercontent.com/2251694/30131429-c5560a7a-931a-11e7-8cd7-d4be54eb171e.png)
