### PR TITLE
Do not send estimated alerts immediately

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -249,20 +249,17 @@ defmodule AlertProcessor.NotificationBuilderTest do
       created_at: time.now
     }
 
-    [s4_notification_2, s1_notification, s4_notification_1, s3_notification] = NotificationBuilder.build_notifications({user, [sub1, sub3, sub2, sub4]}, alert, time.now)
+    [s4_notification_2, s1_notification, s4_notification_1] = NotificationBuilder.build_notifications({user, [sub1, sub3, sub2, sub4]}, alert, time.now)
 
     sub1_id = sub1.id
-    sub3_id = sub3.id
     sub4_id = sub4.id
 
     assert %{notification_subscriptions: [%{subscription_id: ^sub4_id}]} = s4_notification_2
     assert %{notification_subscriptions: [%{subscription_id: ^sub1_id}]} = s1_notification
     assert %{notification_subscriptions: [%{subscription_id: ^sub4_id}]} = s4_notification_1
-    assert %{notification_subscriptions: [%{subscription_id: ^sub3_id}]} = s3_notification
 
     assert DT.same_time?(DT.add!(time.now, (86_400 * 2) - 655 - (12 * 60 * 60)), s4_notification_2.send_after)
     assert DT.same_time?(DT.add!(time.now, 86_400 - 655 - (3 * 60 * 60)), s1_notification.send_after)
     assert DT.same_time?(DT.add!(time.now, 86_400 - 655 - (12 * 60 * 60)), s4_notification_1.send_after)
-    assert DT.same_time?(time.now, s3_notification.send_after)
   end
 end


### PR DESCRIPTION
When an alert's duration is `estimated`, then do not send the first notification immediately. Instead, send it `A` minutes before the start of the subscription, where `A` is defined using the formula below:

```
S = advanced notice requirement by severity, in minutes
60 for minor, 120 for moderate, 240 for severe (calculated by Concierge)
D = the projected duration in minutes (as defined in the feed)
A = the minimum of the alert duration D OR severity based advance notice S
```

The code previously used this formula for sending followup notifications. The only change made in this PR it that it applies the above logic to *all* notifications, not only followup notifications.

There are other issues with the `estimated` alert sending logic which are not addressed in this PR. For a summary, see [here](https://app.asana.com/0/415342363785198/495798504989716/f).