### PR TITLE
properly determine direction id for round trip subscriptions 

### DIFF
--- a/apps/alert_processor/test/alert_processor/subscription/subway_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/subway_mapper_test.exs
@@ -222,6 +222,30 @@ defmodule AlertProcessor.Subscription.SubwayMapperTest do
       assert route_entity_count == 1
     end
 
+    test "works for northbound departure trip" do
+      {:ok, [{_sub1, ie1}, {_sub2, ie2}]} = SubwayMapper.map_subscriptions(Map.merge(@round_trip_params, %{"origin" => "place-rcmnl", "destination" => "place-tumnl"}))
+      route_entity_count =
+        Enum.count(ie1, fn(informed_entity) ->
+          match?(%InformedEntity{route: "Orange", route_type: 1, stop: nil, direction_id: nil}, informed_entity)
+        end)
+      assert route_entity_count == 1
+      route_entity_count =
+        Enum.count(ie1, fn(informed_entity) ->
+          match?(%InformedEntity{route: "Orange", route_type: 1, stop: nil, direction_id: 1}, informed_entity)
+        end)
+      assert route_entity_count == 1
+      route_entity_count =
+        Enum.count(ie2, fn(informed_entity) ->
+          match?(%InformedEntity{route: "Orange", route_type: 1, stop: nil, direction_id: nil}, informed_entity)
+        end)
+      assert route_entity_count == 1
+      route_entity_count =
+        Enum.count(ie2, fn(informed_entity) ->
+          match?(%InformedEntity{route: "Orange", route_type: 1, stop: nil, direction_id: 0}, informed_entity)
+        end)
+      assert route_entity_count == 1
+    end
+
     test "constructs subscription with route type" do
       {:ok, [{_sub1, ie1}, {_sub2, ie2}]} = SubwayMapper.map_subscriptions(@round_trip_params)
       route_type_entity_count =


### PR DESCRIPTION
for round trip subscriptions we were not properly determining the direction id so if the departure trip was actually northbound, the directions were reversed since they were actually just hardcoded and not calculated. 