### PR TITLE
Feedback link in footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,4 @@ SMTP_PASSWORD=
 AWS_ACCESS_KEY=
 AWS_SECRET_KEY=
 HOST_URL=ec2-something.compute-1.amazonaws.com
+FEEDBACK_URL=http://mbtafeedback.com/

--- a/apps/concierge_site/assets/css/_colors.scss
+++ b/apps/concierge_site/assets/css/_colors.scss
@@ -1,5 +1,6 @@
 $brand-primary: #1c77c3;
 $brand-primary-lightest: #cee0f4;
+$brand-primary-light-contrast: #a1c6ed;
 $brand-danger: #d0021b;
 $brand-success: #428608;
 $brand-navy-dark: #071d2e;
@@ -16,6 +17,7 @@ $gunmetal: #494f5c;
 $steel: #788094;
 
 $link-color: $brand-primary;
+$link-color-dark-background: $brand-primary-light-contrast;
 $link-hover-color: darken($link-color, 15%);
 $secondary-link-color: $cerulean;
 $secondary-link-hover-color: $pale-blue;

--- a/apps/concierge_site/assets/css/_footer.scss
+++ b/apps/concierge_site/assets/css/_footer.scss
@@ -9,6 +9,17 @@
   color: white;
   text-align: center;
   position: relative;
-  top: 5rem;
+  top: 3rem;
   margin-bottom: 0;
+}
+
+.footer-link {
+  color: $link-color-dark-background;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $link-color-dark-background;
+    text-decoration: underline;
+  }
 }

--- a/apps/concierge_site/config/config.exs
+++ b/apps/concierge_site/config/config.exs
@@ -30,6 +30,7 @@ config :concierge_site, ConciergeSite.Dissemination.DummyMailer,
   deliver_later_strategy: ConciergeSite.Dissemination.DeliverLaterStrategy
 
 config :concierge_site, send_from_email: {:system, "SENDER_EMAIL_ADDRESS", "alert@mbta.com"}
+config :concierge_site, feedback_url: {:system, "FEEDBACK_URL", nil}
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/apps/concierge_site/lib/plugs/feedback_plug.ex
+++ b/apps/concierge_site/lib/plugs/feedback_plug.ex
@@ -1,0 +1,25 @@
+defmodule ConciergeSite.Plugs.FeedbackPlug do
+  @moduledoc """
+  Plug to get the feedback link from the config and put it in conn so that it's
+  available later in the pipeline
+  """
+
+  import Plug.Conn
+  alias AlertProcessor.Helpers.ConfigHelper
+
+  @behaviour Plug
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    assign(conn, :feedback_url, feedback_url())
+  end
+
+  defp feedback_url do
+    case ConfigHelper.get_string(:feedback_url, :concierge_site) do
+      "" -> nil
+      nil -> nil
+      url -> url
+    end
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -8,6 +8,7 @@ defmodule ConciergeSite.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug ConciergeSite.Plugs.Authorized
+    plug ConciergeSite.Plugs.FeedbackPlug
   end
 
   pipeline :browser_auth do

--- a/apps/concierge_site/lib/templates/layout/app.html.eex
+++ b/apps/concierge_site/lib/templates/layout/app.html.eex
@@ -53,6 +53,9 @@
     </div>
     <footer class="footer">
       <p>&copy; Massachusetts Bay Transportation Authority, all rights reserved.</p>
+      <%= if @feedback_url do %>
+        <p><a href="<%= @feedback_url %>" target="_blank" class="footer-link">Send us your comments or questions</a></p>
+      <% end %>
     </footer>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>

--- a/apps/concierge_site/test/feature/feedback_test.exs
+++ b/apps/concierge_site/test/feature/feedback_test.exs
@@ -1,0 +1,11 @@
+defmodule ConciergeSite.FeedbackTest do
+  use ConciergeSite.FeatureCase, async: true
+
+  import Wallaby.Query, only: [xpath: 1]
+
+  test "leaving feedback", %{session: session} do
+    session
+    |> visit("/")
+    |> assert_has(xpath("//a[text()='Send us your comments or questions' and @href='http://mbtafeedback.com/']"))
+  end
+end

--- a/apps/concierge_site/test/web/plugs/feedback_plug_test.exs
+++ b/apps/concierge_site/test/web/plugs/feedback_plug_test.exs
@@ -1,0 +1,15 @@
+defmodule ConciergeSite.FeedbackPlugTest do
+  use ConciergeSite.ConnCase, async: true
+  alias ConciergeSite.Plugs.FeedbackPlug
+
+  test "init/1 returns what it's given" do
+    assert FeedbackPlug.init("test") == "test"
+  end
+
+  test "adds feedback url to assigns" do
+    conn = build_conn()
+    |> FeedbackPlug.call(%{})
+
+    assert conn.assigns.feedback_url == "http://mbtafeedback.com/"
+  end
+end


### PR DESCRIPTION
Add a feedback link to the footer. The content is taken from mbta.com and the link is configurable as an environment variable. If it is blank or doesn't exist, the link won't show up at all.

<img width="649" alt="screen shot 2017-12-14 at 15 28 20" src="https://user-images.githubusercontent.com/3039310/34012896-7d9c8558-e0e3-11e7-9382-e4cff7f3e56c.png">
