### PR TITLE
roaming subscription my subscriptions error

### DIFF
--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -65,6 +65,18 @@ defmodule AlertProcessor.Factory do
     ]
   end
 
+  def roaming_subway_subscription_entities() do
+    [
+      %InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", direction_id: 0, activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", direction_id: 1, activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", stop: "place-davis", activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", stop: "place-portr", activities: InformedEntity.default_entity_activities()},
+      %InformedEntity{route_type: 1, route: "Red", stop: "place-harsq", activities: InformedEntity.default_entity_activities()}
+    ]
+  end
+
   def bus_subscription(%Subscription{} = subscription) do
     %{subscription |
       type: :bus

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -212,7 +212,7 @@ defmodule ConciergeSite.SubscriptionView do
   defp direction_name(subscription) do
     case parse_direction(subscription) do
       :roaming ->
-        "Roaming"
+        :roaming
       direction ->
         {:ok, direction_name} = ServiceInfoCache.get_direction_name(parse_route_id(subscription), direction)
         direction_name

--- a/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
@@ -22,6 +22,15 @@ defmodule ConciergeSite.SubscriptionControllerTest do
       :subscription
       |> build(user: user)
       |> weekday_subscription()
+      |> subway_subscription()
+      |> Repo.preload(:informed_entities)
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:informed_entities, roaming_subway_subscription_entities())
+      |> Repo.insert()
+
+      :subscription
+      |> build(user: user)
+      |> weekday_subscription()
       |> commuter_rail_subscription()
       |> Repo.preload(:informed_entities)
       |> Ecto.Changeset.change()


### PR DESCRIPTION
displaying roaming subscriptions on my subscriptions page was failing due to me changing the returned value from an atom to a string https://github.com/mbta/alerts_concierge/pull/427/files#diff-eba9b60257869c944fc76b3d8143c358R215 which wasn't necessary