### PR TITLE
catch no common trips for trip options

### DIFF
--- a/apps/alert_processor/lib/subscription/mapper.ex
+++ b/apps/alert_processor/lib/subscription/mapper.ex
@@ -331,6 +331,8 @@ defmodule AlertProcessor.Subscription.Mapper do
   end
   def get_trip_info(origin, destination, relevant_days, timestamp, map_trip_options_fn) do
     case map_trip_options_fn.(origin, destination, relevant_days) do
+      {:ok, []} ->
+        :error
       {:ok, trips} ->
         departure_start = timestamp |> Time.from_iso8601!() |> DateTimeHelper.seconds_of_day()
         closest_trip = Enum.min_by(trips, &calculate_difference(&1, departure_start))

--- a/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
@@ -574,6 +574,7 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
     test "returns error if origin/destination are not on the same route" do
       :error = FerryMapper.get_trip_info("Boat-Hingham", "Boat-Charlestown", :sunday, "10:00:00")
       :error = FerryMapper.get_trip_info("Boat-Hingham", "Boat-Charlestown", :sunday, ["Boat-F1-Boat-Hingham-11:00:00-weekend-1", "Boat-F1-Boat-Hingham-15:00:00-weekend-1"])
+      :error = FerryMapper.get_trip_info("Boat-Long", "Boat-Rowes", :weekday, "10:00:00")
     end
   end
 


### PR DESCRIPTION
catch empty set of matching schedules for ferry station combinations which may be on the same route but not have common schedules.