### PR TITLE
Customized alerts for stations with slashes

### DIFF
--- a/apps/alert_processor/lib/rules_engine/text_replacement.ex
+++ b/apps/alert_processor/lib/rules_engine/text_replacement.ex
@@ -20,7 +20,7 @@ defmodule AlertProcessor.TextReplacement do
             trip = Map.get(stop_schedules, {stop, time})
             Enum.reduce(subscriptions, %{}, fn(sub, acc) ->
               case trip_schedules[{sub.origin, trip}] do
-                %Time{} = time -> Map.put(acc, index, {train, sub.origin, time})
+                {%Time{} = time, trip_name} -> Map.put(acc, index, {train, trip_name, time})
                 _ -> acc
               end
             end)
@@ -119,8 +119,8 @@ defmodule AlertProcessor.TextReplacement do
         case ServiceInfoCache.get_stop(schedule.stop_id) do
           {:ok, {stop_name, _}} ->
             departure_time = extract_time(schedule.departure_time)
-            stop_time_trips = Map.put(stop_time_trips, {stop_name, departure_time}, schedule.trip_id)
-            trip_schedules = Map.put(trip_schedules, {stop_name, schedule.trip_id}, departure_time)
+            stop_time_trips = Map.put(stop_time_trips, {schedule.stop_id, departure_time}, schedule.trip_id)
+            trip_schedules = Map.put(trip_schedules, {schedule.stop_id, schedule.trip_id}, {departure_time, stop_name})
             {stop_time_trips, trip_schedules}
           _ -> {stop_time_trips, trip_schedules}
         end

--- a/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
@@ -87,6 +87,57 @@ defmodule AlertProcessor.TextReplacementTest do
 
       assert TextReplacement.replace_text(alert, [sub]) == Map.merge(alert, expected)
     end
+
+    test "if subscription matches alert and the origin station's id differs from its name, replace text" do
+      sub = %Subscription{
+        destination: "place-south",
+        informed_entities: [
+          %AlertProcessor.Model.InformedEntity{
+            activities: ["BOARD"],
+            stop: "Four Corners / Geneva"
+          }
+        ],
+        origin: "Four Corners / Geneva"
+      }
+
+      alert = %Alert{
+        description: "Affected trips: Fairmount Train 752 (9:25 PM from Fairmount)",
+        header: "Fairmount Train 752 (9:25 pm from Fairmount) has departed Fairmount 20-40 minutes late and will operate at a reduced speed due to a mechanical issue.",
+        id: "115346",
+        informed_entities: [
+          %InformedEntity{
+            activities: ["BOARD", "EXIT", "RIDE"],
+            route: "CR-Fairmount",
+            route_type: 2,
+            schedule: [
+              %{
+                 departure_time: "2017-10-30T21:25:00-04:00",
+                 stop_id: "Fairmount",
+                 trip_id: "CR-Weekday-Aug14th-17-NR-180"
+               },
+               %{
+                departure_time: "2017-10-30T22:17:00-04:00",
+                stop_id: "Four Corners / Geneva",
+                trip_id: "CR-Weekday-Aug14th-17-NR-180"
+               },
+              %{
+                departure_time: "2017-10-30T22:28:00-04:00",
+                stop_id: "South Station",
+                trip_id: "CR-Weekday-Aug14th-17-NR-180"
+              }
+            ],
+            trip: "180"
+          }
+        ],
+      }
+
+      expected = %{
+        header: "Fairmount Train 752 (22:17 pm from Four Corners/Geneva) has departed Fairmount 20-40 minutes late and will operate at a reduced speed due to a mechanical issue.",
+        description: "Affected trips: Fairmount Train 752 (22:17 pm from Four Corners/Geneva)"
+      }
+
+      assert TextReplacement.replace_text(alert, [sub]) == Map.merge(alert, expected)
+    end
   end
 
   describe "parse_target/1" do


### PR DESCRIPTION
Asana ticket: [Stations with a "/" in the name do not get customized alerts ](https://app.asana.com/0/415342363785198/476953637945362/f)

For commuter rail alerts, specific stations' names are interpolated into the description for some users. For example, if an alert has the following description:

> Affected trips: Newburyport Train 180 (9:25 PM from Newburyport)

and the station someone is interested in is Chelsea, then the description in the alert will be updated to look like this:

> Affected trips: Newburyport Train 180 (22:17 pm from Chelsea)

This functionality was not working with stations with slashes in them (or more generally, any station where the station `name` and station `id` are the same).

The fix I went with was to match against the station `id` instead of the `name` and only use the `name` in the generated description text.

---

Assigned to @ryan-mahoney 