### PR TITLE
add white-space: pre; to description paragraph tag to retain line breaks

### DIFF
--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -18,9 +18,7 @@
         <%= notification.header %>
       </p>
       <br>
-      <p class="notification-description">
-        <%= notification.description %>
-      </p>
+      <p class="notification-description"><%= notification.description %></p>
 
       <p class="notification-link-wrapper">
         <a class="notification-link" href="https://t.mbta.com/">View all alerts &rarr;</a>

--- a/apps/concierge_site/lib/mail_templates/styles/notification_styles.css
+++ b/apps/concierge_site/lib/mail_templates/styles/notification_styles.css
@@ -26,6 +26,7 @@ h1.notification-service-effect {
   font-size: 16px;
   line-height: 1.5;
   color: #1c1e23;
+  white-space: pre;
 }
 
 .notification-link-wrapper {


### PR DESCRIPTION
<img width="685" alt="screen shot 2017-09-20 at 1 18 03 pm" src="https://user-images.githubusercontent.com/526017/30658483-c740da2e-9e08-11e7-8435-17eaf1285f47.png">
