### PR TITLE
handle empty schedule info responses for display info

### DIFF
--- a/apps/alert_processor/test/alert_processor/subscription/display_info_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/display_info_test.exs
@@ -40,6 +40,24 @@ defmodule AlertProcessor.Subscriptions.DisplayInfoTest do
         assert {:ok, %{}} == DisplayInfo.departure_times_for_subscriptions([subscription], @test_date)
       end
     end
+
+    test "with empty response" do
+      use_cassette "schedule_display_info_empty", custom: true, clear_mock: true, match_requests_on: [:query] do
+        informed_entities = [
+          %InformedEntity{route_type: 4, activities: InformedEntity.default_entity_activities()},
+          %InformedEntity{route_type: 4, route: "Boat-F1", direction_id: 1, activities: InformedEntity.default_entity_activities()},
+          %InformedEntity{route_type: 4, route: "Boat-F1", stop: "Boat-Hingham", activities: ["BOARD"]},
+          %InformedEntity{route_type: 4, route: "Boat-F1", stop: "Boat-Rowes", activities: ["EXIT"]}
+        ]
+
+        subscription =
+          :subscription
+          |> build(origin: "Boat-Hingham", destination: "Boat-Rowes", type: :ferry, informed_entities: informed_entities)
+          |> saturday_subscription()
+
+        assert {:ok, %{}} == DisplayInfo.departure_times_for_subscriptions([subscription], @test_date)
+      end
+    end
   end
 
   describe "station_names_for_subscriptions" do

--- a/apps/alert_processor/test/fixture/custom_cassettes/schedule_display_info_empty.json
+++ b/apps/alert_processor/test/fixture/custom_cassettes/schedule_display_info_empty.json
@@ -1,0 +1,28 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://dev.api.mbtace.com/schedules?filter[stop]=Boat-Hingham,Boat-Rowes&fields[schedule]=departure_time,arrival_time&date=2017-07-12&include=trip&fields[trip]=name"
+    },
+    "response": {
+      "body": "{\"jsonapi\":{\"version\":\"1.0\"},\"data\":[]}",
+      "headers": {
+        "cache-control": "max-age=0, private, must-revalidate",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "Date": "Tue, 24 Oct 2017 15:08:12 GMT",
+        "etag": "830133B84F9A91055FC7C4AC754914C593F2427CB9FB3AC364528EFC339F2AC6",
+        "last-modified": "Mon, 23 Oct 2017 23:32:51 GMT",
+        "Server": "nginx/1.12.1",
+        "x-request-id": "24167kkr3e4i5ulh9vsmafpt7ovjebv7",
+        "Content-Length": "39",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]


### PR DESCRIPTION
was seeing some errors coming through when having a weekday ferry subscription and an additional weekend subscription which would cause the api client to try and fetch schedule info for the ferry stops on the weekend (which currently don't exist) and returning an empty set. This PR filters the subscriptions to only use the commuter rail and ferry subscriptions as intended and also handles an empty response gracefully.