### PR TITLE
update subscription during dnd period check to ignore amenity subscriptions

### DIFF
--- a/apps/concierge_site/lib/views/time_helper.ex
+++ b/apps/concierge_site/lib/views/time_helper.ex
@@ -83,6 +83,7 @@ defmodule ConciergeSite.TimeHelper do
 
   @spec subscription_during_do_not_disturb?(Subscription.t, User.t) :: boolean
   def subscription_during_do_not_disturb?(_, %User{do_not_disturb_start: nil, do_not_disturb_end: nil}), do: false
+  def subscription_during_do_not_disturb?(%Subscription{type: :amenity}, _), do: false
   def subscription_during_do_not_disturb?(%Subscription{start_time: sub_start_time, end_time: sub_end_time}, %User{do_not_disturb_start: dnd_start, do_not_disturb_end: dnd_end}) do
     start_time = time_shift_zone(sub_start_time, "Etc/UTC", "America/New_York")
     end_time = time_shift_zone(sub_end_time, "Etc/UTC", "America/New_York")

--- a/apps/concierge_site/test/web/views/time_helper_test.exs
+++ b/apps/concierge_site/test/web/views/time_helper_test.exs
@@ -82,5 +82,9 @@ defmodule ConciergeSite.TimeHelperTest do
     test "returns false if dnd period is not set" do
       refute TimeHelper.subscription_during_do_not_disturb?(%Subscription{start_time: ~T[12:00:00], end_time: ~T[18:00:00]}, %User{do_not_disturb_start: nil, do_not_disturb_end: nil})
     end
+
+    test "returns false if subscription is type amenity" do
+      refute TimeHelper.subscription_during_do_not_disturb?(%Subscription{type: :amenity, start_time: ~T[18:00:00], end_time: ~T[22:00:00]}, %User{do_not_disturb_start: ~T[17:00:00], do_not_disturb_end: ~T[02:00:00]})
+    end
   end
 end


### PR DESCRIPTION
need to ignore amenity subscription for the dnd overlap warning since amenity subscriptions run 24/7.