### PR TITLE
fix scheduling first digest send time calculation

### DIFF
--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -116,7 +116,7 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
     if difference >= 0 do
       difference
     else
-      interval - difference
+      interval + difference
     end
   end
 


### PR DESCRIPTION
fix bug in scheduling next digest send when starting app later in the week than the digest send date/time. 