### PR TITLE
update digest headers to properly handle end of service day datetimes

### DIFF
--- a/apps/alert_processor/lib/digest/digest_serializer.ex
+++ b/apps/alert_processor/lib/digest/digest_serializer.ex
@@ -4,6 +4,7 @@ defmodule AlertProcessor.DigestSerializer do
   """
   alias AlertProcessor.{Helpers.DateTimeHelper, Model}
   alias Model.{Alert, Digest}
+  alias Calendar.DateTime, as: DT
   @date_groups [:upcoming_weekend, :upcoming_week, :next_weekend, :future]
 
   @doc """
@@ -30,14 +31,15 @@ defmodule AlertProcessor.DigestSerializer do
   end
 
   defp title(date_group, {start_date, end_date}) do
+    adjusted_end_date = DT.subtract!(end_date, 86_400)
     prefix = prefix(date_group)
     cond do
       date_group == :future ->
         prefix
-      start_date.month == end_date.month ->
-        "#{prefix}, #{DateTimeHelper.month_name(start_date)} #{start_date.day} - #{end_date.day}"
+      start_date.month == adjusted_end_date.month ->
+        "#{prefix}, #{DateTimeHelper.month_name(start_date)} #{start_date.day} - #{adjusted_end_date.day}"
       true ->
-        "#{prefix}, #{DateTimeHelper.month_name(start_date)} #{start_date.day} - #{DateTimeHelper.month_name(end_date)} #{end_date.day}"
+        "#{prefix}, #{DateTimeHelper.month_name(start_date)} #{start_date.day} - #{DateTimeHelper.month_name(adjusted_end_date)} #{adjusted_end_date.day}"
     end
   end
 

--- a/apps/alert_processor/test/alert_processor/digest/digest_serializer_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_serializer_test.exs
@@ -21,11 +21,11 @@ defmodule AlertProcessor.DigestSerializerTest do
   @user %User{id: "1"}
 
   @saturday DT.from_erl!({{2017, 06, 03}, {0, 0, 0}}, "America/New_York")
-  @sunday DT.from_erl!({{2017, 06, 04}, {23, 59, 59}}, "America/New_York")
+  @sunday DT.from_erl!({{2017, 06, 05}, {02, 30, 00}}, "America/New_York")
   @monday DT.from_erl!({{2017, 06, 05}, {0, 0, 0}}, "America/New_York")
-  @friday DT.from_erl!({{2017, 06, 09}, {23, 59, 59}}, "America/New_York")
+  @friday DT.from_erl!({{2017, 06, 10}, {02, 30, 00}}, "America/New_York")
   @next_saturday DT.from_erl!({{2017, 06, 10}, {0, 0, 0}}, "America/New_York")
-  @next_sunday DT.from_erl!({{2017, 06, 11}, {23, 59, 59}}, "America/New_York")
+  @next_sunday DT.from_erl!({{2017, 06, 12}, {02, 30, 01}}, "America/New_York")
   @next_monday DT.from_erl!({{2017, 06, 12}, {0, 0, 0}}, "America/New_York")
   @future DT.from_erl!({{3017, 06, 03}, {0, 0, 0}}, "America/New_York")
 
@@ -131,7 +131,7 @@ defmodule AlertProcessor.DigestSerializerTest do
 
   test "serialize/1 serializes title for month boundaries" do
     may = DT.from_erl!({{2017, 05, 29}, {0, 0, 0}}, "America/New_York")
-    june = DT.from_erl!({{2017, 06, 02}, {23, 59, 59}}, "America/New_York")
+    june = DT.from_erl!({{2017, 06, 03}, {02, 30, 00}}, "America/New_York")
 
     ddg = %DigestDateGroup{
       upcoming_weekend: %{

--- a/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
@@ -9,7 +9,7 @@ defmodule ConciergeSite.Dissemination.DigestEmailTest do
 
   @now Calendar.DateTime.now!("America/New_York")
   @saturday DT.from_erl!({{2017, 05, 26}, {0, 0, 0}}, "America/New_York")
-  @end_sunday DT.from_erl!({{2017, 05, 27}, {23, 59, 59}}, "America/New_York")
+  @end_sunday DT.from_erl!({{2017, 05, 28}, {02, 30, 00}}, "America/New_York")
 
   @ddg %DigestDateGroup{
     upcoming_weekend: %{

--- a/apps/concierge_site/test/lib/dissemination/mailer_interface_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/mailer_interface_test.exs
@@ -32,7 +32,7 @@ defmodule ConciergeSite.Dissemination.MailerInterfaceTest do
     test "receives a digest message and sends an email" do
       now = Calendar.DateTime.now!("America/New_York")
       saturday = Calendar.DateTime.from_erl!({{2017, 05, 26}, {0, 0, 0}}, "America/New_York")
-      end_sunday = Calendar.DateTime.from_erl!({{2017, 05, 27}, {23, 59, 59}}, "America/New_York")
+      end_sunday = Calendar.DateTime.from_erl!({{2017, 05, 28}, {02, 30, 00}}, "America/New_York")
 
       digest_date_group = %DigestDateGroup{
         upcoming_weekend: %{


### PR DESCRIPTION
we updated the digest date ranges to account for end of service day rather than midnight, this caused the digest headers to have the end date one date later than expected. 