### PR TITLE
add missing manage subscriptions link to targeted notification email

### DIFF
--- a/apps/concierge_site/lib/dissemination/email.ex
+++ b/apps/concierge_site/lib/dissemination/email.ex
@@ -74,18 +74,20 @@ defmodule ConciergeSite.Dissemination.Email do
     :def,
     :targeted_notification_html_email,
     Path.join(@template_dir, "targeted_notification.html.eex"),
-    [:subject, :body])
+    [:subject, :body, :manage_subscriptions_url])
   EEx.function_from_file(
     :def,
     :targeted_notification_text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates targeted_notification.txt.eex)),
     [:body])
 
-  def targeted_notification_email(email, subject, body) do
+  def targeted_notification_email(user, subject, body) do
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+
     base_email()
-    |> to(email)
+    |> to(user.email)
     |> subject(subject)
-    |> html_body(targeted_notification_html_email(subject, body))
+    |> html_body(targeted_notification_html_email(subject, body, manage_subscriptions_url))
     |> text_body(targeted_notification_text_email(body))
   end
 

--- a/apps/concierge_site/lib/mail_templates/targeted_notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/targeted_notification.html.eex
@@ -23,7 +23,7 @@
               <div class="footer-link-separator-bullet" />
             </td>
             <td>
-              <a class="footer-link" href="#">Edit Your Subscriptions</a>
+              <a class="footer-link" href="<%= manage_subscriptions_url %>">Edit Your Subscriptions</a>
             </td>
           </tr>
         </table>

--- a/apps/concierge_site/lib/subscriptions/targeted_notification.ex
+++ b/apps/concierge_site/lib/subscriptions/targeted_notification.ex
@@ -7,14 +7,14 @@ defmodule ConciergeSite.TargetedNotification do
 
   def send_targeted_notification(subscriber, message)
   def send_targeted_notification(subscriber, %{"carrier" => "email"} = message) do
-    send_email(subscriber.email, message["subject"], message["email_body"])
+    send_email(subscriber, message["subject"], message["email_body"])
   end
   def send_targeted_notification(subscriber, %{"carrier" => "sms"} = message) do
     send_sms(subscriber.phone_number, message)
   end
 
-  defp send_email(email, subject, body) do
-    email
+  defp send_email(subscriber, subject, body) do
+    subscriber
     |> Email.targeted_notification_email(subject, body)
     |> Mailer.deliver_later
   end

--- a/apps/concierge_site/test/lib/dissemination/email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/email_test.exs
@@ -40,7 +40,7 @@ defmodule ConciergeSite.Dissemination.EmailTest do
     subject = "Test Subject"
     body = "This is the body of the test email"
 
-    email = Email.targeted_notification_email(subscriber.email, subject, body)
+    email = Email.targeted_notification_email(subscriber, subject, body)
 
     assert email.to == subscriber.email
     assert email.subject == subject

--- a/apps/concierge_site/test/web/subscriptions/targeted_notification_test.exs
+++ b/apps/concierge_site/test/web/subscriptions/targeted_notification_test.exs
@@ -13,7 +13,7 @@ defmodule ConciergeSite.TargetedNotificationTest do
                   "subject" => "testing", "email_body" => "body of test email"}
       TargetedNotification.send_targeted_notification(subscriber, message)
 
-      email = Email.targeted_notification_email(subscriber.email, message["subject"], message["email_body"])
+      email = Email.targeted_notification_email(subscriber, message["subject"], message["email_body"])
       assert_delivered_with(to: [{nil, "test@test.com"}])
       assert email.html_body =~ "body of test email"
     end


### PR DESCRIPTION
missed the footer link in the targeted notification email for the manage subscription link.