### PR TITLE
adjust digest date groups to treat 2:30am as day boundary

### DIFF
--- a/apps/alert_processor/lib/digest/digest_date_helper.ex
+++ b/apps/alert_processor/lib/digest/digest_date_helper.ex
@@ -63,10 +63,10 @@ defmodule AlertProcessor.DigestDateHelper do
   end
 
   @spec active_period_within?(map, {DateTime.t, DateTime.t}) :: boolean()
-  defp active_period_within?(%{start: aps, end: nil}, {dgs, _dge}) do
-    not DT.after?(aps, dgs)
+  defp active_period_within?(%{start: aps, end: nil}, {_dgs, dge}) do
+    DT.before?(aps, dge)
   end
   defp active_period_within?(%{start: aps, end: ape}, {dgs, dge}) do
-    not DT.before?(dge, aps) and not DT.before?(ape, dgs)
+    !DT.before?(dge, aps) && !DT.before?(ape, dgs)
   end
 end

--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -139,9 +139,9 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
 
     start_time = today
     |> Map.merge(%{
-      hour: 0,
-      minute: 0,
-      second: 0,
+      hour: 2,
+      minute: 30,
+      second: 1,
       microsecond: {0, 0}
     })
     |> DT.add!(seconds_till_saturday(today))

--- a/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
@@ -10,15 +10,15 @@ defmodule AlertProcessor.DigestDateHelperTest do
 
   @ap1 [
     %{
-      start: DT.from_erl!({{2017, 06, 27}, {0, 0, 1}}, "America/New_York"),
+      start: DT.from_erl!({{2017, 06, 27}, {2, 30, 0}}, "America/New_York"),
       end: DT.from_erl!({{2017, 06, 28}, {0, 0, 0}}, "America/New_York")
      }
   ]
 
   @ap2 [
     %{
-      start: DT.from_erl!({{2017, 05, 30}, {0, 0, 1}}, "America/New_York"),
-      end: DT.from_erl!({{2017, 06, 03}, {0, 0, 1}}, "America/New_York")
+      start: DT.from_erl!({{2017, 05, 30}, {2, 30, 0}}, "America/New_York"),
+      end: DT.from_erl!({{2017, 06, 03}, {2, 30, 1}}, "America/New_York")
     }
   ]
 
@@ -31,14 +31,14 @@ defmodule AlertProcessor.DigestDateHelperTest do
 
   @ap4 [
     %{
-      start: DT.from_erl!({{2017, 05, 27}, {1, 0, 1}}, "America/New_York"),
+      start: DT.from_erl!({{2017, 05, 27}, {2, 30, 0}}, "America/New_York"),
       end: DT.from_erl!({{2017, 05, 28}, {23, 0, 0}}, "America/New_York")
     }
   ]
 
   @ap5 [
     %{
-      start: DT.from_erl!({{2017, 05, 27}, {1, 0, 1}}, "America/New_York"),
+      start: DT.from_erl!({{2017, 05, 29}, {2, 30, 0}}, "America/New_York"),
       end: nil
     }
   ]

--- a/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
@@ -43,36 +43,36 @@ defmodule AlertProcessor.Helpers.DateTimeHelperTest do
     @sunday DT.from_erl!({{2017, 5, 28}, {0, 0, 0}}, "America/New_York")
 
     test "upcoming_weekend/0 returns the start and end DateTime of upcoming weekend" do
-      saturday_start = DT.from_erl!({{2017, 5, 27}, {0, 0, 0}}, "America/New_York")
-      sunday_end = DT.from_erl!({{2017, 5, 28}, {23, 59, 59}}, "America/New_York")
+      saturday_start = DT.from_erl!({{2017, 5, 27}, {2, 30, 1}}, "America/New_York")
+      sunday_end = DT.from_erl!({{2017, 5, 29}, {2, 30, 0}}, "America/New_York")
 
       assert DTH.upcoming_weekend(@thursday) == {saturday_start, sunday_end}
     end
 
     test "upcoming_weekend/0 works for current date of Saturday/Sunday" do
-      saturday_start = DT.from_erl!({{2017, 6, 03}, {0, 0, 0}}, "America/New_York")
-      sunday_end = DT.from_erl!({{2017, 6, 04}, {23, 59, 59}}, "America/New_York")
+      saturday_start = DT.from_erl!({{2017, 6, 03}, {2, 30, 1}}, "America/New_York")
+      sunday_end = DT.from_erl!({{2017, 6, 05}, {2, 30, 0}}, "America/New_York")
 
       assert DTH.upcoming_weekend(@saturday) == {saturday_start, sunday_end}
       assert DTH.upcoming_weekend(@sunday) == {saturday_start, sunday_end}
     end
 
     test "upcoming_week/0" do
-      monday_start = DT.from_erl!({{2017, 5, 29}, {0, 0, 0}}, "America/New_York")
-      friday_end = DT.from_erl!({{2017, 6, 2}, {23, 59, 59}}, "America/New_York")
+      monday_start = DT.from_erl!({{2017, 5, 29}, {2, 30, 1}}, "America/New_York")
+      friday_end = DT.from_erl!({{2017, 6, 3}, {2, 30, 0}}, "America/New_York")
 
       assert DTH.upcoming_week(@thursday) == {monday_start, friday_end}
     end
 
     test "next_weekend/0" do
-      saturday_start = DT.from_erl!({{2017, 6, 3}, {0, 0, 0}}, "America/New_York")
-      sunday_end = DT.from_erl!({{2017, 6, 4}, {23, 59, 59}}, "America/New_York")
+      saturday_start = DT.from_erl!({{2017, 6, 3}, {2, 30, 1}}, "America/New_York")
+      sunday_end = DT.from_erl!({{2017, 6, 5}, {2, 30, 0}}, "America/New_York")
 
       assert DTH.next_weekend(@thursday) == {saturday_start, sunday_end}
     end
 
     test "future/0" do
-      monday_start = DT.from_erl!({{2017, 6, 5}, {0, 0, 0}}, "America/New_York")
+      monday_start = DT.from_erl!({{2017, 6, 5}, {2, 30, 1}}, "America/New_York")
       far_in_future = DT.from_erl!({{3000, 01, 01}, {0, 0, 0}}, "America/New_York")
 
       assert DTH.future(@thursday) == {monday_start, far_in_future}


### PR DESCRIPTION
adjustment to digest time bucket calculations to treat 2:30am of the following day as end of day rather than midnight.