### PR TITLE
limit notification query to latest last push per user/alert combo

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -82,4 +82,20 @@ defmodule AlertProcessor.Model.Notification do
       order_by: [asc: n.inserted_at]
     )
   end
+
+  def most_recent_for_subscriptions_and_alerts(subscriptions, alerts) do
+    user_ids = Enum.map(subscriptions, &(&1.user.id))
+    alert_ids = Enum.map(alerts, &(&1.id))
+
+    Repo.all(
+      from n in __MODULE__,
+      where: n.user_id in ^user_ids,
+      where: n.alert_id in ^alert_ids,
+      where: n.status == "sent",
+      preload: [:subscriptions],
+      distinct: [:alert_id, :user_id],
+      order_by: [desc: n.last_push_notification],
+      select: n
+    )
+  end
 end


### PR DESCRIPTION
ran into a bug where after editing an alert, the automatic resends were continuously sending due to the fact that the older notification with an older last_push_notification timestamp was triggering the auto resend. Updated the query that fetches the notifications to only grab the latest last_push_notification timestamp per user/alert combo.