### PR TITLE
Remove unnecessary mention of email from subscription confirmations

### DIFF
--- a/apps/concierge_site/lib/mail_templates/confirmation.html.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.html.eex
@@ -7,7 +7,7 @@
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     <%= ConciergeSite.Helpers.MailHelper.header() %>
     <div class="email-contents">
-      <p>Congratulations, you have successfully subscribed to receive MBTA email alerts.</p>
+      <p>Congratulations, you have successfully subscribed to receive MBTA alerts.</p>
       <p>To update your subscription preferences, please tap on the Edit your Subscriptions link below.</p>
       <p>To stop receiving email alerts, please click unsubscribe below.</p>
 

--- a/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
@@ -1,4 +1,4 @@
-Congratulations, you have successfully subscribed to receive MBTA email alerts.
+Congratulations, you have successfully subscribed to receive MBTA alerts.
 To update your subscription preferences, please tap on the Edit your Subscriptions link below.
 To stop receiving email alerts, please click unsubscribe below.
 

--- a/apps/concierge_site/test/lib/dissemination/email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/email_test.exs
@@ -30,7 +30,7 @@ defmodule ConciergeSite.Dissemination.EmailTest do
 
     assert email.to == user.email
     assert email.subject == "MBTA Alerts Account Confirmation"
-    assert email.html_body =~ "Congratulations, you have successfully subscribed to receive MBTA email alerts."
+    assert email.html_body =~ "Congratulations, you have successfully subscribed to receive MBTA alerts."
     assert email.html_body =~ "/unsubscribe"
     assert email.html_body =~ "/my-account/confirm_disable?token="
   end

--- a/apps/concierge_site/test/web/users/confirmation_message_test.exs
+++ b/apps/concierge_site/test/web/users/confirmation_message_test.exs
@@ -13,7 +13,7 @@ defmodule ConciergeSite.ConfirmationMessageTest do
       email = Email.confirmation_email(user)
       refute_received :publish
       assert_delivered_with(to: [{nil, "test@test.com"}])
-      assert email.html_body =~ "Congratulations, you have successfully subscribed to receive MBTA email alerts"
+      assert email.html_body =~ "Congratulations, you have successfully subscribed to receive MBTA alerts"
     end
 
     test "sends SMS and email to user with phone number" do


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/MTC-458

Reported by a user who wanted SMS alerts that this was confusing