### PR TITLE
simplify token refresh flow

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -341,26 +341,6 @@ defmodule AlertProcessor.Model.User do
   defp authorize_admin({:error, result}), do: {:error, result}
 
   @doc """
-  Adds permission to the user's claims based on the user's role, else
-  based on the previous claims
-  """
-  def claims_with_permission(_, claims, %__MODULE__{role: "customer_support"}) do
-    Guardian.Claims.permissions(claims, admin: [:customer_support], default: Guardian.Permissions.max)
-  end
-  def claims_with_permission(_, claims, %__MODULE__{role: "application_administration"}) do
-    Guardian.Claims.permissions(claims, admin: @active_admin_roles, default: Guardian.Permissions.max)
-  end
-  def claims_with_permission(prev_claims, claims, _) do
-    prev_perm =
-      prev_claims
-      |> Guardian.Permissions.from_claims(:default)
-      |> Guardian.Permissions.to_list
-    default_perms = if prev_perm == [], do: Guardian.Permissions.max, else: prev_perm
-
-    Guardian.Claims.permissions(claims, default: default_perms)
-  end
-
-  @doc """
   Returns user ids based on a list of phone numbers
   """
   def ids_by_phone_numbers(phone_numbers) do

--- a/apps/concierge_site/test/lib/plugs/token_refresh_test.exs
+++ b/apps/concierge_site/test/lib/plugs/token_refresh_test.exs
@@ -12,8 +12,12 @@ defmodule ConciergeSite.Plugs.TokenRefreshTest do
       conn
       |> TokenLogin.call(%{})
     refreshed_conn = TokenRefresh.call(conn, %{})
+    new_token = get_session(conn, "guardian_default")
     refute refreshed_conn == conn
-    refute get_session(refreshed_conn, "guardian_default") == get_session(conn, "guardian_default")
+    refute get_session(refreshed_conn, "guardian_default") == new_token
+    {:ok, old_claims} = Guardian.decode_and_verify(token)
+    {:ok, new_claims} = Guardian.decode_and_verify(new_token)
+    assert Map.take(old_claims, ["pem", "sub"]) == Map.take(new_claims, ["pem", "sub"])
   end
 
   test "it does nothing if the token expires more than fifteen minutes from now", %{conn: conn} do


### PR DESCRIPTION
Seemed to be a bug with the previous implementation of token refresh which wouldn't correctly set the new, refreshed token into the session to be used. The previous implementation was trying to mimic the logic of `Guardian.Plug.sign_in` so instead of re-using the same logic, swapped to using the function directly. 