### PR TITLE
ensure send_after datetime converted to utc

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -163,7 +163,10 @@ defmodule AlertProcessor.NotificationBuilder do
   defp time_to_datetime(time, datetime) do
     erl_time = T.to_erl(time)
     erl_date = DT.to_date(datetime)
-    DT.from_date_and_time_and_zone!(erl_date, erl_time, "America/New_York")
+
+    erl_date
+    |> DT.from_date_and_time_and_zone!(erl_time, "America/New_York")
+    |> DT.shift_zone!("Etc/UTC")
   end
 
   defp before_or_equal(first_dt, second_dt) do

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -103,6 +103,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
 
     [notification] = NotificationBuilder.build_notifications(sub, alert, time.now)
     assert DT.same_time?(notification.send_after, time.one_day_from_now)
+    assert %DateTime{time_zone: "Etc/UTC"} = notification.send_after
   end
 
   test "do not send notification if send_time -> active_period end is inside blackout period", %{time: time} do
@@ -190,7 +191,8 @@ defmodule AlertProcessor.NotificationBuilderTest do
     }
 
     [notification] = NotificationBuilder.build_notifications(sub, alert, today_5am)
-    assert notification.send_after == today_8am
+    assert DT.same_time?(notification.send_after, today_8am)
+    assert %DateTime{time_zone: "Etc/UTC"} = notification.send_after
   end
 
   test """
@@ -222,6 +224,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
     }
 
     [notification] = NotificationBuilder.build_notifications(sub, alert, today_10pm)
-    assert notification.send_after == tomorrow_8am
+    assert DT.same_time?(notification.send_after, tomorrow_8am)
+    assert %DateTime{time_zone: "Etc/UTC"} = notification.send_after
   end
 end


### PR DESCRIPTION
this was an issue which was causing duplicate notifications when coming out of a dnd period. The DateTime used as the send_after DateTime was in EST and would fail to persist the notification causing the repeated attempt to send since no notification was being persisted to stop new notifications from being queued. Then once the user was out of their dnd period, they would use the send after of `DateTime.utc_now` which would properly persist and end the loop.