### PR TITLE
Do not show same alert in digest multiple times

### DIFF
--- a/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/digest/digest_date_helper_test.exs
@@ -18,7 +18,11 @@ defmodule AlertProcessor.DigestDateHelperTest do
   @ap2 [
     %{
       start: DT.from_erl!({{2017, 05, 30}, {2, 30, 0}}, "America/New_York"),
-      end: DT.from_erl!({{2017, 06, 03}, {2, 30, 1}}, "America/New_York")
+      end: DT.from_erl!({{2017, 06, 01}, {2, 30, 1}}, "America/New_York")
+    },
+    %{
+      start: DT.from_erl!({{2017, 06, 03}, {2, 30, 0}}, "America/New_York"),
+      end: DT.from_erl!({{2017, 06, 04}, {2, 30, 1}}, "America/New_York")
     }
   ]
 
@@ -122,11 +126,11 @@ defmodule AlertProcessor.DigestDateHelperTest do
       },
       next_weekend: %{
         timeframe: _n_weekend,
-        alert_ids: ["5"]
+        alert_ids: []
       },
       future: %{
         timeframe: _fut,
-        alert_ids: ["5"]
+        alert_ids: []
       }
     } = digest_date_group
   end


### PR DESCRIPTION
Asana Ticket: [Digests should exclude low-severity alerts that started in the past](https://app.asana.com/0/415342363785198/476953637945398/f)

If an alert spans multiple date groups (`upcoming_weekend`, `upcoming_week`, `next_weekend`, `future`), then only show it once in the digest email instead of showing it multiple times.

However, if the alert is recurring (ie `alert.active_period` is a list with multiple members) then show it in each section that it occurs in.

Assigned to @ryan-mahoney 