### PR TITLE
check for empty digest body and dont send

### DIFF
--- a/apps/alert_processor/lib/digest/digest_dispatcher.ex
+++ b/apps/alert_processor/lib/digest/digest_dispatcher.ex
@@ -10,11 +10,15 @@ defmodule AlertProcessor.DigestDispatcher do
   """
   @spec send_emails([DigestMessage.t]) :: :ok
   def send_emails(digest_messages) do
-    Enum.each(digest_messages, fn(digest_message) ->
-      :timer.sleep(send_rate())
-      @mailer.send_digest_email(digest_message)
-    end)
+    Enum.each(digest_messages, &do_send_email/1)
   end
+
+  defp do_send_email(%DigestMessage{body: []}), do: :ok
+  defp do_send_email(digest_message) do
+    :timer.sleep(send_rate())
+    @mailer.send_digest_email(digest_message)
+  end
+
 
   defp send_rate do
     ConfigHelper.get_int(:send_rate)

--- a/apps/alert_processor/test/alert_processor/digest/digest_dispatcher_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_dispatcher_test.exs
@@ -37,4 +37,16 @@ defmodule AlertProcessor.DigestDispatcherTest do
     DigestDispatcher.send_emails([message])
     assert_received {:sent_digest_email, ^message}
   end
+
+  test "send_email/1 ignores digests without a body" do
+    user = %User{email: "abc@123.com"}
+    alert = %Alert{id: "3",
+                   header: "Test",
+                   informed_entities: [%InformedEntity{route_type: 1, route: "Red"}]}
+    digest = %Digest{user: user, alerts: [alert], digest_date_group: @ddg}
+    message = DigestMessage.from_digest(digest)
+
+    DigestDispatcher.send_emails([message])
+    refute_received {:sent_digest_email, ^message}
+  end
 end


### PR DESCRIPTION
had sent at least one empty digest due to the potential matching alerts only being relevant for the current day and subsequently not falling into any of the buckets within the digest itself causing the digest body to be empty. This PR checks for an empty digest body before sending and if there is one, does not attempt to send the digest.