### PR TITLE
add confirmation screen to unsubscribe flow

### DIFF
--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -42,6 +42,7 @@ defmodule ConciergeSite.Router do
     resources "/login", SessionController, only: [:new, :create, :delete], singleton: true
     get "/reset-password/sent", PasswordResetController, :sent
     resources "/reset-password", PasswordResetController, only: [:new, :create, :edit, :update]
+    post "/unsubscribe", UnsubscribeController, :unsubscribe_confirmed
     get "/unsubscribe/:token", UnsubscribeController, :unsubscribe
     post "/rejected_email", RejectedEmailController, :handle_rejected_email
   end

--- a/apps/concierge_site/lib/templates/unsubscribe/unsubscribe.html.eex
+++ b/apps/concierge_site/lib/templates/unsubscribe/unsubscribe.html.eex
@@ -2,7 +2,13 @@
 
 <div class="my-account-container">
   <div class="unsubscribe-content">
-    <h2>You have been unsubscribed</h2>
-    <p>You have been unsubscribed from all future alerts. To begin receiving alerts again, log in and click <strong>Resume Alerts</strong></p>
+    <h2>Unsubscribe?</h2>
+    <%= flash_error(@conn) %>
+    <p>Are you sure that you’d like to unsubscribe? No further notifications will be sent</p>
+    <%= form_for @conn, unsubscribe_path(@conn, :unsubscribe_confirmed), [as: :unsubscribe], fn f -> %>
+    <%= hidden_input f, :token, value: @token %>
+      <%= submit("Yes, unsubscribe", class: "btn btn-primary btn-wide") %>
+    <% end %>
+    <%= link("Cancel", to: session_path(@conn, :new)) %>
   </div>
 </div>

--- a/apps/concierge_site/lib/templates/unsubscribe/unsubscribe_confirmed.html.eex
+++ b/apps/concierge_site/lib/templates/unsubscribe/unsubscribe_confirmed.html.eex
@@ -1,0 +1,8 @@
+<h1>My Account</h1>
+
+<div class="my-account-container">
+  <div class="unsubscribe-content">
+    <h2>You have been unsubscribed</h2>
+    <p>You have been unsubscribed from all future alerts. To begin receiving alerts again, log in and click <strong>Resume Alerts</strong></p>
+  </div>
+</div>


### PR DESCRIPTION
it seems that some email providers or spam detection will follow links in emails and this was automatically unsubscribing users when their confirmation email (with an unsubscribe link) was being followed. 
<img width="1241" alt="screen shot 2017-09-15 at 2 18 03 pm" src="https://user-images.githubusercontent.com/526017/30497446-e36afe8c-9a20-11e7-8c14-7e3f47435a07.png">
<img width="1251" alt="screen shot 2017-09-15 at 2 17 56 pm" src="https://user-images.githubusercontent.com/526017/30497452-e666cbfc-9a20-11e7-94df-a0ae0f2d038c.png">

