### PR TITLE
Show the alert id for notifications for admin

### DIFF
--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -254,13 +254,15 @@ defmodule ConciergeSite.SubscriberDetails do
   def notification_timeline(user) do
     user
     |> Notification.sent_to_user()
-    |> Enum.map(fn(%Notification{service_effect: service_effect, header: header, description: description, inserted_at: inserted_at} = notification) ->
+    |> Enum.map(fn(%Notification{service_effect: service_effect, header: header, description: description, inserted_at: inserted_at, alert_id: alert_id} = notification) ->
          {date, time} = date_and_time_values(inserted_at)
          {date, time, [
            notification_type(notification),
            " sent to: ",
            notification_contact(notification),
-           " -- ",
+           " (alert id ",
+           alert_id,
+           ") -- ",
            to_string(service_effect),
            " ",
            to_string(header),

--- a/apps/concierge_site/test/web/users/subscriber_details_test.exs
+++ b/apps/concierge_site/test/web/users/subscriber_details_test.exs
@@ -169,14 +169,14 @@ defmodule ConciergeSite.SubscriberDetailsTest do
       user = insert(:user)
       notification = insert(:notification, user: user, alert_id: "123", status: :sent, email: user.email)
       changelog = user |> SubscriberDetails.notification_timeline() |> changelog_to_binary()
-      assert changelog =~ "Email sent to: #{user.email} -- #{notification.service_effect} #{notification.header} #{notification.description}"
+      assert changelog =~ "Email sent to: #{user.email} (alert id 123) -- #{notification.service_effect} #{notification.header} #{notification.description}"
     end
 
     test "works for notification without description" do
       user = insert(:user)
       notification = insert(:notification, user: user, alert_id: "123", status: :sent, email: user.email, description: nil)
       changelog = user |> SubscriberDetails.notification_timeline() |> changelog_to_binary()
-      assert changelog =~ "Email sent to: #{user.email} -- #{notification.service_effect} #{notification.header} "
+      assert changelog =~ "Email sent to: #{user.email} (alert id 123) -- #{notification.service_effect} #{notification.header} "
     end
   end
 


### PR DESCRIPTION
When an admin looks at "Received Notifications" for a user, show the alert id in addition to the phone number, email, and alert text.

The alert id is needed in order to use the "Diagnostics" feature (see screenshot below), so including it in the text visible to admins will make it easier for them to figure out why a certain alert was sent to a user.

---

Before:

![before](https://user-images.githubusercontent.com/3039310/33490706-0980b16a-d686-11e7-9dd1-5ee0f1c5204e.png)

---

After:

![after](https://user-images.githubusercontent.com/3039310/33490719-1222d866-d686-11e7-8302-cd2d739e36e5.png)

---

Diagnostics page:

![diagnostics](https://user-images.githubusercontent.com/3039310/33490725-15748c1c-d686-11e7-8831-e186411cbf14.png)

