### PR TITLE
remove logentries integration

### DIFF
--- a/apps/alert_processor/config/prod.exs
+++ b/apps/alert_processor/config/prod.exs
@@ -5,14 +5,7 @@ config :alert_processor, database_url: {:system, "DATABASE_URL_PROD"}
 config :logger,
   level: :info,
   truncate: :infinity,
-  backends: [{Logger.Backend.Logentries, :logentries}, :console]
-
-config :logger, :logentries,
-  connector: Logger.Backend.Logentries.Output.SslKeepOpen,
-  host: 'data.logentries.com',
-  port: 443,
-  token: "${LOGENTRIES_TOKEN}",
-  format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n"
+  backends: [:console]
 
 # Config for ExAws lib
 config :alert_processor, :ex_aws, ExAws

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -37,7 +37,6 @@ defmodule AlertProcessor.Supervisor do
     children = [
       supervisor(Registry, [:unique, :mailer_process_registry]),
       supervisor(AlertProcessor.Repo, []),
-      worker(Logger.Backend.Logentries.Output.SslKeepOpen.Server, []),
       worker(ServiceInfoCache, []),
       worker(AlertWorker, []),
       worker(AlertCache, []),

--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -38,7 +38,6 @@ defmodule AlertProcessor.Mixfile do
         :hackney,
         :httpoison,
         :logger,
-        :logger_logentries_backend,
         :poison,
         :poolboy,
         :postgrex,
@@ -79,8 +78,7 @@ defmodule AlertProcessor.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:scrivener_ecto, "~> 1.0"},
       {:sweet_xml, "~> 0.6"},
-      {:edeliver, "1.4.3"},
-      {:logger_logentries_backend, github: "paulswartz/logger_logentries_backend"}
+      {:edeliver, "1.4.3"}
     ]
   end
 

--- a/apps/concierge_site/config/prod.exs
+++ b/apps/concierge_site/config/prod.exs
@@ -27,15 +27,7 @@ config :phoenix, :serve_endpoints, true
 config :logger,
   level: :info,
   truncate: :infinity,
-  backends: [{Logger.Backend.Logentries, :logentries}, :console]
-
-config :logger, :logentries,
-  connector: Logger.Backend.Logentries.Output.SslKeepOpen,
-  host: 'data.logentries.com',
-  port: 443,
-  token: "${LOGENTRIES_TOKEN}",
-  format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
-  metadata: [:request_id]
+  backends: [:console]
 
 config :concierge_site, ConciergeSite.Dissemination.Mailer,
   adapter: Bamboo.SMTPAdapter,

--- a/apps/concierge_site/mix.exs
+++ b/apps/concierge_site/mix.exs
@@ -31,7 +31,6 @@ defmodule ConciergeSite.Mixfile do
        :crypto,
        :bamboo,
        :logger,
-       :logger_logentries_backend,
        :runtime_tools
        ]
      ]
@@ -63,7 +62,6 @@ defmodule ConciergeSite.Mixfile do
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
-      {:logger_logentries_backend, github: "paulswartz/logger_logentries_backend"},
       {:wallaby, "~> 0.15", only: :test}
     ]
   end


### PR DESCRIPTION
We were using a custom process for maintaining a connection to Logentries to send log output from the application. This has been removed as we are going to discontinue the use of this product.

To remove it, I remove the dependencies, configurations and the supervised process.