### PR TITLE
Do not send digest email

### DIFF
--- a/apps/concierge_site/config/config.exs
+++ b/apps/concierge_site/config/config.exs
@@ -25,6 +25,10 @@ config :concierge_site, ConciergeSite.Dissemination.Mailer,
   adapter: Bamboo.LocalAdapter,
   deliver_later_strategy: ConciergeSite.Dissemination.DeliverLaterStrategy
 
+config :concierge_site, ConciergeSite.Dissemination.DummyMailer,
+  adapter: ConciergeSite.Dissemination.NullAdapter,
+  deliver_later_strategy: ConciergeSite.Dissemination.DeliverLaterStrategy
+
 config :concierge_site, send_from_email: {:system, "SENDER_EMAIL_ADDRESS", "developer@mbta.com"}
 
 # Configures Elixir's Logger

--- a/apps/concierge_site/lib/dissemination/dummy_mailer.ex
+++ b/apps/concierge_site/lib/dissemination/dummy_mailer.ex
@@ -1,0 +1,4 @@
+defmodule ConciergeSite.Dissemination.DummyMailer do
+  @moduledoc false
+  use Bamboo.Mailer, otp_app: :concierge_site
+end

--- a/apps/concierge_site/lib/dissemination/mailer_interface.ex
+++ b/apps/concierge_site/lib/dissemination/mailer_interface.ex
@@ -5,7 +5,7 @@ defmodule ConciergeSite.Dissemination.MailerInterface do
   """
   use GenServer
   require Logger
-  alias ConciergeSite.Dissemination.{DigestEmail, NotificationEmail, Mailer}
+  alias ConciergeSite.Dissemination.{DigestEmail, NotificationEmail, Mailer, DummyMailer}
 
   @lookup_tuple {:via, Registry, {:mailer_process_registry, :mailer}}
 
@@ -30,8 +30,8 @@ defmodule ConciergeSite.Dissemination.MailerInterface do
     response =
       digest_message
       |> DigestEmail.digest_email()
-      |> Mailer.deliver_later()
-    Logger.info(fn -> "Digest Email result: #{inspect(response)}, user_id: #{digest_message.user.id}" end)
+      |> DummyMailer.deliver_later()
+    Logger.info(fn -> "Digest Email result (not sent): #{inspect(response)}, user_id: #{digest_message.user.id}" end)
     {:reply, response, nil}
   end
 end

--- a/apps/concierge_site/lib/dissemination/null_adapter.ex
+++ b/apps/concierge_site/lib/dissemination/null_adapter.ex
@@ -1,0 +1,7 @@
+defmodule ConciergeSite.Dissemination.NullAdapter do
+  @behaviour Bamboo.Adapter
+
+  def deliver(email, config), do: %{email: email, config: config}
+
+  def handle_config(config), do: config
+end

--- a/apps/concierge_site/test/lib/dissemination/null_adapter_test.ex
+++ b/apps/concierge_site/test/lib/dissemination/null_adapter_test.ex
@@ -1,0 +1,12 @@
+defmodule ConciergeSite.Dissemination.NullAdapterTest do
+  use ExUnit.Case
+  alias ConciergeSite.Dissemination.NullAdapter
+
+  test "deliver/2" do
+    assert NullAdapter.deliver("email", "config") == %{email: "email", config: "config"}
+  end
+
+  test "handle_config/1" do
+    assert NullAdapter.handle_config("config") == "config"
+  end
+end


### PR DESCRIPTION
Asana ticket: [Turn off digests](https://app.asana.com/0/454064799340398/472991175578770)

Stop sending the digest email, but continue to log it. Do this by creating a new mailer (`DummyMailer`) that acts like a real mailer but doesn't actually send any emails.

Assigned to @ryan-mahoney 