### PR TITLE
Mix test.all task

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ configuration.
 
 ### Running tests
 
+#### Running all tests and code coverage
+
+* ``env  `cat .env` MIX_ENV=test mix test.all``
+
+#### Running only Elixir tests
+
 * ``env  `cat .env` mix test``
 
 ### Running the application

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,6 @@ defmodule AlertsConcierge.Mixfile do
   defp aliases do
     ["ecto.setup": ["ecto.create", "ecto.migrate", "run apps/alert_processor/priv/repo/seeds.exs"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
-     "test": ["ecto.create --quiet", "ecto.migrate", "mocha_test", "coveralls.json"]]
+     "test.all": ["ecto.create --quiet", "ecto.migrate", "mocha_test", "coveralls.json", "test"]]
   end
 end
-


### PR DESCRIPTION
Instead of aliasing `mix test` to include the commands `ecto.create`, `ecto.migrate`, `mocha_test`, and `coveralls.json`, introduce `mix test.all`.

This means running `mix test` is much faster and only runs the Elixir tests, making developing and debugging easier. The CI will use the `mix test.all` task.