### PR TITLE
fix description formatting for outlook

### DIFF
--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -18,7 +18,9 @@
         <%= notification.header %>
       </p>
       <br>
-      <p class="notification-description"><%= notification.description %></p>
+      <%= if notification.description do %>
+        <p class="notification-description"><%= String.replace(notification.description, "\r\n", "<br/>") %></p>
+      <% end %>
 
       <p class="notification-link-wrapper">
         <a class="notification-link" href="https://t.mbta.com/">View all alerts &rarr;</a>

--- a/apps/concierge_site/lib/mail_templates/styles/notification_styles.css
+++ b/apps/concierge_site/lib/mail_templates/styles/notification_styles.css
@@ -26,7 +26,6 @@ h1.notification-service-effect {
   font-size: 16px;
   line-height: 1.5;
   color: #1c1e23;
-  white-space: pre;
 }
 
 .notification-link-wrapper {


### PR DESCRIPTION
previous fix worked for other clients, but outlook did not. This method works on outlook as well.