### PR TITLE
Parking subscriptions

### DIFF
--- a/apps/alert_processor/lib/subscription/mapper.ex
+++ b/apps/alert_processor/lib/subscription/mapper.ex
@@ -134,6 +134,19 @@ defmodule AlertProcessor.Subscription.Mapper do
   defp map_accessibility_activities(:escalator), do: ["USING_ESCALATOR"]
   defp map_accessibility_activities(_), do: []
 
+  def map_parking(subscriptions, %{"origin" => origin}) do
+    Enum.map(subscriptions, fn(subscription) ->
+      {subscription, [%InformedEntity{stop: origin, facility_type: :parking_area, activities: ["PARK_CAR"]}]}
+    end)
+  end
+  def map_parking([subscription], %{"stops" => stops}) do
+    entity = %InformedEntity{facility_type: :parking_area, activities: ["PARK_CAR"]}
+    stop_entities = for stop <- stops, do: %{entity | stop: stop}
+
+    [{subscription, stop_entities}]
+  end
+  def map_parking(_, _), do: :error
+
   def map_route_type(subscription_infos, %Route{route_type: type}) do
     route_type_entities = [%InformedEntity{route_type: type, activities: InformedEntity.default_entity_activities()}]
 

--- a/apps/alert_processor/lib/subscription/parking_mapper.ex
+++ b/apps/alert_processor/lib/subscription/parking_mapper.ex
@@ -1,0 +1,122 @@
+defmodule AlertProcessor.Subscription.ParkingMapper do
+  @moduledoc """
+  Module to convert a set of subscription creation parameters for
+  parking into the relevant subscription and informed entity structs.
+  """
+
+  import AlertProcessor.Subscription.Mapper, except: [map_timeframe: 1]
+  import Ecto.Query
+  alias Ecto.Multi
+  alias AlertProcessor.Repo
+  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+
+  defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
+
+  @doc """
+  build_subscription_update_transaction/3 receives a the current subscription
+  and the update params and builds and Ecto.Multi transaction.
+
+  1. It updates the subscription data
+  2. It regenerates the informed entities for that subscription from the new data
+  """
+  def build_subscription_update_transaction(subscription, subscription_infos, originator) do
+    origin =
+      if subscription.user_id != User.wrap_id(originator).id do
+        "admin:update-subscription"
+      end
+    [{sub_changes, informed_entities}] = subscription_infos
+    params =
+      sub_changes
+      |> Map.put(:informed_entities, informed_entities)
+      |> Map.from_struct()
+
+    current_informed_entity_ids =
+      subscription.informed_entities
+      |> Enum.map(& &1.id)
+
+    query = from(ie in InformedEntity, where: ie.id in ^current_informed_entity_ids)
+    current_informed_entities = Repo.all(query)
+
+    multi = informed_entities
+    |> Enum.with_index()
+    |> Enum.reduce(Multi.new(), fn({ie, index}, acc) ->
+        ie_to_insert = Map.put(ie, :subscription_id, subscription.id)
+        Multi.run(acc, {:new_informed_entity, index}, fn _ ->
+          PaperTrail.insert(ie_to_insert, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
+        end)
+      end)
+
+    current_informed_entities
+    |> Enum.with_index
+    |> Enum.reduce(multi, fn({ie, index}, acc) ->
+      Multi.run(acc, {:remove_current, index}, fn _ ->
+        PaperTrail.delete(ie, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
+      end)
+    end)
+    |> Multi.run({:subscription}, fn _ ->
+      changeset = Subscription.update_changeset(subscription, params)
+      PaperTrail.update(changeset, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id}, origin: origin)
+    end)
+  end
+
+  @doc """
+  map_subscription/1 receives a map of parking subscription params and returns
+  arrays of subscription_info to create in the database
+  to be used for matching against alerts.
+  """
+  @spec map_subscriptions(map) :: {:ok, [Subscription.subscription_info]} | :error
+  def map_subscriptions(params) do
+    params = params
+    |> remove_empty_strings()
+    |> map_stop_names()
+    |> set_alert_priority()
+
+    params
+    |> map_timeframe
+    |> map_priority(params)
+    |> map_type(:parking)
+    |> map_entities(params)
+  end
+
+  defp set_alert_priority(params) do
+    Map.put(params, "alert_priority_type", "low")
+  end
+
+  defp remove_empty_strings(params) do
+    Enum.reduce(params, %{}, fn({k, v}, acc) ->
+      if is_list(v) do
+        Map.put(acc, k, Enum.reject(v, & &1 == ""))
+      else
+        Map.put(acc, k, v)
+      end
+    end)
+  end
+
+  defp map_stop_names(params) do
+    stop_ids = Map.get(params, "stops", [])
+    Map.put(params, "stops", stop_ids)
+  end
+
+  defp map_entities(subscriptions, params) do
+    with subscriptions <- map_parking(subscriptions, params),
+         [_sub | _t] <- with_entities(subscriptions) do
+      {:ok, filter_duplicate_entities(subscriptions)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp with_entities(subscriptions) do
+    Enum.filter(subscriptions, fn({_, ie}) ->
+      length(ie) > 0
+    end)
+  end
+
+  defp map_timeframe(%{"relevant_days" => relevant_days}) do
+    [%Subscription{
+      start_time: ~T[00:00:00],
+      end_time: ~T[23:59:59],
+      relevant_days: Enum.map(relevant_days, &String.to_existing_atom/1)
+    }]
+  end
+end

--- a/apps/alert_processor/test/alert_processor/subscription/parking_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/parking_mapper_test.exs
@@ -1,0 +1,48 @@
+defmodule AlertProcessor.Subscription.ParkingMapperTest do
+  use AlertProcessor.DataCase
+  import AlertProcessor.Factory
+  alias AlertProcessor.Subscription.ParkingMapper
+  alias AlertProcessor.Model.InformedEntity
+
+  @params %{
+    "stops" => ["place-north", "place-sstat"],
+    "relevant_days" => ["weekday"]
+  }
+
+  describe "parking_area" do
+    test "creates expected entities" do
+      {:ok, [{_subscription, informed_entities}]} = ParkingMapper.map_subscriptions(@params)
+      north_station_entities_count =
+        Enum.count(informed_entities, fn(informed_entity) ->
+          match?(%InformedEntity{facility_type: :parking_area, stop: "place-north", activities: ["PARK_CAR"]}, informed_entity)
+        end)
+      assert north_station_entities_count == 1
+
+      south_station_entities_count =
+        Enum.count(informed_entities, fn(informed_entity) ->
+          match?(%InformedEntity{facility_type: :parking_area, stop: "place-sstat", activities: ["PARK_CAR"]}, informed_entity)
+        end)
+      assert south_station_entities_count == 1
+    end
+  end
+
+  describe "build_subscription_transaction" do
+    @params %{
+      "stops" => ["place-north", "place-sstat"],
+      "relevant_days" => ["weekday"]
+    }
+
+    test "it builds a multi struct to persist subscriptions and informed_entities" do
+      user = insert(:user)
+      {:ok, subscription_infos} = ParkingMapper.map_subscriptions(@params)
+      multi = ParkingMapper.build_subscription_transaction(subscription_infos, user, user.id)
+      result = Ecto.Multi.to_list(multi)
+
+      assert {{:subscription, 0}, {:run, function}} = List.first(result)
+      assert {{:new_informed_entity, 0, 0}, {:run, _}} = Enum.at(result, 1)
+
+      {:ok, %{model: subscription}} = function.(nil)
+      assert subscription.id != nil
+    end
+  end
+end

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -160,6 +160,20 @@ defmodule AlertProcessor.Factory do
     ]
   end
 
+  def parking_subscription(%Subscription{} = subscription) do
+    %{subscription |
+      alert_priority_type: :low,
+      type: :amenity
+     }
+  end
+
+  def parking_subscription_entities() do
+    [
+      %InformedEntity{route_type: 4, facility_type: :elevator, route: "Green"},
+      %InformedEntity{route_type: 4, facility_type: :escalator, stop: "place-nqncy"}
+    ]
+  end
+
   def user_factory do
     %User{
       email: sequence(:email, &"email-#{&1}@example.com"),

--- a/apps/concierge_site/lib/controllers/parking_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/parking_subscription_controller.ex
@@ -1,0 +1,121 @@
+defmodule ConciergeSite.ParkingSubscriptionController do
+  use ConciergeSite.Web, :controller
+  use Guardian.Phoenix.Controller
+  alias ConciergeSite.Subscriptions.{ParkingParams}
+  alias ConciergeSite.Helpers.MultiSelectHelper
+  alias AlertProcessor.{ServiceInfoCache,
+    Subscription.ParkingMapper, Model.Subscription, Model.User}
+
+  def new(conn, _params, _user, _claims) do
+    render_new_page(conn)
+  end
+
+  def create(conn, %{"subscription" => sub_params}, user, {:ok, claims}) do
+    sub_params = Map.merge(sub_params, %{"user_id" => user.id})
+    with :ok <- ParkingParams.validate_info_params(sub_params),
+      {:ok, subscription_infos} <- ParkingMapper.map_subscriptions(sub_params),
+      multi <- ParkingMapper.build_subscription_transaction(subscription_infos, user, Map.get(claims, "imp", user.id)),
+      :ok <- Subscription.set_versioned_subscription(multi) do
+        redirect(conn, to: subscription_path(conn, :index))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> render_new_page()
+      _ ->
+        conn
+        |> put_flash(:error, "there was an error saving the subscription. Please try again.")
+        |> render_new_page()
+    end
+  end
+
+  def edit(conn, %{"id" => id}, user, _) do
+    with {:ok, subway_stations} <- ServiceInfoCache.get_subway_full_routes(),
+      {:ok, cr_stations} <- ServiceInfoCache.get_commuter_rail_info() do
+        station_select_options = MultiSelectHelper.station_options(cr_stations, subway_stations)
+        subscription = Subscription.one_for_user!(id, user.id, true)
+        changeset = Subscription.update_changeset(subscription)
+
+        render conn,
+          "edit.html",
+          subscription: subscription,
+          changeset: changeset,
+          station_select_options: station_select_options,
+          selected_options: selected_options(subscription)
+    else
+      _error ->
+        conn
+        |> put_flash(:error, "There was an error. Please try again.")
+        |> redirect(to: subscription_path(conn, :index))
+    end
+  end
+
+  def update(conn, %{"id" => id, "subscription" => sub_params}, user, {:ok, claims}) do
+    with subscription <- Subscription.one_for_user!(id, user.id, true),
+      :ok <- ParkingParams.validate_info_params(sub_params),
+      {:ok, subscription_infos} <- ParkingMapper.map_subscriptions(sub_params),
+      multi <- ParkingMapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
+      :ok <- Subscription.set_versioned_subscription(multi) do
+        :ok = User.clear_holding_queue_for_user_id(user.id)
+        redirect(conn, to: subscription_path(conn, :index))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> redirect(to: parking_subscription_path(conn, :edit, id))
+      _ ->
+        conn
+        |> put_flash(:error, "There was an error saving the subscription. Please try again.")
+        |> redirect(to: parking_subscription_path(conn, :edit, id))
+    end
+  end
+
+  defp render_new_page(conn) do
+    with sub_params <- Map.get(conn.params, "subscription", %{}),
+      {:ok, subway_stations} <- ServiceInfoCache.get_subway_full_routes(),
+      {:ok, cr_stations} <- ServiceInfoCache.get_commuter_rail_info() do
+
+      station_select_options = MultiSelectHelper.station_options(cr_stations, subway_stations)
+
+      selected_options = %{
+        relevant_days: sub_params |> Map.get("relevant_days", []) |> Enum.reject(&empty_or_nil?/1),
+        stations: sub_params |> Map.get("stops", []) |> Enum.map(&fetch_stop/1) |> Enum.reject(&empty_or_nil?/1)
+      }
+
+      render conn, :new,
+        station_select_options: station_select_options,
+        selected_options: selected_options
+    else
+      _error ->
+        conn
+        |> put_flash(:error, "There was an error fetching station data. Please try again.")
+        |> redirect(to: subscription_path(conn, :new))
+    end
+  end
+
+  defp selected_options(%Subscription{informed_entities: ies, relevant_days: relevant_days}) do
+    ies
+    |> Enum.reduce(
+      %{relevant_days: MapSet.new, stations: MapSet.new},
+      fn(ie, acc) ->
+        if ie.stop do
+          {:ok, stop} = ServiceInfoCache.get_stop(ie.stop)
+          stations = MapSet.put(acc.stations, stop)
+          Map.put(acc, :stations, stations)
+        else
+          acc
+        end
+      end)
+      |> Map.put(:relevant_days, relevant_days |> Enum.reject(&empty_or_nil?/1) |> MapSet.new(&to_string/1))
+      |> Map.new(fn({k, v}) -> {k, MapSet.to_list(v)} end)
+  end
+
+  defp empty_or_nil?(nil), do: true
+  defp empty_or_nil?(""), do: true
+  defp empty_or_nil?(_), do: false
+
+  defp fetch_stop(stop_id) do
+    {:ok, stop} = ServiceInfoCache.get_stop(stop_id)
+    stop
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -98,6 +98,8 @@ defmodule ConciergeSite.Router do
       only: [:new, :create, :edit, :update]
     resources "/accessibility", AccessibilitySubscriptionController,
       only: [:new, :create, :edit, :update]
+    resources "/parking", ParkingSubscriptionController,
+      only: [:new, :create, :edit, :update]
   end
 
   scope "/admin", ConciergeSite, as: :admin do

--- a/apps/concierge_site/lib/subscriptions/parking_params.ex
+++ b/apps/concierge_site/lib/subscriptions/parking_params.ex
@@ -1,0 +1,49 @@
+defmodule ConciergeSite.Subscriptions.ParkingParams do
+  @moduledoc false
+  import ConciergeSite.Subscriptions.ParamsValidator
+
+  @spec validate_info_params(map) :: :ok | {:error, String.t}
+  def validate_info_params(params) do
+    {_, errors} =
+      {params, []}
+      |> remove_empty_strings()
+      |> validate_at_least_one_travel_day()
+      |> validate_at_least_one_station()
+
+    if errors == [] do
+      :ok
+    else
+      {:error, full_error_message_iodata(errors)}
+    end
+  end
+
+  defp validate_at_least_one_station({params, errors}) do
+    if missing_stops?(params) do
+      {params, ["At least one station must be selected." | errors]}
+    else
+      {params, errors}
+    end
+  end
+
+  defp missing_stops?(%{"stops" => [stop | _]}) when not is_nil(stop), do: false
+  defp missing_stops?(_), do: true
+
+  defp validate_at_least_one_travel_day({params, errors}) do
+    if Enum.empty?(params["relevant_days"]) do
+      {params, ["At least one travel day must be selected." | errors]}
+    else
+      {params, errors}
+    end
+  end
+
+  defp remove_empty_strings({params, errors}) do
+    clean_params = Enum.reduce(params, %{}, fn({k, v}, acc) ->
+      if is_list(v) do
+        Map.put(acc, k, Enum.reject(v, & &1 == ""))
+      else
+        Map.put(acc, k, v)
+      end
+    end)
+    {clean_params, errors}
+  end
+end

--- a/apps/concierge_site/lib/templates/parking_subscription/_parking_form.html.eex
+++ b/apps/concierge_site/lib/templates/parking_subscription/_parking_form.html.eex
@@ -1,0 +1,13 @@
+<div class="parking-subscription-form-section">
+  <%= render "_station_select.html",
+          form: @f,
+          select_options: @station_select_options,
+          selected_station_options: Map.get(@selected_options, :stations, []) %>
+
+  <div class="selected-entity-list"></div>
+
+  <%= render "_travel_days_checkboxes.html",
+              form: @f,
+              checked: Map.get(@selected_options, :relevant_days, []),
+              action: @action %>
+</div>

--- a/apps/concierge_site/lib/templates/parking_subscription/_station_select.html.eex
+++ b/apps/concierge_site/lib/templates/parking_subscription/_station_select.html.eex
@@ -1,0 +1,13 @@
+<div class="form-group select-entity">
+  <label for="station" class="entity-input-label form-label">What stations do you use?</label>
+  <div class="form-sub-label entity-select-sub-label">Enter as many stations as you would like.</div>
+  <div class="entity-select-group">
+    <%= multiple_select @form,
+              :stops,
+              @select_options,
+              selected: Enum.map(@selected_station_options, & elem(&1, 1)),
+              class: "subscription-select multi-select no-js",
+              prompt: "Enter a station",
+              data: [entity_type: "station"] %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/parking_subscription/_travel_days_checkboxes.html.eex
+++ b/apps/concierge_site/lib/templates/parking_subscription/_travel_days_checkboxes.html.eex
@@ -1,0 +1,37 @@
+<div class="form-group select-days">
+  <div class="form-label edit-form-label">What days do you travel?</div>
+  <%= error_tag @form, :relevant_days %>
+  <div class="<%= @action %>-subscription-section-container">
+    <label>
+      <%= checkbox @form,
+                  :weekday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "weekday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "weekday") %>
+      Weekdays
+    </label>
+    <label>
+      <%= checkbox @form,
+                  :saturday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "saturday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "saturday") %>
+      Saturday
+    </label>
+    <label>
+      <%= checkbox @form,
+                  :sunday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "sunday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "sunday") %>
+      Sunday
+    </label>
+  </div>
+</div>
+

--- a/apps/concierge_site/lib/templates/parking_subscription/edit.html.eex
+++ b/apps/concierge_site/lib/templates/parking_subscription/edit.html.eex
@@ -1,0 +1,18 @@
+<%= render ConciergeSite.SubscriptionView,
+           "_edit_subscription_header.html",
+           title: "Subscribe to station parking alerts",
+           subscription: @subscription %>
+
+<%= flash_error(@conn) %>
+
+<div class="subscription-step parking">
+  <div class="enter-trip-info">
+    <%= form_for @changeset, parking_subscription_path(@conn, :update, @subscription), [class: "single-submit-form trip-info-form multi-select-form parking", as: :subscription, method: :patch], fn f -> %>
+      <%= render "_parking_form.html", f: f, station_select_options: @station_select_options, selected_options: @selected_options, action: "edit" %>
+
+      <div class="trip-info-footer">
+        <%= submit "Update Subscription", class: "btn btn-primary btn-subscription-next" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/parking_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/parking_subscription/new.html.eex
@@ -1,0 +1,13 @@
+<h1>Create New Subscription</h1>
+<%= flash_error(@conn) %>
+<div class="subscription-step parking">
+  <div class="enter-trip-info">
+    <%= form_for @conn, parking_subscription_path(@conn, :create), [class: "single-submit-form trip-info-form multi-select-form parking", as: :subscription], fn f -> %>
+      <%= render "_parking_form.html", f: f, station_select_options: @station_select_options, selected_options: @selected_options, action: "new" %>
+
+      <div class="trip-info-footer">
+        <%= submit "Create Subscription", class: "btn btn-primary btn-parking-submit" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/subscription/_parking_subscription_info.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_parking_subscription_info.html.eex
@@ -1,0 +1,31 @@
+<%= unless Enum.empty?(@subscriptions) do %>
+  <div class="parking-subscriptions">
+    <%= for subscription <- @subscriptions do %>
+      <h6><%= route_header(subscription) %></h6>
+      <%= if @render_links do %>
+        <%= link(to: parking_subscription_path(@conn, :edit, subscription), class: "subscription-link") do %>
+          <div class="subscription">
+            <div class="subscription-icon-container">
+              <div class="parking-icon subscription-icon">
+                <img src="<%= static_url(@conn, "/images/parking.svg") %>" />
+              </div>
+            </div>
+            <%= subscription_info(subscription) %>
+            <div class="subscription-edit-link">
+              <i class="fa fa-chevron-right" aria-hidden="true"></i>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+         <div class="subscription">
+          <div class="subscription-icon-container">
+            <div class="parking-icon subscription-icon">
+              <img src="<%= static_url(@conn, "/images/parking.svg") %>" />
+            </div>
+          </div>
+          <%= subscription_info(subscription) %>
+         </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/templates/subscription/_subscriptions.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_subscriptions.html.eex
@@ -5,3 +5,4 @@
   <%= render "_ferry_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:ferry], station_display_names: @station_display_names, departure_time_map: @departure_time_map, render_links: @render_links %>
   <%= render "_amenity_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:amenity], render_links: @render_links %>
   <%= render "_accessibility_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:accessibility], render_links: @render_links %>
+  <%= render "_parking_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:parking], render_links: @render_links %>

--- a/apps/concierge_site/lib/templates/subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/new.html.eex
@@ -47,7 +47,7 @@
               name: "Elevators and Accessibility" %>
 
     <%= render "_service_option.html",
-              link_to: amenity_subscription_path(@conn, :new),
+              link_to: parking_subscription_path(@conn, :new),
               icon_class: "parking-icon",
               icon_src: static_url(@conn, "/images/parking.svg"),
               name: "Parking" %>

--- a/apps/concierge_site/lib/views/parking_subscription_view.ex
+++ b/apps/concierge_site/lib/views/parking_subscription_view.ex
@@ -1,0 +1,65 @@
+defmodule ConciergeSite.ParkingSubscriptionView do
+  use ConciergeSite.Web, :view
+  alias AlertProcessor.Model.Subscription
+  import ConciergeSite.SubscriptionHelper,
+    only: [relevant_days: 1]
+
+  @doc """
+  Returns string with ampersand separated list of facilty types for an parking subscription
+  """
+  @spec parking_facility_type(Subscription.t) :: String.t
+  def parking_facility_type(subscription) do
+    subscription.informed_entities
+    |> Enum.map(&(&1.facility_type))
+    |> Enum.uniq
+    |> Enum.map(fn(parking) ->
+      parking
+      |> Atom.to_string()
+      |> String.replace("_", " ")
+      |> String.capitalize()
+    end)
+    |> Enum.sort
+    |> AlertProcessor.Helpers.StringHelper.and_join()
+  end
+
+  @doc """
+  Returns human readable description of parking schedule
+  # of stations, which lines, and days of travel
+  Example: 2 stations + Green line, Weekdays
+  """
+  @spec parking_schedule(Subscription.t) :: iolist
+  def parking_schedule(subscription) do
+    entity_info = Enum.join(pretty_station_count(subscription) ++ lines(subscription), " + ")
+    [
+      entity_info,
+      " on ",
+      relevant_days(subscription)
+    ]
+  end
+
+  defp pretty_station_count(subscription) do
+    case count = number_of_stations(subscription) do
+      0 -> []
+      1 -> ["1 station"]
+      _ -> ["#{count} stations"]
+    end
+  end
+
+  defp number_of_stations(subscription) do
+    subscription.informed_entities
+    |> Enum.filter(&(!is_nil(&1.stop)))
+    |> Enum.map(&(&1.stop))
+    |> Enum.uniq
+    |> length
+  end
+
+  defp lines(subscription) do
+    subscription.informed_entities
+    |> Enum.filter(&(!is_nil(&1.route)))
+    |> Enum.map(&("#{&1.route} Line"))
+    |> Enum.uniq
+    |> Enum.join(", ")
+    |> List.wrap()
+    |> Enum.filter(& String.length(&1) > 0)
+  end
+end

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -6,7 +6,8 @@ defmodule ConciergeSite.SubscriptionView do
 
   alias AlertProcessor.{Model, ServiceInfoCache}
   alias Model.{InformedEntity, Route, Subscription}
-  alias ConciergeSite.{AmenitySubscriptionView, AccessibilitySubscriptionView, BusSubscriptionView, SubscriptionHelper, TimeHelper}
+  alias ConciergeSite.{AmenitySubscriptionView, AccessibilitySubscriptionView, ParkingSubscriptionView,
+    BusSubscriptionView, SubscriptionHelper, TimeHelper}
 
   import SubscriptionHelper,
     only: [direction_id: 1, relevant_days: 1]
@@ -14,6 +15,8 @@ defmodule ConciergeSite.SubscriptionView do
     only: [amenity_facility_type: 1, amenity_schedule: 1]
   import AccessibilitySubscriptionView,
     only: [accessibility_facility_type: 1, accessibility_schedule: 1]
+  import ParkingSubscriptionView,
+    only: [parking_schedule: 1]
 
   @type subscription_info :: %{
     amenity: [Subscription.t],
@@ -45,12 +48,12 @@ defmodule ConciergeSite.SubscriptionView do
         {route.order, relevant_days_key, start_time_value}
       end)
       |> Enum.group_by(& &1.type)
-    Map.merge(%{amenity: [], accessibility: [], ferry: [], bus: [], commuter_rail: [], subway: []}, subscription_map)
+    Map.merge(%{amenity: [], accessibility: [], parking: [], ferry: [], bus: [], commuter_rail: [], subway: []}, subscription_map)
   end
 
   def subscription_info(subscription, station_display_names \\ nil, departure_time_map \\ nil)
   def subscription_info(%{type: type} = subscription, station_display_names, departure_time_map) do
-    if Enum.member?([:amenity, :accessibility, :bus, :commuter_rail, :ferry, :subway], type) do
+    if Enum.member?([:amenity, :accessibility, :parking, :bus, :commuter_rail, :ferry, :subway], type) do
       do_subscription_info(subscription, station_display_names, departure_time_map)
     else
       ""
@@ -74,6 +77,18 @@ defmodule ConciergeSite.SubscriptionView do
       [
         content_tag :div, class: "subscription-route" do
           "Accessibility Features"
+        end,
+        content_tag :div, class: "subscription-details" do
+          route_body(subscription, nil, nil)
+        end
+      ]
+    end
+  end
+  defp do_subscription_info(%{type: :parking} = subscription, _, _) do
+    content_tag :div, class: "subscription-info" do
+      [
+        content_tag :div, class: "subscription-route" do
+          "Parking"
         end,
         content_tag :div, class: "subscription-details" do
           route_body(subscription, nil, nil)
@@ -114,6 +129,7 @@ defmodule ConciergeSite.SubscriptionView do
 
   def route_header(%{type: :amenity}), do: "Station Amenities"
   def route_header(%{type: :accessibility}), do: "Accessibility"
+  def route_header(%{type: :parking}), do: "Parking"
   def route_header(%{type: :bus} = subscription, _) do
     route_entity_count = Subscription.route_count(subscription)
     if route_entity_count > 1 do
@@ -154,6 +170,13 @@ defmodule ConciergeSite.SubscriptionView do
       end,
       content_tag :div, class: "subscription-amenity-schedule" do
         accessibility_schedule(subscription)
+      end
+    ]
+  end
+  defp route_body(%{type: :parking} = subscription, _, _) do
+    [
+      content_tag :div, class: "subscription-amenity-schedule" do
+        parking_schedule(subscription)
       end
     ]
   end
@@ -235,6 +258,7 @@ defmodule ConciergeSite.SubscriptionView do
 
   def parse_route(%Subscription{type: :amenity}), do: %{order: 1}
   def parse_route(%Subscription{type: :accessibility}), do: %{order: 1}
+  def parse_route(%Subscription{type: :parking}), do: %{order: 1}
   def parse_route(subscription) do
     {:ok, route} = subscription |> parse_route_id() |> ServiceInfoCache.get_route()
     route

--- a/apps/concierge_site/test/feature/parking_subscription_test.exs
+++ b/apps/concierge_site/test/feature/parking_subscription_test.exs
@@ -14,11 +14,10 @@ defmodule ConciergeSite.ParkingSubscriptionTest do
     session
     |> log_in(user)
     |> click(css("a", text: "Parking"))
-    |> click(checkbox("Parking"))
     |> fill_in(text_field("station"), with: "South Station")
     |> click(checkbox("Weekdays"))
     |> click(button("Create Subscription"))
     |> assert_has(css(".header-text", text: "My Subscriptions"))
-    |> assert_has(css(".subscription-details", text: "Parking area"))
+    |> assert_has(css(".subscription-route", text: "Parking"))
   end
 end

--- a/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
@@ -1,0 +1,184 @@
+defmodule ConciergeSite.ParkingSubscriptionControllerTest do
+  use ConciergeSite.ConnCase
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  alias AlertProcessor.{HoldingQueue, Model.Subscription, Model.InformedEntity, Repo}
+
+  describe "authorized" do
+    setup :login_user
+
+    test "GET /subscriptions/parking/new", %{conn: conn}  do
+      conn = conn
+      |> get("/subscriptions/parking/new")
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+    end
+
+    test "POST /subscriptions/parking with valid params", %{conn: conn} do
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => ["saturday"],
+      }}
+
+      conn = conn
+      |> post("/subscriptions/parking", params)
+
+      subscriptions = Repo.all(Subscription)
+
+      assert html_response(conn, 302) =~ "my-subscriptions"
+      assert length(subscriptions) == 1
+    end
+
+    test "POST /subscriptions/parking with invalid params", %{conn: conn} do
+      params = %{"subscription" => %{
+        "relevant_days" => [],
+      }}
+
+      conn = conn
+      |> post("/subscriptions/parking", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one station must be selected. At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+      assert expected_error == error
+    end
+
+    test "POST /subscriptions/parking with invalid params with stations selected", %{conn: conn} do
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => [],
+      }}
+
+      conn = post(conn, "/subscriptions/parking", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+      assert html_response(conn, 200) =~ "North Quincy"
+      assert html_response(conn, 200) =~ "Forest Hills"
+      assert expected_error == error
+    end
+
+    test "GET /subscriptions/parking/:id/edit", %{conn: conn, user: user} do
+      parking_subscription_entities =     [
+        %InformedEntity{route_type: 4, facility_type: :elevator, route: "Green"},
+        %InformedEntity{route_type: 4, facility_type: :elevator, stop: "place-nqncy"}
+      ]
+
+      sub = subscription_factory()
+      |> Map.put(:informed_entities, parking_subscription_entities)
+      |> parking_subscription()
+      |> weekday_subscription()
+      |> Map.merge(%{user: user})
+      |> insert()
+
+      use_cassette "parking_update", clear_mock: true  do
+        conn = get(conn, parking_subscription_path(conn, :edit, sub.id))
+        result = html_response(conn, 200)
+
+        weekday_checked? = result =~ "<input checked=\"checked\" class=\"subscription-day-checkbox\" id=\"subscription_weekday\" name=\"subscription[relevant_days][]\" type=\"checkbox\" value=\"weekday\">"
+        sunday_unchecked? = result =~ "<input class=\"subscription-day-checkbox\" id=\"subscription_sunday\" name=\"subscription[relevant_days][]\" type=\"checkbox\" value=\"sunday\">"
+
+        assert result =~ "Subscribe to station parking alerts"
+
+        assert weekday_checked?
+        assert sunday_unchecked?
+      end
+    end
+
+    test "PATCH /subscriptions/parking/:id", %{conn: conn, user: user} do
+      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
+      :ok = HoldingQueue.enqueue(notification)
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, parking_subscription_entities())
+        |> parking_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => ["saturday"],
+      }}
+
+      use_cassette "parking_update", clear_mock: true  do
+        conn = patch(conn, "/subscriptions/parking/#{subscription.id}", params)
+        assert html_response(conn, 302) =~ "my-subscriptions"
+        assert :error = HoldingQueue.pop()
+      end
+    end
+
+    test "PATCH /subscriptions/parking/:id with incomplete params", %{conn: conn, user: user} do
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, parking_subscription_entities())
+        |> parking_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => [],
+      }}
+
+      conn = patch(conn, "/subscriptions/parking/#{subscription.id}", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 302) =~ "/subscriptions/parking/#{subscription.id}/edit"
+      assert expected_error == error
+    end
+
+    test "PATCH /subscriptions/parking/:id with empty params", %{conn: conn, user: user} do
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, parking_subscription_entities())
+        |> parking_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => [],
+        "relevant_days" => [],
+      }}
+
+      conn = patch(conn, "/subscriptions/parking/#{subscription.id}", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one station must be selected. At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 302) =~ "/subscriptions/parking/#{subscription.id}/edit"
+      assert expected_error == error
+    end
+  end
+
+  describe "unauthorized" do
+    test "GET /subscriptions/parking/new", %{conn: conn} do
+      conn = get(conn, "/subscriptions/parking/new")
+      assert html_response(conn, 302) =~ "/login"
+    end
+  end
+
+  defp login_user(%{conn: c}) do
+    user = insert(:user)
+    conn = guardian_login(user, c)
+    {:ok, [conn: conn, user: user]}
+  end
+end

--- a/apps/concierge_site/test/web/subscriptions/parking_params_test.exs
+++ b/apps/concierge_site/test/web/subscriptions/parking_params_test.exs
@@ -1,0 +1,37 @@
+defmodule ConciergeSite.Subscriptions.ParkingParamsTest do
+  use ExUnit.Case
+  alias ConciergeSite.Subscriptions.ParkingParams
+
+  @valid_params %{
+    "stops" => ["place-north"],
+    "relevant_days" => ["weekday"]
+  }
+
+  describe "validate_info_params/1" do
+    test "with valid params" do
+      assert ParkingParams.validate_info_params(@valid_params) == :ok
+    end
+
+    test "handles empty strings" do
+      params = Map.put(@valid_params, "relevant_days", ["", "", ""])
+
+      assert {:error, _} = ParkingParams.validate_info_params(params)
+    end
+
+    test "errors if no travel days selected" do
+      params = Map.put(@valid_params, "relevant_days", [])
+      messages = ["Please correct the following errors to proceed: ", ["At least one travel day must be selected."]]
+
+      assert ParkingParams.validate_info_params(params) == {:error, messages}
+    end
+
+    test "errors if no stations AND no subway lines selected" do
+      params =
+        @valid_params
+        |> Map.put("stops", "")
+      messages = ["Please correct the following errors to proceed: ", ["At least one station must be selected."]]
+
+      assert ParkingParams.validate_info_params(params) == {:error, messages}
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/parking_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/parking_subscription_view_test.exs
@@ -1,0 +1,85 @@
+defmodule ConciergeSite.ParkingSubscriptionViewTest do
+  use ExUnit.Case
+  alias ConciergeSite.ParkingSubscriptionView
+  alias AlertProcessor.Model.{Subscription, InformedEntity}
+
+  @informed_entities [
+    %InformedEntity{
+      facility_type: :escalator,
+      stop: "place-nqncy"
+    },
+    %InformedEntity{
+      facility_type: :elevator,
+      route: "Green"
+    }
+  ]
+
+  @subscription %Subscription{
+    informed_entities: @informed_entities,
+    relevant_days: [:saturday, :weekday]
+  }
+
+  describe "parking_facility_type/1" do
+    test "it returns and separated list of parking" do
+      result =
+        @subscription
+        |> ParkingSubscriptionView.parking_facility_type()
+        |> IO.iodata_to_binary
+      assert result == "Elevator and Escalator"
+    end
+  end
+
+  describe "parking_schedule/1" do
+    test "it returns the schedule details" do
+      result =
+        @subscription
+        |> ParkingSubscriptionView.parking_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "1 station + Green Line on Saturdays, Weekdays"
+    end
+
+    test "pluralizes stops" do
+      informed_entity = %InformedEntity{
+        facility_type: :escalator,
+        stop: "place-harvard"
+      }
+      ies = @informed_entities ++ [informed_entity]
+      sub = Map.put(@subscription, :informed_entities, ies)
+      result =
+        sub
+        |> ParkingSubscriptionView.parking_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "2 stations + Green Line on Saturdays, Weekdays"
+    end
+
+    test "it omits text about stations if there are none" do
+      subscription = %Subscription{
+        informed_entities: [%InformedEntity{facility_type: :elevator, route: "Green"}],
+        relevant_days: [:saturday]
+      }
+
+      result =
+        subscription
+        |> ParkingSubscriptionView.parking_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "Green Line on Saturdays"
+    end
+
+    test "it displays stops only properly" do
+      subscription = %Subscription{
+        informed_entities: [%InformedEntity{facility_type: :elevator, stop: "place-harvard"}],
+        relevant_days: [:saturday]
+      }
+
+      result =
+        subscription
+        |> ParkingSubscriptionView.parking_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "1 station on Saturdays"
+    end
+  end
+end


### PR DESCRIPTION
Create a new parking flow for creating alerts related to parking. Start by copying the amenities controllers, views, mappers, etc. and then making some changes in other places in the code and in the tests to support the new flow. This PR is very similar to https://github.com/mbta/alerts_concierge/pull/471 which creates an accessibility subscription flow.

Some screens from the new parking flow:

![screen shot 2017-12-08 at 15 30 41](https://user-images.githubusercontent.com/3039310/33783941-d0e3293a-dc2c-11e7-8a25-9d063b00440e.png)

---

![screen shot 2017-12-08 at 15 30 53](https://user-images.githubusercontent.com/3039310/33783942-d0ee351e-dc2c-11e7-9bfd-65b5eb3c174b.png)

---

![screen shot 2017-12-08 at 15 30 58](https://user-images.githubusercontent.com/3039310/33783943-d0fc6ff8-dc2c-11e7-8682-8bc11a06b7d8.png)
