### PR TITLE
enable keyboard controls for route and station auto complete suggestions

### DIFF
--- a/apps/concierge_site/assets/css/_subscription.scss
+++ b/apps/concierge_site/assets/css/_subscription.scss
@@ -184,6 +184,10 @@
   padding: .75rem 0 .75rem 1rem;
 }
 
+.station-suggestion.selected-suggestion {
+  background-color: $pale-grey;
+}
+
 .station-suggestion.hidden {
   display: none;
 }

--- a/apps/concierge_site/assets/js/station-select-helpers.js
+++ b/apps/concierge_site/assets/js/station-select-helpers.js
@@ -55,9 +55,89 @@ function generateStationList(className, $) {
   return stations;
 }
 
+function onKeyDownOverrides(event, state, $) {
+  const visibleSuggestionCount = $(".station-suggestion").length;
+  const $target = $(event.target);
+
+  if (event.keyCode === 38 && $target.is(".station-input")) {
+    event.preventDefault();
+    decrementselectedSuggestionIndex(state, visibleSuggestionCount)
+
+  } else if (event.keyCode === 40 && $target.is(".station-input")) {
+    event.preventDefault();
+    incrementselectedSuggestionIndex(state, visibleSuggestionCount)
+  } else if (event.keyCode === 13 && $target.is(".btn-subscription-next")) {
+    return;
+  } else if (event.keyCode === 13) {
+    event.preventDefault();
+    let focusable,
+        targetIndex,
+        next;
+
+    focusable = $target.parent().parent().find("input,a,select,button").not(".no-js, input[type=hidden]").toArray();
+    targetIndex = focusable.indexOf($target[0]);
+
+    if (targetIndex >= focusable.length - 1) {
+      next = focusable[0];
+    } else {
+      next = focusable[targetIndex + 1];
+    }
+
+    $target.focusout();
+    next.focus();
+  }
+}
+
+function onKeyDownOverridesAmenity(event, state, chooseSuggestion, removeStation, $) {
+  const visibleSuggestionCount = $(".station-suggestion").length;
+  const $target = $(event.target);
+
+  if (event.keyCode === 38 && $target.is(".station-input")) {
+    event.preventDefault();
+    decrementselectedSuggestionIndex(state, visibleSuggestionCount)
+
+  } else if (event.keyCode === 40  && $target.is(".station-input")) {
+    event.preventDefault();
+    incrementselectedSuggestionIndex(state, visibleSuggestionCount)
+  } else if (event.keyCode === 13) {
+    if ($target.is("button.btn-amenity-submit")) {
+      return;
+    } else if ($target.is("button.btn-selected-station")) {
+      event.preventDefault();
+      removeStation(event);
+    } else {
+      event.preventDefault();
+      chooseSuggestion();
+    }
+  }
+}
+
+function selectedSuggestionClass(selectedSuggestionIndex, index) {
+  if (selectedSuggestionIndex === index){
+    return "selected-suggestion";
+  } else {
+    return "";
+  }
+}
+
+function incrementselectedSuggestionIndex(state, visibleSuggestionCount){
+  if (state.selectedSuggestionIndex + 1 < visibleSuggestionCount) {
+    state.selectedSuggestionIndex = state.selectedSuggestionIndex + 1;
+  }
+}
+
+function decrementselectedSuggestionIndex(state, visibleSuggestionCount){
+  if (state.selectedSuggestionIndex - 1 >= 0) {
+    state.selectedSuggestionIndex = state.selectedSuggestionIndex - 1;
+  }
+}
+
 export {
   generateRouteList,
   generateStationList,
+  onKeyDownOverrides,
+  onKeyDownOverridesAmenity,
   renderStationInput,
-  unmountStationSuggestions
+  selectedSuggestionClass,
+  unmountStationSuggestions,
 };

--- a/apps/concierge_site/assets/test/select-amenity-station_test.js
+++ b/apps/concierge_site/assets/test/select-amenity-station_test.js
@@ -1,6 +1,7 @@
 import 'jsdom-global/register';
 import jsdom from 'mocha-jsdom';
 import { assert } from 'chai';
+import { simulateKeyUp, simulateKeyPress } from './utils';
 import selectAmenityStation from '../js/select-amenity-station';
 
 describe("selectAmenityStation", function() {
@@ -32,7 +33,93 @@ describe("selectAmenityStation", function() {
 
       assert.lengthOf(list.first().children(), 0)
     })
-  })
+  });
+
+  describe("keypress handling for suggestions", () => {
+    it("first suggestion is selected by default", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+
+      const $firstSuggestion = $(".amenity-station").first();
+      const $lastSuggestion = $(".amenity-station").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow moves the selected suggestion down to the next suggestion", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+      simulateKeyPress($stationInput[0], 40);
+      const $firstSuggestion = $(".amenity-station").first();
+      const $lastSuggestion = $(".amenity-station").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow doesn't do anything if there aren't any more suggestions below", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+      simulateKeyPress($stationInput[0], 40);
+      simulateKeyPress($stationInput[0], 40);
+      const $firstSuggestion = $(".amenity-station").first();
+      const $lastSuggestion = $(".amenity-station").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow moves the selected suggestion up to the previous suggestion", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+      simulateKeyPress($stationInput[0], 40);
+      simulateKeyPress($stationInput[0], 38);
+      const $firstSuggestion = $(".amenity-station").first();
+      const $lastSuggestion = $(".amenity-station").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow doesn't do anything if there aren't any more suggestions above", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+      simulateKeyPress($stationInput[0], 38);
+      const $firstSuggestion = $(".amenity-station").first();
+      const $lastSuggestion = $(".amenity-station").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing enter selects the highlighted suggestion", () => {
+      const $stationInput = $("input.subscription-select-amenity-station");
+      $stationInput.val("Quincy");
+
+      simulateKeyUp($stationInput[0]);
+      simulateKeyPress($stationInput[0], 40);
+
+      const $lastSuggestion = $(".amenity-station").last();
+      assert($lastSuggestion.is(".selected-suggestion"));
+
+      simulateKeyPress($stationInput[0], 13);
+
+      const $selectedStations = $(".btn-selected-station")
+
+      assert.equal($selectedStations[0].textContent.trim(), "Quincy Center")
+    });
+  });
 
   describe("immediate changes upon page load", () => {
     it("adds text inputs to the page for station entry", () => {
@@ -123,7 +210,6 @@ describe("selectAmenityStation", function() {
     })
   })
 
-
   describe("route input losing focus", () => {
     it("clears removes suggestions", () => {
       const $stationInput = $("input.subscription-select-amenity-station");
@@ -148,6 +234,7 @@ describe("selectAmenityStation", function() {
             <option value="">Select a station</option>
             <optgroup label="Red Line">
               <option value="place-nqncy">North Quincy</option>
+              <option value="place-qnctr">Quincy Center</option>
               <option value="place-central">Central Square</option>
             </optgroup>
             <optgroup label="Needham Line">
@@ -160,10 +247,4 @@ describe("selectAmenityStation", function() {
       </form>
     </div>
     `
-
-  function simulateKeyUp(target) {
-    const event = document.createEvent("HTMLEvents");
-    event.initEvent("keyup", true, true);
-    target.dispatchEvent(event);
-  }
 });

--- a/apps/concierge_site/assets/test/select-bus-route_test.js
+++ b/apps/concierge_site/assets/test/select-bus-route_test.js
@@ -1,6 +1,7 @@
 import 'jsdom-global/register';
 import jsdom from 'mocha-jsdom';
 import { assert } from 'chai';
+import { simulateKeyUp, simulateKeyPress } from './utils';
 import selectBusRoute from '../js/select-bus-route';
 
 describe("selectBusRoute", function() {
@@ -52,10 +53,11 @@ describe("selectBusRoute", function() {
       simulateKeyUp($routeInput[0])
 
       const $suggestions = $(".bus-route")
-      const routeSuggestion = $suggestions.first().text();
+      const routeSuggestion = $suggestions.text();
 
-      assert.lengthOf($suggestions, 1)
+      assert.lengthOf($suggestions, 2)
       assert.include(routeSuggestion, "Silver Line SL1 - Inbound")
+      assert.include(routeSuggestion, "Silver Line SL1 - Outbound")
     });
 
 
@@ -67,10 +69,11 @@ describe("selectBusRoute", function() {
       simulateKeyUp($routeInput[0])
 
       const $suggestions = $(".bus-route")
-      const routeSuggestion = $suggestions.first().text();
+      const routeSuggestion = $suggestions.text();
 
-      assert.lengthOf($suggestions, 1)
+      assert.lengthOf($suggestions, 2)
       assert.include(routeSuggestion, "Silver Line SL1 - Inbound")
+      assert.include(routeSuggestion, "Silver Line SL1 - Outbound")
     });
   });
 
@@ -87,6 +90,75 @@ describe("selectBusRoute", function() {
       assert.equal($routeInput.val(), "Silver Line SL1 - Inbound");
     });
   })
+
+  describe("keypress handling for suggestions", () => {
+    it("first suggestion is selected by default", () => {
+      const $routeInput = $("input.subscription-select-route");
+      $routeInput.val("7");
+
+      simulateKeyUp($routeInput[0]);
+
+      const $firstSuggestion = $(".bus-route").first();
+      const $lastSuggestion = $(".bus-route").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow moves the selected suggestion down to the next suggestion", () => {
+      const $routeInput = $("input.subscription-select-route");
+      $routeInput.val("7");
+
+      simulateKeyUp($routeInput[0]);
+      simulateKeyPress($routeInput[0], 40);
+      const $firstSuggestion = $(".bus-route").first();
+      const $lastSuggestion = $(".bus-route").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow doesn't do anything if there aren't any more suggestions below", () => {
+      const $routeInput = $("input.subscription-select-route");
+      $routeInput.val("7");
+
+      simulateKeyUp($routeInput[0]);
+      simulateKeyPress($routeInput[0], 40);
+      simulateKeyPress($routeInput[0], 40);
+      const $firstSuggestion = $(".bus-route").first();
+      const $lastSuggestion = $(".bus-route").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow moves the selected suggestion up to the previous suggestion", () => {
+      const $routeInput = $("input.subscription-select-route");
+      $routeInput.val("7");
+
+      simulateKeyUp($routeInput[0]);
+      simulateKeyPress($routeInput[0], 40);
+      simulateKeyPress($routeInput[0], 38);
+      const $firstSuggestion = $(".bus-route").first();
+      const $lastSuggestion = $(".bus-route").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow doesn't do anything if there aren't any more suggestions above", () => {
+      const $routeInput = $("input.subscription-select-route");
+      $routeInput.val("7");
+
+      simulateKeyUp($routeInput[0]);
+      simulateKeyPress($routeInput[0], 38);
+      const $firstSuggestion = $(".bus-route").first();
+      const $lastSuggestion = $(".bus-route").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+  });
 
   describe("route input losing focus", () => {
     it("populates the route input field with the first suggestion", () => {
@@ -148,23 +220,19 @@ describe("selectBusRoute", function() {
   });
 
   const tripInfoPageHtml = `
-    <div class="enter-trip-info bus">
-      <form>
+    <div class="enter-trip-info">
+      <form class="trip-info-form bus">
         <div class="form-group select-route">
           <label for="route" class="station-input-label form-label">Origin</label>
           <select class="subscription-select subscription-select-route no-js">
             <option value="">Enter your bus route and direction</option>
             <option value="741 - 1">Silver Line SL1 - Inbound</option>
+            <option value="741 - 0">Silver Line SL1 - Outbound</option>
+            <option value="57 - 1">Route 57 - Inbound</option>
             <option value="57 - 0">Route 57 - Outbound</option>
           </select>
         </div>
       </form>
     </div>
     `
-
-  function simulateKeyUp(target) {
-    const event = document.createEvent("HTMLEvents");
-    event.initEvent("keyup", true, true);
-    target.dispatchEvent(event);
-  }
 });

--- a/apps/concierge_site/assets/test/select-commuter-rail_test.js
+++ b/apps/concierge_site/assets/test/select-commuter-rail_test.js
@@ -1,7 +1,7 @@
 import 'jsdom-global/register';
 import jsdom from 'mocha-jsdom';
 import { assert } from 'chai';
-import { simulateKeyUp } from './utils';
+import { simulateKeyUp, simulateKeyPress } from './utils';
 import selectStation from '../js/select-station';
 
 describe("selectCommuterRailStation", function() {
@@ -128,6 +128,100 @@ describe("selectCommuterRailStation", function() {
     });
   });
 
+  describe("keypress handling for suggestions", () => {
+    beforeEach(function() {
+      $("body").append(commuterRailHtml);
+      selectStation($);
+    });
+
+    afterEach(function() {
+      $("body > div").remove()
+    });
+
+    it("first suggestion is selected by default", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow moves the selected suggestion down to the next suggestion", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+      simulateKeyPress($originInput[0], 40);
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the down arrow doesn't do anything if there aren't any more suggestions below", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+      simulateKeyPress($originInput[0], 40);
+      simulateKeyPress($originInput[0], 40);
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+
+      assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+      assert($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow moves the selected suggestion up to the previous suggestion", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+      simulateKeyPress($originInput[0], 40);
+      simulateKeyPress($originInput[0], 38);
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing the up arrow doesn't do anything if there aren't any more suggestions above", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+      simulateKeyPress($originInput[0], 38);
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+
+      assert($firstSuggestion.is(".selected-suggestion"));
+      assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+    });
+
+    it("pressing enter selects the highlighted suggestion", () => {
+      const $originInput = $("input.subscription-select-origin");
+      $originInput.val("tation");
+
+      simulateKeyUp($originInput[0]);
+      simulateKeyPress($originInput[0], 40);
+
+      const $firstSuggestion = $(".origin-station-suggestion").first();
+      const $lastSuggestion = $(".origin-station-suggestion").last();
+      assert($lastSuggestion.is(".selected-suggestion"));
+
+      simulateKeyPress($originInput[0], 13);
+
+      assert.equal($originInput.val(), "South Station")
+    });
+  });
+
   describe("commuter rail prefilled", () => {
     beforeEach(function() {
       $("body").append(commuterRailHtmlWithSelections);
@@ -157,43 +251,40 @@ describe("selectCommuterRailStation", function() {
       <input type="hidden" name="mode" value="commuter-rail">
       <div class="form-group select-station">
         <label for="origin" class="station-input-label form-label">Origin</label>
+        <select class="subscription-select subscription-select-origin no-js" id="subscription_origin" name="subscription[origin]" data-valid="false">
+          <option value="">Select a station</option>
+          <optgroup label="Lowell Line">
+            <option value="place-north">North Station</option>
+          </optgroup>
+          <optgroup label="Newburyport/Rockport Line">
+            <option value="Gloucester">Gloucester</option>
+            <option value="place-north">North Station</option>
+          </optgroup>
+          <optgroup label="Middleborough/Lakeville Line">
+            <option value="place-brntn">Braintree</option>
+            <option value="place-qnctr">Quincy Center</option>
+            <option value="place-sstat">South Station</option>
+          </optgroup>
+        </select>
       </div>
-      <i class="fa fa-check-circle valid-checkmark-icon"></i>
-      <select class="subscription-select subscription-select-origin no-js" id="subscription_origin" name="subscription[origin]" data-valid="false">
-        <option value="">Select a station</option>
-        <optgroup label="Lowell Line">
-          <option value="place-north">North Station</option>
-        </optgroup>
-        <optgroup label="Newburyport/Rockport Line">
-          <option value="Gloucester">Gloucester</option>
-          <option value="place-north">North Station</option>
-        </optgroup>
-        <optgroup label="Middleborough/Lakeville Line">
-          <option value="place-brntn">Braintree</option>
-          <option value="place-qnctr">Quincy Center</option>
-          <option value="place-sstat">South Station</option>
-        </optgroup>
-      </select>
       <div class="form-group select-station">
         <label for="destination" class="station-input-label form-label">Destination</label>
-        <div class="suggestion-container">
+        <select class="subscription-select subscription-select-destination no-js" id="subscription_destination" name="subscription[destination]" data-valid="false">
+          <option value="">Select a station</option>
+          <optgroup label="Lowell Line">
+            <option value="place-north">North Station</option>
+          </optgroup>
+          <optgroup label="Newburyport/Rockport Line">
+            <option value="Gloucester">Gloucester</option>
+            <option value="place-north">North Station</option>
+          </optgroup>
+          <optgroup label="Middleborough/Lakeville Line">
+            <option value="place-brntn">Braintree</option>
+            <option value="place-qnctr">Quincy Center</option>
+            <option value="place-sstat">South Station</option>
+          </optgroup>
+        </select>
       </div>
-      <i class="fa fa-check-circle valid-checkmark-icon"></i>
-      <select class="subscription-select subscription-select-destination no-js" id="subscription_destination" name="subscription[destination]" data-valid="false">
-        <option value="">Select a station</option>
-        <optgroup label="Lowell Line">
-          <option value="place-north">North Station</option>
-        </optgroup>
-        <optgroup label="Newburyport/Rockport Line">
-          <option value="Gloucester">Gloucester</option>
-          <option value="place-north">North Station</option>
-        </optgroup>
-        <optgroup label="Middleborough/Lakeville Line">
-          <option value="place-brntn">Braintree</option>
-          <option value="place-qnctr">Quincy Center</option>
-          <option value="place-sstat">South Station</option>
-        </optgroup>
-      </select>
     </form>
   </div>
   `;

--- a/apps/concierge_site/assets/test/select-station_test.js
+++ b/apps/concierge_site/assets/test/select-station_test.js
@@ -1,7 +1,7 @@
 import 'jsdom-global/register';
 import jsdom from 'mocha-jsdom';
 import { assert } from 'chai';
-import { simulateKeyUp } from './utils';
+import { simulateKeyUp, simulateKeyPress } from './utils';
 import selectStation from '../js/select-station';
 
 describe("selectStation", function() {
@@ -185,6 +185,91 @@ describe("selectStation", function() {
         assert.equal($destinationInput.attr("data-station-id"), "place-brntn");
       });
     })
+
+    describe("keypress handling for suggestions", () => {
+      it("first suggestion is selected by default", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+
+        assert($firstSuggestion.is(".selected-suggestion"));
+        assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+      });
+
+      it("pressing the down arrow moves the selected suggestion down to the next suggestion", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+        simulateKeyPress($originInput[0], 40);
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+
+        assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+        assert($lastSuggestion.is(".selected-suggestion"));
+      });
+
+      it("pressing the down arrow doesn't do anything if there aren't any more suggestions below", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+        simulateKeyPress($originInput[0], 40);
+        simulateKeyPress($originInput[0], 40);
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+
+        assert.isFalse($firstSuggestion.is(".selected-suggestion"));
+        assert($lastSuggestion.is(".selected-suggestion"));
+      });
+
+      it("pressing the up arrow moves the selected suggestion up to the previous suggestion", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+        simulateKeyPress($originInput[0], 40);
+        simulateKeyPress($originInput[0], 38);
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+
+        assert($firstSuggestion.is(".selected-suggestion"));
+        assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+      });
+
+      it("pressing the up arrow doesn't do anything if there aren't any more suggestions above", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+        simulateKeyPress($originInput[0], 38);
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+
+        assert($firstSuggestion.is(".selected-suggestion"));
+        assert.isFalse($lastSuggestion.is(".selected-suggestion"));
+      });
+
+      it("pressing enter selects the highlighted suggestion", () => {
+        const $originInput = $("input.subscription-select-origin");
+        $originInput.val("ee");
+
+        simulateKeyUp($originInput[0]);
+        simulateKeyPress($originInput[0], 40);
+
+        const $firstSuggestion = $(".origin-station-suggestion").first();
+        const $lastSuggestion = $(".origin-station-suggestion").last();
+        assert($lastSuggestion.is(".selected-suggestion"));
+
+        simulateKeyPress($originInput[0], 13);
+
+        assert.equal($originInput.val(), "Park Street")
+      });
+    });
 
     describe("station input losing focus", () => {
       it("populates the origin input field with the first suggestion", () => {
@@ -393,7 +478,7 @@ describe("selectStation", function() {
         <form class="trip-info-form subway">
           <div class="form-group select-station">
             <label for="origin" class="station-input-label form-label">Origin</label>
-            <select class="subscription-select-origin no-js" id="subscription_origin" name="subscription[origin]">
+            <select class="subscription-select subscription-select-origin no-js" id="subscription_origin" name="subscription[origin]">
               <option value="">Select a station</option>
               <optgroup label="Red Line">
                 <option value="place-brntn">Braintree</option>
@@ -408,7 +493,7 @@ describe("selectStation", function() {
           </div>
           <div class="form-group select-station">
             <label for="destination" class="station-input-label form-label">Destination</label>
-            <select class="subscription-select-destination no-js" id="subscription_destination" name="subscription[destination]">
+            <select class="subscription-select subscription-select-destination no-js" id="subscription_destination" name="subscription[destination]">
               <option value="">Select a station</option>
               <optgroup label="Red Line">
                 <option value="place-brntn">Braintree</option>

--- a/apps/concierge_site/assets/test/utils.js
+++ b/apps/concierge_site/assets/test/utils.js
@@ -1,5 +1,18 @@
-export function simulateKeyUp(target) {
+function simulateKeyUp(target) {
   const event = document.createEvent("HTMLEvents");
   event.initEvent("keyup", true, true);
   target.dispatchEvent(event);
+}
+
+function simulateKeyPress(target, keyCode) {
+  const event = document.createEvent("HTMLEvents");
+  event.initEvent("keydown", true, true);
+  event.keyCode = keyCode;
+  target.dispatchEvent(event);
+  simulateKeyUp(target);
+}
+
+export {
+  simulateKeyPress,
+  simulateKeyUp
 }


### PR DESCRIPTION
Previously, users were unable to select suggestions using the up and down arrows on the keyboard and if they hit enter while focusing one of the inputs, the form would submit. Now users can move up and down in the list of suggestions and select one by hitting enter and will move you on to the next field.

demos using only keyboard to navigate page:
![zrsfjs78ng](https://user-images.githubusercontent.com/526017/31251218-3655b220-a9eb-11e7-9cef-29e6e34e430d.gif)

![pmx7d8njx3](https://user-images.githubusercontent.com/526017/31251466-fd774026-a9eb-11e7-9ebb-10cad74f2beb.gif)
