### PR TITLE
update mailer settings to avoid aws throttling on port 25

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -16,10 +16,6 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-config :alert_processor, AlertProcessor,
-  pool_size: 2,
-  overflow: 1
-
 # Configure your database
 config :alert_processor, AlertProcessor.Repo,
   adapter: Ecto.Adapters.Postgres,
@@ -38,6 +34,8 @@ config :alert_processor, database_url: {:system, "DATABASE_URL_DEV", "postgresql
 
 # Config for Rate Limiter. Scale: time period in ms. Limit: # of requests per time period. Send Rate: ms delay between send
 config :alert_processor,
+  pool_size: 2,
+  overflow: 1,
   rate_limit_scale: {:system, "RATE_LIMIT_SCALE", "3600000"},
   rate_limit: {:system, "RATE_LIMIT", "30"},
   send_rate: {:system, "SEND_RATE", "100"}

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -17,8 +17,8 @@ defmodule AlertProcessor.Supervisor do
     SmsOptOutWorker
   }
 
-  @worker_pool_size Application.get_env(__MODULE__, :pool_size)
-  @worker_pool_overflow Application.get_env(__MODULE__, :overflow)
+  @worker_pool_size Application.get_env(:alert_processor, :pool_size)
+  @worker_pool_overflow Application.get_env(:alert_processor, :overflow)
 
   def start_link do
     Supervisor.start_link(__MODULE__, [])

--- a/apps/concierge_site/config/prod.exs
+++ b/apps/concierge_site/config/prod.exs
@@ -39,7 +39,7 @@ config :logger, :logentries,
 config :concierge_site, ConciergeSite.Dissemination.Mailer,
   adapter: Bamboo.SMTPAdapter,
   server: "email-smtp.us-east-1.amazonaws.com",
-  port: 25,
+  port: 587,
   tls: :always, # can be `:always` or `:never`
   ssl: false, # can be `true`
   retries: 3,


### PR DESCRIPTION
looks like aws throttles send rates on port 25 even when slowed down to a 5 second delay after the third email will start timing out. Switching to a different port suggested here: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/limits.html#limits-ec2 seems to resolve the issue. 

config lookup was no longer valid since module where settings were attempting to be called from is no longer `AlertProcessor` but `Supervisor` moved in with the rest of notification related config items.