### PR TITLE
Refactor build_subscription_update_transaction

### DIFF
--- a/apps/alert_processor/lib/subscription/accessibility_mapper.ex
+++ b/apps/alert_processor/lib/subscription/accessibility_mapper.ex
@@ -5,59 +5,9 @@ defmodule AlertProcessor.Subscription.AccessibilityMapper do
   """
 
   import AlertProcessor.Subscription.Mapper, except: [map_timeframe: 1]
-  import Ecto.Query
-  alias Ecto.Multi
-  alias AlertProcessor.Repo
-  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+  alias AlertProcessor.Model.Subscription
 
   defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
-
-  @doc """
-  build_subscription_update_transaction/3 receives a the current subscription
-  and the update params and builds and Ecto.Multi transaction.
-
-  1. It updates the subscription data
-  2. It regenerates the informed entities for that subscription from the new data
-  """
-  def build_subscription_update_transaction(subscription, subscription_infos, originator) do
-    origin =
-      if subscription.user_id != User.wrap_id(originator).id do
-        "admin:update-subscription"
-      end
-    [{sub_changes, informed_entities}] = subscription_infos
-    params =
-      sub_changes
-      |> Map.put(:informed_entities, informed_entities)
-      |> Map.from_struct()
-
-    current_informed_entity_ids =
-      subscription.informed_entities
-      |> Enum.map(& &1.id)
-
-    query = from(ie in InformedEntity, where: ie.id in ^current_informed_entity_ids)
-    current_informed_entities = Repo.all(query)
-
-    multi = informed_entities
-    |> Enum.with_index()
-    |> Enum.reduce(Multi.new(), fn({ie, index}, acc) ->
-        ie_to_insert = Map.put(ie, :subscription_id, subscription.id)
-        Multi.run(acc, {:new_informed_entity, index}, fn _ ->
-          PaperTrail.insert(ie_to_insert, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-        end)
-      end)
-
-    current_informed_entities
-    |> Enum.with_index
-    |> Enum.reduce(multi, fn({ie, index}, acc) ->
-      Multi.run(acc, {:remove_current, index}, fn _ ->
-        PaperTrail.delete(ie, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-      end)
-    end)
-    |> Multi.run({:subscription}, fn _ ->
-      changeset = Subscription.update_changeset(subscription, params)
-      PaperTrail.update(changeset, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id}, origin: origin)
-    end)
-  end
 
   @doc """
   map_subscription/1 receives a map of accessibility subscription params and returns

--- a/apps/alert_processor/lib/subscription/bike_storage_mapper.ex
+++ b/apps/alert_processor/lib/subscription/bike_storage_mapper.ex
@@ -5,59 +5,9 @@ defmodule AlertProcessor.Subscription.BikeStorageMapper do
   """
 
   import AlertProcessor.Subscription.Mapper, except: [map_timeframe: 1]
-  import Ecto.Query
-  alias Ecto.Multi
-  alias AlertProcessor.Repo
-  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+  alias AlertProcessor.Model.Subscription
 
   defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
-
-  @doc """
-  build_subscription_update_transaction/3 receives a the current subscription
-  and the update params and builds and Ecto.Multi transaction.
-
-  1. It updates the subscription data
-  2. It regenerates the informed entities for that subscription from the new data
-  """
-  def build_subscription_update_transaction(subscription, subscription_infos, originator) do
-    origin =
-      if subscription.user_id != User.wrap_id(originator).id do
-        "admin:update-subscription"
-      end
-    [{sub_changes, informed_entities}] = subscription_infos
-    params =
-      sub_changes
-      |> Map.put(:informed_entities, informed_entities)
-      |> Map.from_struct()
-
-    current_informed_entity_ids =
-      subscription.informed_entities
-      |> Enum.map(& &1.id)
-
-    query = from(ie in InformedEntity, where: ie.id in ^current_informed_entity_ids)
-    current_informed_entities = Repo.all(query)
-
-    multi = informed_entities
-    |> Enum.with_index()
-    |> Enum.reduce(Multi.new(), fn({ie, index}, acc) ->
-        ie_to_insert = Map.put(ie, :subscription_id, subscription.id)
-        Multi.run(acc, {:new_informed_entity, index}, fn _ ->
-          PaperTrail.insert(ie_to_insert, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-        end)
-      end)
-
-    current_informed_entities
-    |> Enum.with_index
-    |> Enum.reduce(multi, fn({ie, index}, acc) ->
-      Multi.run(acc, {:remove_current, index}, fn _ ->
-        PaperTrail.delete(ie, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-      end)
-    end)
-    |> Multi.run({:subscription}, fn _ ->
-      changeset = Subscription.update_changeset(subscription, params)
-      PaperTrail.update(changeset, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id}, origin: origin)
-    end)
-  end
 
   @doc """
   map_subscription/1 receives a map of bike_storage subscription params and returns

--- a/apps/alert_processor/lib/subscription/parking_mapper.ex
+++ b/apps/alert_processor/lib/subscription/parking_mapper.ex
@@ -5,59 +5,9 @@ defmodule AlertProcessor.Subscription.ParkingMapper do
   """
 
   import AlertProcessor.Subscription.Mapper, except: [map_timeframe: 1]
-  import Ecto.Query
-  alias Ecto.Multi
-  alias AlertProcessor.Repo
-  alias AlertProcessor.Model.{InformedEntity, Subscription, User}
+  alias AlertProcessor.Model.Subscription
 
   defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
-
-  @doc """
-  build_subscription_update_transaction/3 receives a the current subscription
-  and the update params and builds and Ecto.Multi transaction.
-
-  1. It updates the subscription data
-  2. It regenerates the informed entities for that subscription from the new data
-  """
-  def build_subscription_update_transaction(subscription, subscription_infos, originator) do
-    origin =
-      if subscription.user_id != User.wrap_id(originator).id do
-        "admin:update-subscription"
-      end
-    [{sub_changes, informed_entities}] = subscription_infos
-    params =
-      sub_changes
-      |> Map.put(:informed_entities, informed_entities)
-      |> Map.from_struct()
-
-    current_informed_entity_ids =
-      subscription.informed_entities
-      |> Enum.map(& &1.id)
-
-    query = from(ie in InformedEntity, where: ie.id in ^current_informed_entity_ids)
-    current_informed_entities = Repo.all(query)
-
-    multi = informed_entities
-    |> Enum.with_index()
-    |> Enum.reduce(Multi.new(), fn({ie, index}, acc) ->
-        ie_to_insert = Map.put(ie, :subscription_id, subscription.id)
-        Multi.run(acc, {:new_informed_entity, index}, fn _ ->
-          PaperTrail.insert(ie_to_insert, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-        end)
-      end)
-
-    current_informed_entities
-    |> Enum.with_index
-    |> Enum.reduce(multi, fn({ie, index}, acc) ->
-      Multi.run(acc, {:remove_current, index}, fn _ ->
-        PaperTrail.delete(ie, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id})
-      end)
-    end)
-    |> Multi.run({:subscription}, fn _ ->
-      changeset = Subscription.update_changeset(subscription, params)
-      PaperTrail.update(changeset, originator: User.wrap_id(originator), meta: %{owner: subscription.user_id}, origin: origin)
-    end)
-  end
 
   @doc """
   map_subscription/1 receives a map of parking subscription params and returns

--- a/apps/alert_processor/test/alert_processor/subscription/bike_storage_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/bike_storage_mapper_test.exs
@@ -9,7 +9,7 @@ defmodule AlertProcessor.Subscription.BikeStorageMapperTest do
     "relevant_days" => ["weekday"]
   }
 
-  describe "bike_storage_area" do
+  describe "bike_storage" do
     test "creates expected entities" do
       {:ok, [{_subscription, informed_entities}]} = BikeStorageMapper.map_subscriptions(@params)
       north_station_entities_count =

--- a/apps/alert_processor/test/alert_processor/subscription/mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/mapper_test.exs
@@ -1,0 +1,33 @@
+defmodule AlertProcessor.Subscription.MapperTest do
+  use AlertProcessor.DataCase
+  import AlertProcessor.Factory
+  alias AlertProcessor.Subscription.{Mapper, BikeStorageMapper}
+  alias AlertProcessor.Model.{Subscription, InformedEntity}
+
+  @params %{
+    "stops" => ["place-north", "place-sstat"],
+    "relevant_days" => ["weekday"]
+  }
+
+  describe "build_subscription_update_transaction" do
+    test "it builds a multi struct to persist subscriptions and informed_entities" do
+      subscription = insert(:subscription, informed_entities: [%InformedEntity{stop: "place-north", facility_type: :bike_storage}])
+      user = insert(:user)
+      {:ok, subscription_infos} = BikeStorageMapper.map_subscriptions(@params)
+      multi = Mapper.build_subscription_update_transaction(subscription, subscription_infos, user.id)
+      result = Ecto.Multi.to_list(multi)
+
+      assert [{{:new_informed_entity, 0}, {:run, ie_fun}},
+        {{:new_informed_entity, 1}, {:run, _}},
+        {{:remove_current, 0}, {:run, remove_current_fun}},
+        {{:subscription}, {:run, sub_fun}}] = result
+
+      {:ok, %{model: %InformedEntity{} = ie}} = ie_fun.(nil)
+      assert ie.id != nil
+      {:ok, %{model: %InformedEntity{} = current}} = remove_current_fun.(nil)
+      assert current.id != nil
+      {:ok, %{model: %Subscription{} = sub}} = sub_fun.(nil)
+      assert sub.id == subscription.id
+    end
+  end
+end

--- a/apps/concierge_site/lib/controllers/accessibility_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/accessibility_subscription_controller.ex
@@ -3,8 +3,8 @@ defmodule ConciergeSite.AccessibilitySubscriptionController do
   use Guardian.Phoenix.Controller
   alias ConciergeSite.Subscriptions.{AccessibilityParams}
   alias ConciergeSite.Helpers.MultiSelectHelper
-  alias AlertProcessor.{ServiceInfoCache,
-    Subscription.AccessibilityMapper, Model.Subscription, Model.User}
+  alias AlertProcessor.{ServiceInfoCache, Subscription.AccessibilityMapper,
+    Subscription.Mapper, Model.Subscription, Model.User}
 
   def new(conn, _params, _user, _claims) do
     render_new_page(conn)
@@ -54,7 +54,7 @@ defmodule ConciergeSite.AccessibilitySubscriptionController do
     with subscription <- Subscription.one_for_user!(id, user.id, true),
       :ok <- AccessibilityParams.validate_info_params(sub_params),
       {:ok, subscription_infos} <- AccessibilityMapper.map_subscriptions(sub_params),
-      multi <- AccessibilityMapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
+      multi <- Mapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
       :ok <- Subscription.set_versioned_subscription(multi) do
         :ok = User.clear_holding_queue_for_user_id(user.id)
         redirect(conn, to: subscription_path(conn, :index))

--- a/apps/concierge_site/lib/controllers/bike_storage_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/bike_storage_subscription_controller.ex
@@ -3,8 +3,8 @@ defmodule ConciergeSite.BikeStorageSubscriptionController do
   use Guardian.Phoenix.Controller
   alias ConciergeSite.Subscriptions.{BikeStorageParams}
   alias ConciergeSite.Helpers.MultiSelectHelper
-  alias AlertProcessor.{ServiceInfoCache,
-    Subscription.BikeStorageMapper, Model.Subscription, Model.User}
+  alias AlertProcessor.{ServiceInfoCache, Subscription.BikeStorageMapper,
+    Subscription.Mapper, Model.Subscription, Model.User}
 
   def new(conn, _params, _user, _claims) do
     render_new_page(conn)
@@ -54,7 +54,7 @@ defmodule ConciergeSite.BikeStorageSubscriptionController do
     with subscription <- Subscription.one_for_user!(id, user.id, true),
       :ok <- BikeStorageParams.validate_info_params(sub_params),
       {:ok, subscription_infos} <- BikeStorageMapper.map_subscriptions(sub_params),
-      multi <- BikeStorageMapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
+      multi <- Mapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
       :ok <- Subscription.set_versioned_subscription(multi) do
         :ok = User.clear_holding_queue_for_user_id(user.id)
         redirect(conn, to: subscription_path(conn, :index))

--- a/apps/concierge_site/lib/controllers/parking_subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/parking_subscription_controller.ex
@@ -3,8 +3,8 @@ defmodule ConciergeSite.ParkingSubscriptionController do
   use Guardian.Phoenix.Controller
   alias ConciergeSite.Subscriptions.{ParkingParams}
   alias ConciergeSite.Helpers.MultiSelectHelper
-  alias AlertProcessor.{ServiceInfoCache,
-    Subscription.ParkingMapper, Model.Subscription, Model.User}
+  alias AlertProcessor.{ServiceInfoCache, Subscription.ParkingMapper,
+    Subscription.Mapper, Model.Subscription, Model.User}
 
   def new(conn, _params, _user, _claims) do
     render_new_page(conn)
@@ -54,7 +54,7 @@ defmodule ConciergeSite.ParkingSubscriptionController do
     with subscription <- Subscription.one_for_user!(id, user.id, true),
       :ok <- ParkingParams.validate_info_params(sub_params),
       {:ok, subscription_infos} <- ParkingMapper.map_subscriptions(sub_params),
-      multi <- ParkingMapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
+      multi <- Mapper.build_subscription_update_transaction(subscription, subscription_infos, Map.get(claims, "imp", user.id)),
       :ok <- Subscription.set_versioned_subscription(multi) do
         :ok = User.clear_holding_queue_for_user_id(user.id)
         redirect(conn, to: subscription_path(conn, :index))


### PR DESCRIPTION
Remove the function `build_subscription_update_transaction/3` from a bunch of different `*Mapper` modules and put it in a single place: the `Mapper` module. Also add a test for it. The DRYs up the code and should fix an issue where CodeCov wasn't recognizing test coverage because the controller tests are in a different application.

While doing this, I realized there are no other tests for `Mapper`, so I created a tech debt [ticket](https://app.asana.com/0/415342363785198/502793352397248/f) to fix that.