### PR TITLE
extend manage subscriptions link ttl to 30 days

### DIFF
--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -128,7 +128,7 @@ defmodule ConciergeSite.Helpers.MailHelper do
   end
 
   def manage_subscriptions_url(user) do
-    {:ok, token, _permissions} = Token.issue(user, [:manage_subscriptions])
+    {:ok, token, _permissions} = Token.issue(user, [:manage_subscriptions], {30, :days})
     Helpers.subscription_url(ConciergeSite.Endpoint, :index, token: token)
   end
 end


### PR DESCRIPTION
manage subscriptions url was using default value of 24 hours instead of 30 days.