### PR TITLE
Fix compiler warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir v1.5.2-otp-20
+nodejs 8.7.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functionality remain low and that MBTA can manage and improve the system.
 * Elixir 1.5.2 (you can use [asdf](https://github.com/asdf-vm/asdf) with
   [asdf-elixir](https://github.com/asdf-vm/asdf-elixir) to manage Elixir
   versions)
-* Node.js 7.10 (you can use [asdf](https://github.com/asdf-vm/asdf) with
+* Node.js 8.7.0 (you can use [asdf](https://github.com/asdf-vm/asdf) with
   [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) or
   [nvm](https://github.com/creationix/nvm) to manage Node.js versions)
 * Yarn ~1.3.2

--- a/apps/concierge_site/lib/views/amenity_subscription_view.ex
+++ b/apps/concierge_site/lib/views/amenity_subscription_view.ex
@@ -46,20 +46,16 @@ defmodule ConciergeSite.AmenitySubscriptionView do
 
   defp number_of_stations(subscription) do
     subscription.informed_entities
-    |> Enum.filter_map(
-      &(!is_nil(&1.stop)),
-      &(&1.stop)
-    )
+    |> Enum.filter(&(!is_nil(&1.stop)))
+    |> Enum.map(&(&1.stop))
     |> Enum.uniq
     |> length
   end
 
   defp lines(subscription) do
     subscription.informed_entities
-    |> Enum.filter_map(
-      &(!is_nil(&1.route)),
-      &("#{&1.route} Line")
-    )
+    |> Enum.filter(&(!is_nil(&1.route)))
+    |> Enum.map(&("#{&1.route} Line"))
     |> Enum.uniq
     |> Enum.join(", ")
     |> List.wrap()

--- a/apps/concierge_site/lib/views/bus_subscription_view.ex
+++ b/apps/concierge_site/lib/views/bus_subscription_view.ex
@@ -92,7 +92,8 @@ defmodule ConciergeSite.BusSubscriptionView do
 
   defp direction_name(subscription) do
     subscription.informed_entities
-    |> Enum.filter_map(&(!is_nil(&1.direction_id)), &(&1.direction_id))
+    |> Enum.filter(&(!is_nil(&1.direction_id)))
+    |> Enum.map(&(&1.direction_id))
     |> List.first()
     |> Integer.to_string()
     |> named_direction()


### PR DESCRIPTION
Get rid of compiler warnings (`filter_map` deprecation) and specify the Elixir version to use.