### PR TITLE
Don't allow updating subs to end after service day

### DIFF
--- a/apps/concierge_site/lib/controllers/bus_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/bus_subscription_controller.ex
@@ -15,18 +15,22 @@ defmodule ConciergeSite.BusSubscriptionController do
   end
 
   def update(conn, %{"id" => id, "subscription" => subscription_params}, user, {:ok, claims}) do
-    subscription = Subscription.one_for_user!(id, user.id)
-    params = SubscriptionParams.prepare_for_update_changeset(subscription_params)
-
-    case Subscription.update_subscription(subscription, params, Map.get(claims, "imp", user.id)) do
-      {:ok, _subscription} ->
-        :ok = User.clear_holding_queue_for_user_id(user.id)
-        conn
-        |> put_flash(:info, "Subscription updated.")
-        |> redirect(to: subscription_path(conn, :index))
-      {:error, changeset} ->
+    subscription = Subscription.one_for_user!(id, user.id, true)
+    with {:ok, params} <- SubscriptionParams.prepare_for_update_changeset(subscription_params),
+         {:ok, _subscription} <- Subscription.update_subscription(subscription, params, Map.get(claims, "imp", user.id)) do
+      :ok = User.clear_holding_queue_for_user_id(user.id)
+      conn
+      |> put_flash(:info, "Subscription updated.")
+      |> redirect(to: subscription_path(conn, :index))
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
         conn
         |> put_flash(:error, "Subscription could not be updated. Please see errors below.")
+        |> render("edit.html", subscription: subscription, changeset: changeset)
+      {:error, error_message} ->
+        changeset = Subscription.create_changeset(subscription)
+        conn
+        |> put_flash(:error, error_message)
         |> render("edit.html", subscription: subscription, changeset: changeset)
     end
   end

--- a/apps/concierge_site/lib/subscriptions/bus_params.ex
+++ b/apps/concierge_site/lib/subscriptions/bus_params.ex
@@ -37,25 +37,6 @@ defmodule ConciergeSite.Subscriptions.BusParams do
     end
   end
 
-  defp validate_endtime_after_starttime({%{"return_start" => _} = params, errors}) do
-    cond do
-      outside_service_time_range(params["return_start"], params["return_end"]) ->
-        {params, ["Start time on return trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-      outside_service_time_range(params["departure_start"], params["departure_end"]) ->
-        {params, ["Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-      true ->
-        {params, errors}
-    end
-  end
-
-  defp validate_endtime_after_starttime({params, errors}) do
-    if outside_service_time_range(params["departure_start"], params["departure_end"]) do
-      {params, ["Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-    else
-      {params, errors}
-    end
-  end
-
   @doc """
   Transform submitted subscription params for BusMapper
   """

--- a/apps/concierge_site/lib/subscriptions/subway_params.ex
+++ b/apps/concierge_site/lib/subscriptions/subway_params.ex
@@ -64,25 +64,6 @@ defmodule ConciergeSite.Subscriptions.SubwayParams do
     end
   end
 
-  defp validate_endtime_after_starttime({%{"return_start" => _} = params, errors}) do
-    cond do
-      outside_service_time_range(params["return_start"], params["return_end"]) ->
-        {params, ["Start time on return trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-      outside_service_time_range(params["departure_start"], params["departure_end"]) ->
-        {params, ["Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-      true ->
-        {params, errors}
-    end
-  end
-
-  defp validate_endtime_after_starttime({params, errors}) do
-    if outside_service_time_range(params["departure_start"], params["departure_end"]) do
-      {params, ["Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM."]}
-    else
-      {params, errors}
-    end
-  end
-
   def map_station_schedules(origin, destination) do
     case ApiClient.subway_schedules_union(origin, destination) do
       {:ok, schedule_data, included_data} ->

--- a/apps/concierge_site/test/web/subscriptions/bus_params_test.exs
+++ b/apps/concierge_site/test/web/subscriptions/bus_params_test.exs
@@ -43,18 +43,20 @@ defmodule ConciergeSite.Subscriptions.BusParamsTest do
     test "it returns error messages when the departure end is before departure start" do
       params = %{
         "route" => "88 - 0",
+        "weekday" => "true",
         "departure_start" => "14:00:00",
         "departure_end" => "12:00:00",
         "trip_type" => "one_way"
       }
 
-      {:error, message} = BusParams.validate_info_params(params) 
+      {:error, message} = BusParams.validate_info_params(params)
       assert IO.iodata_to_binary(message) == "Please correct the following errors to proceed: Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM."
     end
 
     test "it returns error messages when the return end is before return start" do
       params = %{
         "route" => "88 - 0",
+        "weekday" => "true",
         "departure_start" => "12:00:00",
         "departure_end" => "14:00:00",
         "return_start" => "18:00:00",
@@ -64,6 +66,21 @@ defmodule ConciergeSite.Subscriptions.BusParamsTest do
 
       {:error, message} = BusParams.validate_info_params(params)
       assert IO.iodata_to_binary(message) == "Please correct the following errors to proceed: Start time on return trip cannot be same as or later than end time. End of service day is 03:00AM."
+    end
+
+    test "it returns error messages when the return end is before return start and departure end is before departure start" do
+      params = %{
+        "route" => "88 - 0",
+        "weekday" => "true",
+        "departure_start" => "16:00:00",
+        "departure_end" => "14:00:00",
+        "return_start" => "18:00:00",
+        "return_end" => "17:00:00",
+        "trip_type" => "one_way"
+      }
+
+      {:error, message} = BusParams.validate_info_params(params)
+      assert IO.iodata_to_binary(message) == "Please correct the following errors to proceed: Start time on departure trip cannot be same as or later than end time. End of service day is 03:00AM. Start time on return trip cannot be same as or later than end time. End of service day is 03:00AM."
     end
 
     test "it returns ok when the return end is before return start but before 3:00AM" do


### PR DESCRIPTION
creation flow was working as intended but update flow was not validating that end of subscription time frame was falling before the end of the service day.