### PR TITLE
Fetch alerts more frequently by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-ALERT_FETCH_INTERVAL=60000
+ALERT_FETCH_INTERVAL=10000
 API_URL=https://dev.api.mbtace.com/
 ALERT_API_URL=http://s3.amazonaws.com/mbta-realtime-test-v2/alerts_enhanced.json
 DATABASE_URL_TEST=postgresql://__username__:password@localhost:5432/alert_concierge_test


### PR DESCRIPTION
Decrease the default `ALERT_FETCH_INTERVAL` to fetch alerts once every ten seconds instead of once a minute. This will cause alerts to be sent out closer to when they are issued, instead of more than a minute after being issued.