### PR TITLE
Refactor to use Alert Parser, fix issue with nil activities for informed entity

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -34,7 +34,7 @@ defmodule AlertProcessor.AlertParser do
     end
   end
 
-  defp parse_alert(%{
+  def parse_alert(%{
     "active_period" => active_periods,
     "effect_detail" => effect_name,
     "id" => alert_id,
@@ -58,7 +58,7 @@ defmodule AlertProcessor.AlertParser do
     }
   end
 
-  defp parse_alert(alert, _) do
+  def parse_alert(alert, _) do
     Logger.warn("Failed to parse alert: #{Poison.encode!(alert)}")
     nil
   end

--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -43,7 +43,7 @@ defmodule AlertProcessor.InformedEntityFilter do
 
     normal_subscriptions
     |> Kernel.++(admin_subscriptions)
-    |> Enum.uniq()
+    |> Enum.uniq
   end
 
   defp entity_match?(%{trip: trip_id}, %{trip: subscription_trip_id}) when not is_nil(trip_id) do

--- a/apps/alert_processor/lib/subscription/admin/diagnostic.ex
+++ b/apps/alert_processor/lib/subscription/admin/diagnostic.ex
@@ -49,6 +49,7 @@ defmodule AlertProcessor.Subscription.Diagnostic do
         |> Enum.map(fn(snap) ->
           build_diagnosis(alert_snapshot, notifications, [snap])
         end)
+        |> Enum.reject(&(is_nil(&1)))
         {:ok, result}
     else
       _ ->
@@ -81,7 +82,6 @@ defmodule AlertProcessor.Subscription.Diagnostic do
 
   defp matches_informed_entities?(diagnostic, alert: alert, subscriptions: subscriptions) do
     subs = InformedEntityFilter.filter(subscriptions, alert: alert)
-
     if subs == [] do
       diagnostic
       |> Map.put(:passed_informed_entity_filter?, false)

--- a/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
@@ -187,8 +187,11 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
       assert result.passed_active_period_filter? == false
     end
 
-    test "alert matched severity", %{user: user} do
-      data = Map.put(@alert_params, "severity", 7)
+    test "alert severity is greater or equal to subscription", %{user: user} do
+      data = Map.merge(@alert_params, %{
+        "effect_detail" => "invalid",
+        "severity" => 5
+      })
 
       alert_params =  %{
         alert_id: "114167",


### PR DESCRIPTION
Avoid duplication by using existing alert parser code, fix 500 caused by empty 'activities' for an informed entity