### PR TITLE
add manage subscriptions link to email footer

### DIFF
--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -139,7 +139,7 @@ defmodule AlertProcessor.Model.UserTest do
         |> User.claims_with_permission(claims, admin_user)
         |> Guardian.Permissions.from_claims()
         |> Guardian.Permissions.to_list()
-      assert [:reset_password, :unsubscribe, :disable_account, :full_permissions] == new_claims
+      assert [:reset_password, :unsubscribe, :disable_account, :full_permissions, :manage_subscriptions] == new_claims
     end
 
     test "encodes the user's claims with previous permission" do

--- a/apps/concierge_site/config/config.exs
+++ b/apps/concierge_site/config/config.exs
@@ -47,7 +47,8 @@ config :guardian, Guardian,
       :reset_password,
       :unsubscribe,
       :disable_account,
-      :full_permissions
+      :full_permissions,
+      :manage_subscriptions
     ],
     admin: [
       :customer_support,

--- a/apps/concierge_site/lib/dissemination/digest_email.ex
+++ b/apps/concierge_site/lib/dissemination/digest_email.ex
@@ -13,7 +13,7 @@ defmodule ConciergeSite.Dissemination.DigestEmail do
     :def,
     :html_email,
     Path.join(@template_dir, "digest.html.eex"),
-    [:digest_date_groups, :unsubscribe_url])
+    [:digest_date_groups, :unsubscribe_url, :manage_subscriptions_url])
   EEx.function_from_file(
     :def,
     :text_email,
@@ -24,10 +24,11 @@ defmodule ConciergeSite.Dissemination.DigestEmail do
   @spec digest_email(DigestMessage.t) :: Elixir.Bamboo.Email.t
   def digest_email(digest_message) do
     unsubscribe_url = MailHelper.unsubscribe_url(digest_message.user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(digest_message.user)
     base_email()
     |> to(digest_message.user.email)
     |> subject("MBTA Alerts Digest")
-    |> html_body(html_email(digest_message.body, unsubscribe_url))
+    |> html_body(html_email(digest_message.body, unsubscribe_url, manage_subscriptions_url))
     |> text_body(text_email(digest_message.body, unsubscribe_url))
   end
 

--- a/apps/concierge_site/lib/dissemination/email.ex
+++ b/apps/concierge_site/lib/dissemination/email.ex
@@ -12,7 +12,7 @@ defmodule ConciergeSite.Dissemination.Email do
     :def,
     :password_reset_html_email,
     Path.join(@template_dir, "password_reset.html.eex"),
-    [:password_reset_id, :unsubscribe_url])
+    [:password_reset_id, :unsubscribe_url, :manage_subscriptions_url])
   EEx.function_from_file(
     :def,
     :password_reset_text_email,
@@ -21,10 +21,11 @@ defmodule ConciergeSite.Dissemination.Email do
 
   def password_reset_email(user, password_reset) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
     base_email()
     |> to(user.email)
     |> subject("Reset Your MBTA Alerts Password")
-    |> html_body(password_reset_html_email(password_reset.id, unsubscribe_url))
+    |> html_body(password_reset_html_email(password_reset.id, unsubscribe_url, manage_subscriptions_url))
     |> text_body(password_reset_text_email(password_reset.id, unsubscribe_url))
   end
 
@@ -51,7 +52,7 @@ defmodule ConciergeSite.Dissemination.Email do
     :def,
     :confirmation_html_email,
     Path.join(@template_dir, "confirmation.html.eex"),
-    [:unsubscribe_url, :disable_account_url])
+    [:unsubscribe_url, :disable_account_url, :manage_subscriptions_url])
   EEx.function_from_file(
     :def,
     :confirmation_text_email,
@@ -61,10 +62,11 @@ defmodule ConciergeSite.Dissemination.Email do
   def confirmation_email(user) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
     disable_account_url = MailHelper.disable_account_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
     base_email()
     |> to(user.email)
     |> subject("MBTA Alerts Account Confirmation")
-    |> html_body(confirmation_html_email(unsubscribe_url, disable_account_url))
+    |> html_body(confirmation_html_email(unsubscribe_url, disable_account_url, manage_subscriptions_url))
     |> text_body(confirmation_text_email(unsubscribe_url, disable_account_url))
   end
 

--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -14,7 +14,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
     :def,
     :html_email,
     Path.join(@template_dir, "notification.html.eex"),
-    [:notification, :unsubscribe_url])
+    [:notification, :unsubscribe_url, :manage_subscriptions_url])
   EEx.function_from_file(
     :def,
     :text_email,
@@ -25,12 +25,13 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
   @spec notification_email(Notification.t) :: Elixir.Bamboo.Email.t
   def notification_email(%Notification{user: user} = notification) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
     notification_email_subject = email_subject(notification)
 
     base_email()
     |> to(user.email)
     |> subject(notification_email_subject)
-    |> html_body(html_email(notification, unsubscribe_url))
+    |> html_body(html_email(notification, unsubscribe_url, manage_subscriptions_url))
     |> text_body(text_email(notification, unsubscribe_url))
   end
 

--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -15,7 +15,7 @@ defmodule ConciergeSite.Helpers.MailHelper do
     :def,
     :footer,
     Path.join(@template_dir, "_footer.html.eex"),
-    [:unsubscribe_url]
+    [:unsubscribe_url, :manage_subscriptions_url]
   )
 
   EEx.function_from_file(
@@ -125,5 +125,10 @@ defmodule ConciergeSite.Helpers.MailHelper do
 
   def reset_password_url(password_reset_id) do
     Helpers.password_reset_url(ConciergeSite.Endpoint, :edit, password_reset_id)
+  end
+
+  def manage_subscriptions_url(user) do
+    {:ok, token, _permissions} = Token.issue(user, [:manage_subscriptions])
+    Helpers.subscription_url(ConciergeSite.Endpoint, :index, token: token)
   end
 end

--- a/apps/concierge_site/lib/mail_templates/_footer.html.eex
+++ b/apps/concierge_site/lib/mail_templates/_footer.html.eex
@@ -18,7 +18,7 @@
         <div class="footer-link-separator-bullet" />
       </td>
       <td>
-        <a class="footer-link" href="#">Edit Your Subscriptions</a>
+        <a class="footer-link" href="<%= manage_subscriptions_url %>">Edit Your Subscriptions</a>
       </td>
     </tr>
   </table>

--- a/apps/concierge_site/lib/mail_templates/confirmation.html.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.html.eex
@@ -14,7 +14,7 @@
       <p>If you did NOT request an account to receive MBTA alerts, click <a href="<%= disable_account_url %>">here</a> to disable the account.<p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/digest.html.eex
+++ b/apps/concierge_site/lib/mail_templates/digest.html.eex
@@ -65,7 +65,7 @@
         </div>
       </div>
 
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
     </center>
 	</body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -27,7 +27,7 @@
       </p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
     </center>
 	</body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/password_reset.html.eex
+++ b/apps/concierge_site/lib/mail_templates/password_reset.html.eex
@@ -28,7 +28,7 @@
       </p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
+++ b/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
@@ -153,4 +153,13 @@ defmodule ConcerigeSite.Helpers.MailHelperTest do
       assert url =~ "reset-password/#{password_reset_id}/edit"
     end
   end
+
+  describe "manage_subscription_url" do
+    test "generates url with token" do
+      user = insert(:user)
+      url = MailHelper.manage_subscriptions_url(user)
+      assert url =~ "http"
+      assert url =~ ~r/my-subscriptions\?token=(.+)/
+    end
+  end
 end


### PR DESCRIPTION
previously footer link wasn't included since all the subscription flows were not yet completed, this adds a scoped link to be able to manage subscriptions but not other aspects of the account.