### PR TITLE
Bike storage subscriptions

### DIFF
--- a/apps/alert_processor/lib/subscription/bike_storage_mapper.ex
+++ b/apps/alert_processor/lib/subscription/bike_storage_mapper.ex
@@ -1,0 +1,122 @@
+defmodule AlertProcessor.Subscription.BikeStorageMapper do
+  @moduledoc """
+  Module to convert a set of subscription creation parameters for
+  bike_storage into the relevant subscription and informed entity structs.
+  """
+
+  import AlertProcessor.Subscription.Mapper, except: [map_timeframe: 1]
+  import Ecto.Query
+  alias Ecto.Multi
+  alias AlertProcessor.Repo
+  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+
+  defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
+
+  @doc """
+  build_subscription_update_transaction/3 receives a the current subscription
+  and the update params and builds and Ecto.Multi transaction.
+
+  1. It updates the subscription data
+  2. It regenerates the informed entities for that subscription from the new data
+  """
+  def build_subscription_update_transaction(subscription, subscription_infos, originator) do
+    origin =
+      if subscription.user_id != User.wrap_id(originator).id do
+        "admin:update-subscription"
+      end
+    [{sub_changes, informed_entities}] = subscription_infos
+    params =
+      sub_changes
+      |> Map.put(:informed_entities, informed_entities)
+      |> Map.from_struct()
+
+    current_informed_entity_ids =
+      subscription.informed_entities
+      |> Enum.map(& &1.id)
+
+    query = from(ie in InformedEntity, where: ie.id in ^current_informed_entity_ids)
+    current_informed_entities = Repo.all(query)
+
+    multi = informed_entities
+    |> Enum.with_index()
+    |> Enum.reduce(Multi.new(), fn({ie, index}, acc) ->
+        ie_to_insert = Map.put(ie, :subscription_id, subscription.id)
+        Multi.run(acc, {:new_informed_entity, index}, fn _ ->
+          PaperTrail.insert(ie_to_insert, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
+        end)
+      end)
+
+    current_informed_entities
+    |> Enum.with_index
+    |> Enum.reduce(multi, fn({ie, index}, acc) ->
+      Multi.run(acc, {:remove_current, index}, fn _ ->
+        PaperTrail.delete(ie, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
+      end)
+    end)
+    |> Multi.run({:subscription}, fn _ ->
+      changeset = Subscription.update_changeset(subscription, params)
+      PaperTrail.update(changeset, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id}, origin: origin)
+    end)
+  end
+
+  @doc """
+  map_subscription/1 receives a map of bike_storage subscription params and returns
+  arrays of subscription_info to create in the database
+  to be used for matching against alerts.
+  """
+  @spec map_subscriptions(map) :: {:ok, [Subscription.subscription_info]} | :error
+  def map_subscriptions(params) do
+    params = params
+    |> remove_empty_strings()
+    |> map_stop_names()
+    |> set_alert_priority()
+
+    params
+    |> map_timeframe
+    |> map_priority(params)
+    |> map_type(:bike_storage)
+    |> map_entities(params)
+  end
+
+  defp set_alert_priority(params) do
+    Map.put(params, "alert_priority_type", "low")
+  end
+
+  defp remove_empty_strings(params) do
+    Enum.reduce(params, %{}, fn({k, v}, acc) ->
+      if is_list(v) do
+        Map.put(acc, k, Enum.reject(v, & &1 == ""))
+      else
+        Map.put(acc, k, v)
+      end
+    end)
+  end
+
+  defp map_stop_names(params) do
+    stop_ids = Map.get(params, "stops", [])
+    Map.put(params, "stops", stop_ids)
+  end
+
+  defp map_entities(subscriptions, params) do
+    with subscriptions <- map_bike_storage(subscriptions, params),
+         [_sub | _t] <- with_entities(subscriptions) do
+      {:ok, filter_duplicate_entities(subscriptions)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp with_entities(subscriptions) do
+    Enum.filter(subscriptions, fn({_, ie}) ->
+      length(ie) > 0
+    end)
+  end
+
+  defp map_timeframe(%{"relevant_days" => relevant_days}) do
+    [%Subscription{
+      start_time: ~T[00:00:00],
+      end_time: ~T[23:59:59],
+      relevant_days: Enum.map(relevant_days, &String.to_existing_atom/1)
+    }]
+  end
+end

--- a/apps/alert_processor/lib/subscription/mapper.ex
+++ b/apps/alert_processor/lib/subscription/mapper.ex
@@ -147,6 +147,19 @@ defmodule AlertProcessor.Subscription.Mapper do
   end
   def map_parking(_, _), do: :error
 
+  def map_bike_storage(subscriptions, %{"origin" => origin}) do
+    Enum.map(subscriptions, fn(subscription) ->
+      {subscription, [%InformedEntity{stop: origin, facility_type: :bike_storage, activities: ["STORE_BIKE"]}]}
+    end)
+  end
+  def map_bike_storage([subscription], %{"stops" => stops}) do
+    entity = %InformedEntity{facility_type: :bike_storage, activities: ["STORE_BIKE"]}
+    stop_entities = for stop <- stops, do: %{entity | stop: stop}
+
+    [{subscription, stop_entities}]
+  end
+  def map_bike_storage(_, _), do: :error
+
   def map_route_type(subscription_infos, %Route{route_type: type}) do
     route_type_entities = [%InformedEntity{route_type: type, activities: InformedEntity.default_entity_activities()}]
 

--- a/apps/alert_processor/test/alert_processor/subscription/bike_storage_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/bike_storage_mapper_test.exs
@@ -1,0 +1,48 @@
+defmodule AlertProcessor.Subscription.BikeStorageMapperTest do
+  use AlertProcessor.DataCase
+  import AlertProcessor.Factory
+  alias AlertProcessor.Subscription.BikeStorageMapper
+  alias AlertProcessor.Model.InformedEntity
+
+  @params %{
+    "stops" => ["place-north", "place-sstat"],
+    "relevant_days" => ["weekday"]
+  }
+
+  describe "bike_storage_area" do
+    test "creates expected entities" do
+      {:ok, [{_subscription, informed_entities}]} = BikeStorageMapper.map_subscriptions(@params)
+      north_station_entities_count =
+        Enum.count(informed_entities, fn(informed_entity) ->
+          match?(%InformedEntity{facility_type: :bike_storage, stop: "place-north", activities: ["STORE_BIKE"]}, informed_entity)
+        end)
+      assert north_station_entities_count == 1
+
+      south_station_entities_count =
+        Enum.count(informed_entities, fn(informed_entity) ->
+          match?(%InformedEntity{facility_type: :bike_storage, stop: "place-sstat", activities: ["STORE_BIKE"]}, informed_entity)
+        end)
+      assert south_station_entities_count == 1
+    end
+  end
+
+  describe "build_subscription_transaction" do
+    @params %{
+      "stops" => ["place-north", "place-sstat"],
+      "relevant_days" => ["weekday"]
+    }
+
+    test "it builds a multi struct to persist subscriptions and informed_entities" do
+      user = insert(:user)
+      {:ok, subscription_infos} = BikeStorageMapper.map_subscriptions(@params)
+      multi = BikeStorageMapper.build_subscription_transaction(subscription_infos, user, user.id)
+      result = Ecto.Multi.to_list(multi)
+
+      assert {{:subscription, 0}, {:run, function}} = List.first(result)
+      assert {{:new_informed_entity, 0, 0}, {:run, _}} = Enum.at(result, 1)
+
+      {:ok, %{model: subscription}} = function.(nil)
+      assert subscription.id != nil
+    end
+  end
+end

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -169,8 +169,22 @@ defmodule AlertProcessor.Factory do
 
   def parking_subscription_entities() do
     [
-      %InformedEntity{route_type: 4, facility_type: :elevator, route: "Green"},
-      %InformedEntity{route_type: 4, facility_type: :escalator, stop: "place-nqncy"}
+      %InformedEntity{route_type: 4, facility_type: :parking_area, route: "Green"},
+      %InformedEntity{route_type: 4, facility_type: :parking_area, stop: "place-nqncy"}
+    ]
+  end
+
+  def bike_storage_subscription(%Subscription{} = subscription) do
+    %{subscription |
+      alert_priority_type: :low,
+      type: :amenity
+     }
+  end
+
+  def bike_storage_subscription_entities() do
+    [
+      %InformedEntity{route_type: 4, facility_type: :bike_storage, route: "Green"},
+      %InformedEntity{route_type: 4, facility_type: :bike_storage, stop: "place-nqncy"}
     ]
   end
 

--- a/apps/concierge_site/lib/controllers/bike_storage_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/bike_storage_subscription_controller.ex
@@ -1,0 +1,121 @@
+defmodule ConciergeSite.BikeStorageSubscriptionController do
+  use ConciergeSite.Web, :controller
+  use Guardian.Phoenix.Controller
+  alias ConciergeSite.Subscriptions.{BikeStorageParams}
+  alias ConciergeSite.Helpers.MultiSelectHelper
+  alias AlertProcessor.{ServiceInfoCache,
+    Subscription.BikeStorageMapper, Model.Subscription, Model.User}
+
+  def new(conn, _params, _user, _claims) do
+    render_new_page(conn)
+  end
+
+  def create(conn, %{"subscription" => sub_params}, user, {:ok, claims}) do
+    sub_params = Map.merge(sub_params, %{"user_id" => user.id})
+    with :ok <- BikeStorageParams.validate_info_params(sub_params),
+      {:ok, subscription_infos} <- BikeStorageMapper.map_subscriptions(sub_params),
+      multi <- BikeStorageMapper.build_subscription_transaction(subscription_infos, user, Map.get(claims, "imp", user.id)),
+      :ok <- Subscription.set_versioned_subscription(multi) do
+        redirect(conn, to: subscription_path(conn, :index))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> render_new_page()
+      _ ->
+        conn
+        |> put_flash(:error, "there was an error saving the subscription. Please try again.")
+        |> render_new_page()
+    end
+  end
+
+  def edit(conn, %{"id" => id}, user, _) do
+    with {:ok, subway_stations} <- ServiceInfoCache.get_subway_full_routes(),
+      {:ok, cr_stations} <- ServiceInfoCache.get_commuter_rail_info() do
+        station_select_options = MultiSelectHelper.station_options(cr_stations, subway_stations)
+        subscription = Subscription.one_for_user!(id, user.id, true)
+        changeset = Subscription.update_changeset(subscription)
+
+        render conn,
+          "edit.html",
+          subscription: subscription,
+          changeset: changeset,
+          station_select_options: station_select_options,
+          selected_options: selected_options(subscription)
+    else
+      _error ->
+        conn
+        |> put_flash(:error, "There was an error. Please try again.")
+        |> redirect(to: subscription_path(conn, :index))
+    end
+  end
+
+  def update(conn, %{"id" => id, "subscription" => sub_params}, user, {:ok, claims}) do
+    with subscription <- Subscription.one_for_user!(id, user.id, true),
+      :ok <- BikeStorageParams.validate_info_params(sub_params),
+      {:ok, subscription_infos} <- BikeStorageMapper.map_subscriptions(sub_params),
+      multi <- BikeStorageMapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
+      :ok <- Subscription.set_versioned_subscription(multi) do
+        :ok = User.clear_holding_queue_for_user_id(user.id)
+        redirect(conn, to: subscription_path(conn, :index))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> redirect(to: bike_storage_subscription_path(conn, :edit, id))
+      _ ->
+        conn
+        |> put_flash(:error, "There was an error saving the subscription. Please try again.")
+        |> redirect(to: bike_storage_subscription_path(conn, :edit, id))
+    end
+  end
+
+  defp render_new_page(conn) do
+    with sub_params <- Map.get(conn.params, "subscription", %{}),
+      {:ok, subway_stations} <- ServiceInfoCache.get_subway_full_routes(),
+      {:ok, cr_stations} <- ServiceInfoCache.get_commuter_rail_info() do
+
+      station_select_options = MultiSelectHelper.station_options(cr_stations, subway_stations)
+
+      selected_options = %{
+        relevant_days: sub_params |> Map.get("relevant_days", []) |> Enum.reject(&empty_or_nil?/1),
+        stations: sub_params |> Map.get("stops", []) |> Enum.map(&fetch_stop/1) |> Enum.reject(&empty_or_nil?/1)
+      }
+
+      render conn, :new,
+        station_select_options: station_select_options,
+        selected_options: selected_options
+    else
+      _error ->
+        conn
+        |> put_flash(:error, "There was an error fetching station data. Please try again.")
+        |> redirect(to: subscription_path(conn, :new))
+    end
+  end
+
+  defp selected_options(%Subscription{informed_entities: ies, relevant_days: relevant_days}) do
+    ies
+    |> Enum.reduce(
+      %{relevant_days: MapSet.new, stations: MapSet.new},
+      fn(ie, acc) ->
+        if ie.stop do
+          {:ok, stop} = ServiceInfoCache.get_stop(ie.stop)
+          stations = MapSet.put(acc.stations, stop)
+          Map.put(acc, :stations, stations)
+        else
+          acc
+        end
+      end)
+      |> Map.put(:relevant_days, relevant_days |> Enum.reject(&empty_or_nil?/1) |> MapSet.new(&to_string/1))
+      |> Map.new(fn({k, v}) -> {k, MapSet.to_list(v)} end)
+  end
+
+  defp empty_or_nil?(nil), do: true
+  defp empty_or_nil?(""), do: true
+  defp empty_or_nil?(_), do: false
+
+  defp fetch_stop(stop_id) do
+    {:ok, stop} = ServiceInfoCache.get_stop(stop_id)
+    stop
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -100,6 +100,8 @@ defmodule ConciergeSite.Router do
       only: [:new, :create, :edit, :update]
     resources "/parking", ParkingSubscriptionController,
       only: [:new, :create, :edit, :update]
+    resources "/bike_storage", BikeStorageSubscriptionController,
+      only: [:new, :create, :edit, :update]
   end
 
   scope "/admin", ConciergeSite, as: :admin do

--- a/apps/concierge_site/lib/subscriptions/bike_storage_params.ex
+++ b/apps/concierge_site/lib/subscriptions/bike_storage_params.ex
@@ -1,0 +1,49 @@
+defmodule ConciergeSite.Subscriptions.BikeStorageParams do
+  @moduledoc false
+  import ConciergeSite.Subscriptions.ParamsValidator
+
+  @spec validate_info_params(map) :: :ok | {:error, String.t}
+  def validate_info_params(params) do
+    {_, errors} =
+      {params, []}
+      |> remove_empty_strings()
+      |> validate_at_least_one_travel_day()
+      |> validate_at_least_one_station()
+
+    if errors == [] do
+      :ok
+    else
+      {:error, full_error_message_iodata(errors)}
+    end
+  end
+
+  defp validate_at_least_one_station({params, errors}) do
+    if missing_stops?(params) do
+      {params, ["At least one station must be selected." | errors]}
+    else
+      {params, errors}
+    end
+  end
+
+  defp missing_stops?(%{"stops" => [stop | _]}) when not is_nil(stop), do: false
+  defp missing_stops?(_), do: true
+
+  defp validate_at_least_one_travel_day({params, errors}) do
+    if Enum.empty?(params["relevant_days"]) do
+      {params, ["At least one travel day must be selected." | errors]}
+    else
+      {params, errors}
+    end
+  end
+
+  defp remove_empty_strings({params, errors}) do
+    clean_params = Enum.reduce(params, %{}, fn({k, v}, acc) ->
+      if is_list(v) do
+        Map.put(acc, k, Enum.reject(v, & &1 == ""))
+      else
+        Map.put(acc, k, v)
+      end
+    end)
+    {clean_params, errors}
+  end
+end

--- a/apps/concierge_site/lib/templates/bike_storage_subscription/_bike_storage_form.html.eex
+++ b/apps/concierge_site/lib/templates/bike_storage_subscription/_bike_storage_form.html.eex
@@ -1,0 +1,13 @@
+<div class="bike_storage-subscription-form-section">
+  <%= render "_station_select.html",
+          form: @f,
+          select_options: @station_select_options,
+          selected_station_options: Map.get(@selected_options, :stations, []) %>
+
+  <div class="selected-entity-list"></div>
+
+  <%= render "_travel_days_checkboxes.html",
+              form: @f,
+              checked: Map.get(@selected_options, :relevant_days, []),
+              action: @action %>
+</div>

--- a/apps/concierge_site/lib/templates/bike_storage_subscription/_station_select.html.eex
+++ b/apps/concierge_site/lib/templates/bike_storage_subscription/_station_select.html.eex
@@ -1,0 +1,13 @@
+<div class="form-group select-entity">
+  <label for="station" class="entity-input-label form-label">What stations do you use?</label>
+  <div class="form-sub-label entity-select-sub-label">Enter as many stations as you would like.</div>
+  <div class="entity-select-group">
+    <%= multiple_select @form,
+              :stops,
+              @select_options,
+              selected: Enum.map(@selected_station_options, & elem(&1, 1)),
+              class: "subscription-select multi-select no-js",
+              prompt: "Enter a station",
+              data: [entity_type: "station"] %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/bike_storage_subscription/_travel_days_checkboxes.html.eex
+++ b/apps/concierge_site/lib/templates/bike_storage_subscription/_travel_days_checkboxes.html.eex
@@ -1,0 +1,37 @@
+<div class="form-group select-days">
+  <div class="form-label edit-form-label">What days do you travel?</div>
+  <%= error_tag @form, :relevant_days %>
+  <div class="<%= @action %>-subscription-section-container">
+    <label>
+      <%= checkbox @form,
+                  :weekday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "weekday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "weekday") %>
+      Weekdays
+    </label>
+    <label>
+      <%= checkbox @form,
+                  :saturday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "saturday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "saturday") %>
+      Saturday
+    </label>
+    <label>
+      <%= checkbox @form,
+                  :sunday,
+                  name: "subscription[relevant_days][]",
+                  checked_value: "sunday",
+                  unchecked_value: nil,
+                  class: "subscription-day-checkbox",
+                  checked: Enum.member?(@checked, "sunday") %>
+      Sunday
+    </label>
+  </div>
+</div>
+

--- a/apps/concierge_site/lib/templates/bike_storage_subscription/edit.html.eex
+++ b/apps/concierge_site/lib/templates/bike_storage_subscription/edit.html.eex
@@ -1,0 +1,18 @@
+<%= render ConciergeSite.SubscriptionView,
+           "_edit_subscription_header.html",
+           title: "Subscribe to station bike storage alerts",
+           subscription: @subscription %>
+
+<%= flash_error(@conn) %>
+
+<div class="subscription-step bike_storage">
+  <div class="enter-trip-info">
+    <%= form_for @changeset, bike_storage_subscription_path(@conn, :update, @subscription), [class: "single-submit-form trip-info-form multi-select-form bike_storage", as: :subscription, method: :patch], fn f -> %>
+      <%= render "_bike_storage_form.html", f: f, station_select_options: @station_select_options, selected_options: @selected_options, action: "edit" %>
+
+      <div class="trip-info-footer">
+        <%= submit "Update Subscription", class: "btn btn-primary btn-subscription-next" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/bike_storage_subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/bike_storage_subscription/new.html.eex
@@ -1,0 +1,13 @@
+<h1>Create New Subscription</h1>
+<%= flash_error(@conn) %>
+<div class="subscription-step bike_storage">
+  <div class="enter-trip-info">
+    <%= form_for @conn, bike_storage_subscription_path(@conn, :create), [class: "single-submit-form trip-info-form multi-select-form bike_storage", as: :subscription], fn f -> %>
+      <%= render "_bike_storage_form.html", f: f, station_select_options: @station_select_options, selected_options: @selected_options, action: "new" %>
+
+      <div class="trip-info-footer">
+        <%= submit "Create Subscription", class: "btn btn-primary btn-bike_storage-submit" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/subscription/_bike_storage_subscription_info.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_bike_storage_subscription_info.html.eex
@@ -1,0 +1,31 @@
+<%= unless Enum.empty?(@subscriptions) do %>
+  <div class="bike_storage-subscriptions">
+    <%= for subscription <- @subscriptions do %>
+      <h6><%= route_header(subscription) %></h6>
+      <%= if @render_links do %>
+        <%= link(to: bike_storage_subscription_path(@conn, :edit, subscription), class: "subscription-link") do %>
+          <div class="subscription">
+            <div class="subscription-icon-container">
+              <div class="bike_storage-icon subscription-icon">
+                <img src="<%= static_url(@conn, "/images/bike_storage.svg") %>" />
+              </div>
+            </div>
+            <%= subscription_info(subscription) %>
+            <div class="subscription-edit-link">
+              <i class="fa fa-chevron-right" aria-hidden="true"></i>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+         <div class="subscription">
+          <div class="subscription-icon-container">
+            <div class="bike_storage-icon subscription-icon">
+              <img src="<%= static_url(@conn, "/images/bike_storage.svg") %>" />
+            </div>
+          </div>
+          <%= subscription_info(subscription) %>
+         </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/templates/subscription/_subscriptions.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/_subscriptions.html.eex
@@ -6,3 +6,4 @@
   <%= render "_amenity_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:amenity], render_links: @render_links %>
   <%= render "_accessibility_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:accessibility], render_links: @render_links %>
   <%= render "_parking_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:parking], render_links: @render_links %>
+  <%= render "_bike_storage_subscription_info.html", conn: @conn, subscriptions: customer_subscription_map[:bike_storage], render_links: @render_links %>

--- a/apps/concierge_site/lib/templates/subscription/new.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/new.html.eex
@@ -53,7 +53,7 @@
               name: "Parking" %>
 
     <%= render "_service_option.html",
-              link_to: amenity_subscription_path(@conn, :new),
+              link_to: bike_storage_subscription_path(@conn, :new),
               icon_class: "bike-storage-icon",
               icon_src: static_url(@conn, "/images/bike_storage.svg"),
               name: "Bike Storage" %>

--- a/apps/concierge_site/lib/views/bike_storage_subscription_view.ex
+++ b/apps/concierge_site/lib/views/bike_storage_subscription_view.ex
@@ -1,0 +1,65 @@
+defmodule ConciergeSite.BikeStorageSubscriptionView do
+  use ConciergeSite.Web, :view
+  alias AlertProcessor.Model.Subscription
+  import ConciergeSite.SubscriptionHelper,
+    only: [relevant_days: 1]
+
+  @doc """
+  Returns string with ampersand separated list of facilty types for an bike_storage subscription
+  """
+  @spec bike_storage_facility_type(Subscription.t) :: String.t
+  def bike_storage_facility_type(subscription) do
+    subscription.informed_entities
+    |> Enum.map(&(&1.facility_type))
+    |> Enum.uniq
+    |> Enum.map(fn(bike_storage) ->
+      bike_storage
+      |> Atom.to_string()
+      |> String.replace("_", " ")
+      |> String.capitalize()
+    end)
+    |> Enum.sort
+    |> AlertProcessor.Helpers.StringHelper.and_join()
+  end
+
+  @doc """
+  Returns human readable description of bike_storage schedule
+  # of stations, which lines, and days of travel
+  Example: 2 stations + Green line, Weekdays
+  """
+  @spec bike_storage_schedule(Subscription.t) :: iolist
+  def bike_storage_schedule(subscription) do
+    entity_info = Enum.join(pretty_station_count(subscription) ++ lines(subscription), " + ")
+    [
+      entity_info,
+      " on ",
+      relevant_days(subscription)
+    ]
+  end
+
+  defp pretty_station_count(subscription) do
+    case count = number_of_stations(subscription) do
+      0 -> []
+      1 -> ["1 station"]
+      _ -> ["#{count} stations"]
+    end
+  end
+
+  defp number_of_stations(subscription) do
+    subscription.informed_entities
+    |> Enum.filter(&(!is_nil(&1.stop)))
+    |> Enum.map(&(&1.stop))
+    |> Enum.uniq
+    |> length
+  end
+
+  defp lines(subscription) do
+    subscription.informed_entities
+    |> Enum.filter(&(!is_nil(&1.route)))
+    |> Enum.map(&("#{&1.route} Line"))
+    |> Enum.uniq
+    |> Enum.join(", ")
+    |> List.wrap()
+    |> Enum.filter(& String.length(&1) > 0)
+  end
+end

--- a/apps/concierge_site/test/feature/bike_storage_subscription_test.exs
+++ b/apps/concierge_site/test/feature/bike_storage_subscription_test.exs
@@ -14,11 +14,10 @@ defmodule ConciergeSite.BikeStorageSubscriptionTest do
     session
     |> log_in(user)
     |> click(css("a", text: "Bike Storage"))
-    |> click(checkbox("Bike Storage"))
     |> fill_in(text_field("station"), with: "Alewife")
     |> click(checkbox("Weekdays"))
     |> click(button("Create Subscription"))
     |> assert_has(css(".header-text", text: "My Subscriptions"))
-    |> assert_has(css(".subscription-details", text: "Bike storage"))
+    |> assert_has(css(".subscription-route", text: "Bike Storage"))
   end
 end

--- a/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
@@ -1,0 +1,184 @@
+defmodule ConciergeSite.BikeStorageSubscriptionControllerTest do
+  use ConciergeSite.ConnCase
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  alias AlertProcessor.{HoldingQueue, Model.Subscription, Model.InformedEntity, Repo}
+
+  describe "authorized" do
+    setup :login_user
+
+    test "GET /subscriptions/bike_storage/new", %{conn: conn}  do
+      conn = conn
+      |> get("/subscriptions/bike_storage/new")
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+    end
+
+    test "POST /subscriptions/bike_storage with valid params", %{conn: conn} do
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => ["saturday"],
+      }}
+
+      conn = conn
+      |> post("/subscriptions/bike_storage", params)
+
+      subscriptions = Repo.all(Subscription)
+
+      assert html_response(conn, 302) =~ "my-subscriptions"
+      assert length(subscriptions) == 1
+    end
+
+    test "POST /subscriptions/bike_storage with invalid params", %{conn: conn} do
+      params = %{"subscription" => %{
+        "relevant_days" => [],
+      }}
+
+      conn = conn
+      |> post("/subscriptions/bike_storage", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one station must be selected. At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+      assert expected_error == error
+    end
+
+    test "POST /subscriptions/bike_storage with invalid params with stations selected", %{conn: conn} do
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => [],
+      }}
+
+      conn = post(conn, "/subscriptions/bike_storage", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 200) =~ "Create New Subscription"
+      assert html_response(conn, 200) =~ "North Quincy"
+      assert html_response(conn, 200) =~ "Forest Hills"
+      assert expected_error == error
+    end
+
+    test "GET /subscriptions/bike_storage/:id/edit", %{conn: conn, user: user} do
+      bike_storage_subscription_entities =     [
+        %InformedEntity{route_type: 4, facility_type: :elevator, route: "Green"},
+        %InformedEntity{route_type: 4, facility_type: :elevator, stop: "place-nqncy"}
+      ]
+
+      sub = subscription_factory()
+      |> Map.put(:informed_entities, bike_storage_subscription_entities)
+      |> bike_storage_subscription()
+      |> weekday_subscription()
+      |> Map.merge(%{user: user})
+      |> insert()
+
+      use_cassette "bike_storage_update", clear_mock: true  do
+        conn = get(conn, bike_storage_subscription_path(conn, :edit, sub.id))
+        result = html_response(conn, 200)
+
+        weekday_checked? = result =~ "<input checked=\"checked\" class=\"subscription-day-checkbox\" id=\"subscription_weekday\" name=\"subscription[relevant_days][]\" type=\"checkbox\" value=\"weekday\">"
+        sunday_unchecked? = result =~ "<input class=\"subscription-day-checkbox\" id=\"subscription_sunday\" name=\"subscription[relevant_days][]\" type=\"checkbox\" value=\"sunday\">"
+
+        assert result =~ "Subscribe to station bike storage alerts"
+
+        assert weekday_checked?
+        assert sunday_unchecked?
+      end
+    end
+
+    test "PATCH /subscriptions/bike_storage/:id", %{conn: conn, user: user} do
+      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
+      :ok = HoldingQueue.enqueue(notification)
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, bike_storage_subscription_entities())
+        |> bike_storage_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => ["saturday"],
+      }}
+
+      use_cassette "bike_storage_update", clear_mock: true  do
+        conn = patch(conn, "/subscriptions/bike_storage/#{subscription.id}", params)
+        assert html_response(conn, 302) =~ "my-subscriptions"
+        assert :error = HoldingQueue.pop()
+      end
+    end
+
+    test "PATCH /subscriptions/bike_storage/:id with incomplete params", %{conn: conn, user: user} do
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, bike_storage_subscription_entities())
+        |> bike_storage_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => ["place-nqncy", "place-forhl"],
+        "relevant_days" => [],
+      }}
+
+      conn = patch(conn, "/subscriptions/bike_storage/#{subscription.id}", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 302) =~ "/subscriptions/bike_storage/#{subscription.id}/edit"
+      assert expected_error == error
+    end
+
+    test "PATCH /subscriptions/bike_storage/:id with empty params", %{conn: conn, user: user} do
+      subscription =
+        subscription_factory()
+        |> Map.put(:informed_entities, bike_storage_subscription_entities())
+        |> bike_storage_subscription()
+        |> weekday_subscription()
+        |> Map.merge(%{user: user})
+        |> PaperTrail.insert!()
+
+      params = %{"subscription" => %{
+        "stops" => [],
+        "relevant_days" => [],
+      }}
+
+      conn = patch(conn, "/subscriptions/bike_storage/#{subscription.id}", params)
+
+      expected_error = "Please correct the following errors to proceed: At least one station must be selected. At least one travel day must be selected."
+      error =
+        conn
+        |> get_flash("error")
+        |> IO.iodata_to_binary()
+
+      assert html_response(conn, 302) =~ "/subscriptions/bike_storage/#{subscription.id}/edit"
+      assert expected_error == error
+    end
+  end
+
+  describe "unauthorized" do
+    test "GET /subscriptions/bike_storage/new", %{conn: conn} do
+      conn = get(conn, "/subscriptions/bike_storage/new")
+      assert html_response(conn, 302) =~ "/login"
+    end
+  end
+
+  defp login_user(%{conn: c}) do
+    user = insert(:user)
+    conn = guardian_login(user, c)
+    {:ok, [conn: conn, user: user]}
+  end
+end

--- a/apps/concierge_site/test/web/subscriptions/bike_storage_params_test.exs
+++ b/apps/concierge_site/test/web/subscriptions/bike_storage_params_test.exs
@@ -1,0 +1,37 @@
+defmodule ConciergeSite.Subscriptions.BikeStorageParamsTest do
+  use ExUnit.Case
+  alias ConciergeSite.Subscriptions.BikeStorageParams
+
+  @valid_params %{
+    "stops" => ["place-north"],
+    "relevant_days" => ["weekday"]
+  }
+
+  describe "validate_info_params/1" do
+    test "with valid params" do
+      assert BikeStorageParams.validate_info_params(@valid_params) == :ok
+    end
+
+    test "handles empty strings" do
+      params = Map.put(@valid_params, "relevant_days", ["", "", ""])
+
+      assert {:error, _} = BikeStorageParams.validate_info_params(params)
+    end
+
+    test "errors if no travel days selected" do
+      params = Map.put(@valid_params, "relevant_days", [])
+      messages = ["Please correct the following errors to proceed: ", ["At least one travel day must be selected."]]
+
+      assert BikeStorageParams.validate_info_params(params) == {:error, messages}
+    end
+
+    test "errors if no stations AND no subway lines selected" do
+      params =
+        @valid_params
+        |> Map.put("stops", "")
+      messages = ["Please correct the following errors to proceed: ", ["At least one station must be selected."]]
+
+      assert BikeStorageParams.validate_info_params(params) == {:error, messages}
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/bike_storage_subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/bike_storage_subscription_view_test.exs
@@ -1,0 +1,85 @@
+defmodule ConciergeSite.BikeStorageSubscriptionViewTest do
+  use ExUnit.Case
+  alias ConciergeSite.BikeStorageSubscriptionView
+  alias AlertProcessor.Model.{Subscription, InformedEntity}
+
+  @informed_entities [
+    %InformedEntity{
+      facility_type: :escalator,
+      stop: "place-nqncy"
+    },
+    %InformedEntity{
+      facility_type: :elevator,
+      route: "Green"
+    }
+  ]
+
+  @subscription %Subscription{
+    informed_entities: @informed_entities,
+    relevant_days: [:saturday, :weekday]
+  }
+
+  describe "bike_storage_facility_type/1" do
+    test "it returns and separated list of bike_storage" do
+      result =
+        @subscription
+        |> BikeStorageSubscriptionView.bike_storage_facility_type()
+        |> IO.iodata_to_binary
+      assert result == "Elevator and Escalator"
+    end
+  end
+
+  describe "bike_storage_schedule/1" do
+    test "it returns the schedule details" do
+      result =
+        @subscription
+        |> BikeStorageSubscriptionView.bike_storage_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "1 station + Green Line on Saturdays, Weekdays"
+    end
+
+    test "pluralizes stops" do
+      informed_entity = %InformedEntity{
+        facility_type: :escalator,
+        stop: "place-harvard"
+      }
+      ies = @informed_entities ++ [informed_entity]
+      sub = Map.put(@subscription, :informed_entities, ies)
+      result =
+        sub
+        |> BikeStorageSubscriptionView.bike_storage_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "2 stations + Green Line on Saturdays, Weekdays"
+    end
+
+    test "it omits text about stations if there are none" do
+      subscription = %Subscription{
+        informed_entities: [%InformedEntity{facility_type: :elevator, route: "Green"}],
+        relevant_days: [:saturday]
+      }
+
+      result =
+        subscription
+        |> BikeStorageSubscriptionView.bike_storage_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "Green Line on Saturdays"
+    end
+
+    test "it displays stops only properly" do
+      subscription = %Subscription{
+        informed_entities: [%InformedEntity{facility_type: :elevator, stop: "place-harvard"}],
+        relevant_days: [:saturday]
+      }
+
+      result =
+        subscription
+        |> BikeStorageSubscriptionView.bike_storage_schedule()
+        |> IO.iodata_to_binary
+
+      assert result == "1 station on Saturdays"
+    end
+  end
+end


### PR DESCRIPTION
* Copy amenities controllers, views, templates, etc. and use the copies as a basis for bike storage controller, views, and templates.
* Update text in the application to make sense with bike storage
* Update the tests

This is similar to https://github.com/mbta/alerts_concierge/pull/473 only with bike storage instead of parking. This finishes the user-facing amenities redesign, but there are two followup PRs after this one. One that removes the old amenities code and one that fixes the Codecov issues.

Screenshots:

<img width="1076" alt="screen shot 2017-12-12 at 08 22 40" src="https://user-images.githubusercontent.com/3039310/33887296-524999ae-df17-11e7-9ecf-95f42d89aa30.png">

---


<img width="1076" alt="screen shot 2017-12-12 at 08 22 48" src="https://user-images.githubusercontent.com/3039310/33887295-52346bd8-df17-11e7-8aae-aa83325c970e.png">

---

<img width="1076" alt="screen shot 2017-12-12 at 08 23 09" src="https://user-images.githubusercontent.com/3039310/33887294-521b0058-df17-11e7-89cf-64221fc03b2c.png">
