### PR TITLE
Feedback URL in email footer

### DIFF
--- a/apps/concierge_site/lib/dissemination/digest_email.ex
+++ b/apps/concierge_site/lib/dissemination/digest_email.ex
@@ -13,23 +13,24 @@ defmodule ConciergeSite.Dissemination.DigestEmail do
     :def,
     :html_email,
     Path.join(@template_dir, "digest.html.eex"),
-    [:digest_date_groups, :unsubscribe_url, :manage_subscriptions_url])
+    [:digest_date_groups, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
   EEx.function_from_file(
     :def,
     :text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates digest.txt.eex)),
-    [:digest_date_groups, :unsubscribe_url])
+    [:digest_date_groups, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
 
   @doc "digest_email/1 takes a digest and builds a message to a user"
   @spec digest_email(DigestMessage.t) :: Elixir.Bamboo.Email.t
   def digest_email(digest_message) do
     unsubscribe_url = MailHelper.unsubscribe_url(digest_message.user)
     manage_subscriptions_url = MailHelper.manage_subscriptions_url(digest_message.user)
+    feedback_url = MailHelper.feedback_url()
     base_email()
     |> to(digest_message.user.email)
     |> subject("MBTA Alerts Digest")
-    |> html_body(html_email(digest_message.body, unsubscribe_url, manage_subscriptions_url))
-    |> text_body(text_email(digest_message.body, unsubscribe_url))
+    |> html_body(html_email(digest_message.body, unsubscribe_url, manage_subscriptions_url, feedback_url))
+    |> text_body(text_email(digest_message.body, unsubscribe_url, manage_subscriptions_url, feedback_url))
   end
 
   @spec base_email() :: Elixir.Bamboo.Email.t

--- a/apps/concierge_site/lib/dissemination/email.ex
+++ b/apps/concierge_site/lib/dissemination/email.ex
@@ -12,21 +12,22 @@ defmodule ConciergeSite.Dissemination.Email do
     :def,
     :password_reset_html_email,
     Path.join(@template_dir, "password_reset.html.eex"),
-    [:password_reset_id, :unsubscribe_url, :manage_subscriptions_url])
+    [:password_reset_id, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
   EEx.function_from_file(
     :def,
     :password_reset_text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates password_reset.txt.eex)),
-    [:password_reset_id, :unsubscribe_url])
+    [:password_reset_id, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
 
   def password_reset_email(user, password_reset) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
     manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    feedback_url = MailHelper.feedback_url()
     base_email()
     |> to(user.email)
     |> subject("Reset Your MBTA Alerts Password")
-    |> html_body(password_reset_html_email(password_reset.id, unsubscribe_url, manage_subscriptions_url))
-    |> text_body(password_reset_text_email(password_reset.id, unsubscribe_url))
+    |> html_body(password_reset_html_email(password_reset.id, unsubscribe_url, manage_subscriptions_url, feedback_url))
+    |> text_body(password_reset_text_email(password_reset.id, unsubscribe_url, manage_subscriptions_url, feedback_url))
   end
 
   EEx.function_from_file(
@@ -52,43 +53,46 @@ defmodule ConciergeSite.Dissemination.Email do
     :def,
     :confirmation_html_email,
     Path.join(@template_dir, "confirmation.html.eex"),
-    [:unsubscribe_url, :disable_account_url, :manage_subscriptions_url])
+    [:unsubscribe_url, :disable_account_url, :manage_subscriptions_url, :feedback_url])
   EEx.function_from_file(
     :def,
     :confirmation_text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates confirmation.txt.eex)),
-    [:unsubscribe_url, :disable_account_url])
+    [:unsubscribe_url, :disable_account_url, :manage_subscriptions_url, :feedback_url])
 
   def confirmation_email(user) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
     disable_account_url = MailHelper.disable_account_url(user)
     manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    feedback_url = MailHelper.feedback_url()
     base_email()
     |> to(user.email)
     |> subject("MBTA Alerts Account Confirmation")
-    |> html_body(confirmation_html_email(unsubscribe_url, disable_account_url, manage_subscriptions_url))
-    |> text_body(confirmation_text_email(unsubscribe_url, disable_account_url))
+    |> html_body(confirmation_html_email(unsubscribe_url, disable_account_url, manage_subscriptions_url, feedback_url))
+    |> text_body(confirmation_text_email(unsubscribe_url, disable_account_url, manage_subscriptions_url, feedback_url))
   end
 
   EEx.function_from_file(
     :def,
     :targeted_notification_html_email,
     Path.join(@template_dir, "targeted_notification.html.eex"),
-    [:subject, :body, :manage_subscriptions_url])
+    [:subject, :body, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
   EEx.function_from_file(
     :def,
     :targeted_notification_text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates targeted_notification.txt.eex)),
-    [:body])
+    [:subject, :body, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
 
   def targeted_notification_email(user, subject, body) do
+    unsubscribe_url = MailHelper.unsubscribe_url(user)
     manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    feedback_url = MailHelper.feedback_url()
 
     base_email()
     |> to(user.email)
     |> subject(subject)
-    |> html_body(targeted_notification_html_email(subject, body, manage_subscriptions_url))
-    |> text_body(targeted_notification_text_email(body))
+    |> html_body(targeted_notification_html_email(subject, body, unsubscribe_url, manage_subscriptions_url, feedback_url))
+    |> text_body(targeted_notification_text_email(subject, body, unsubscribe_url, manage_subscriptions_url, feedback_url))
   end
 
   defp base_email do

--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -14,25 +14,26 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
     :def,
     :html_email,
     Path.join(@template_dir, "notification.html.eex"),
-    [:notification, :unsubscribe_url, :manage_subscriptions_url])
+    [:notification, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
   EEx.function_from_file(
     :def,
     :text_email,
     Path.join(~w(#{System.cwd!} lib mail_templates notification.txt.eex)),
-    [:notification, :unsubscribe_url])
+    [:notification, :unsubscribe_url, :manage_subscriptions_url, :feedback_url])
 
   @doc "notification_email/1 takes a notification and builds an email to be sent to user."
   @spec notification_email(Notification.t) :: Elixir.Bamboo.Email.t
   def notification_email(%Notification{user: user} = notification) do
     unsubscribe_url = MailHelper.unsubscribe_url(user)
     manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    feedback_url = MailHelper.feedback_url()
     notification_email_subject = email_subject(notification)
 
     base_email()
     |> to(user.email)
     |> subject(notification_email_subject)
-    |> html_body(html_email(notification, unsubscribe_url, manage_subscriptions_url))
-    |> text_body(text_email(notification, unsubscribe_url))
+    |> html_body(html_email(notification, unsubscribe_url, manage_subscriptions_url, feedback_url))
+    |> text_body(text_email(notification, unsubscribe_url, manage_subscriptions_url, feedback_url))
   end
 
   @spec base_email() :: Elixir.Bamboo.Email.t

--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -9,18 +9,26 @@ defmodule ConciergeSite.Helpers.MailHelper do
   alias AlertProcessor.Model.{Alert, InformedEntity}
   alias ConciergeSite.Auth.Token
   alias ConciergeSite.Router.Helpers
+  alias AlertProcessor.Helpers.ConfigHelper
   require EEx
 
   EEx.function_from_file(
     :def,
-    :footer,
+    :html_footer,
     Path.join(@template_dir, "_footer.html.eex"),
-    [:unsubscribe_url, :manage_subscriptions_url]
+    [:unsubscribe_url, :manage_subscriptions_url, :feedback_url]
   )
 
   EEx.function_from_file(
     :def,
-    :header,
+    :text_footer,
+    Path.join(@template_dir, "_footer.txt.eex"),
+    [:unsubscribe_url, :manage_subscriptions_url, :feedback_url]
+  )
+
+  EEx.function_from_file(
+    :def,
+    :html_header,
     Path.join(@template_dir, "_header.html.eex"),
     []
   )
@@ -142,5 +150,13 @@ defmodule ConciergeSite.Helpers.MailHelper do
   def manage_subscriptions_url(user) do
     {:ok, token, _permissions} = Token.issue(user, [:manage_subscriptions], {30, :days})
     Helpers.subscription_url(ConciergeSite.Endpoint, :index, token: token)
+  end
+
+  def feedback_url do
+    case ConfigHelper.get_string(:feedback_url, :concierge_site) do
+      "" -> nil
+      nil -> nil
+      url -> url
+    end
   end
 end

--- a/apps/concierge_site/lib/mail_templates/_footer.html.eex
+++ b/apps/concierge_site/lib/mail_templates/_footer.html.eex
@@ -8,12 +8,16 @@
       <td style="border-collapse: collapse;">
         <a class="footer-link" href="<%= unsubscribe_url %>" style="font-size: .75rem; line-height: 1.6; text-align: center; color: #67a0d1; text-decoration: none;">Unsubscribe</a>
       </td>
-      <td class="footer-link-separator" style="border-collapse: collapse; width: 10px; height: 10px;">
-        <div class="footer-link-separator-bullet" style="height: 5px; width: 5px; border-radius: 100%; background-color: #ffffff;">
-      </div></td>
-      <td style="border-collapse: collapse;">
-        <a class="footer-link" href="https://t.mbta.com/customer-support" style="font-size: .75rem; line-height: 1.6; text-align: center; color: #67a0d1; text-decoration: none;">Feedback</a>
-      </td>
+
+      <%= if feedback_url do %>
+        <td class="footer-link-separator" style="border-collapse: collapse; width: 10px; height: 10px;">
+          <div class="footer-link-separator-bullet" style="height: 5px; width: 5px; border-radius: 100%; background-color: #ffffff;">
+        </div></td>
+        <td style="border-collapse: collapse;">
+          <a class="footer-link" href="<%= feedback_url %>" style="font-size: .75rem; line-height: 1.6; text-align: center; color: #67a0d1; text-decoration: none;">Feedback</a>
+        </td>
+      <% end %>
+
       <td class="footer-link-separator" style="border-collapse: collapse; width: 10px; height: 10px;">
         <div class="footer-link-separator-bullet" style="height: 5px; width: 5px; border-radius: 100%; background-color: #ffffff;">
       </div></td>

--- a/apps/concierge_site/lib/mail_templates/_footer.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/_footer.txt.eex
@@ -1,0 +1,4 @@
+Unsubscribe: <%= unsubscribe_url %>
+<%= if feedback_url do %> Feedback: <%= feedback_url %><% end %>
+
+Edit your subscription: <%= manage_subscriptions_url %>

--- a/apps/concierge_site/lib/mail_templates/confirmation.html.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.html.eex
@@ -5,7 +5,7 @@
     <title>MBTA Alert</title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
     <div class="email-contents" style="padding: 16px;">
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">Congratulations, you have successfully subscribed to receive MBTA alerts.</p>
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">To update your subscription preferences, please tap on the Edit your Subscriptions link below.</p>
@@ -14,7 +14,7 @@
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">If you did NOT request an account to receive MBTA alerts, click <a href="<%= disable_account_url %>">here</a> to disable the account.</p><p style="margin: 0; padding: 0; margin-bottom: 16px;">
     </p></div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
@@ -2,6 +2,6 @@ Congratulations, you have successfully subscribed to receive MBTA alerts.
 To update your subscription preferences, please tap on the Edit your Subscriptions link below.
 To stop receiving email alerts, please click unsubscribe below.
 
-If you no longer wish to receive any emails please unsubscribe: <%= unsubscribe_url %>
-
 If you did NOT request an account to receive MBTA alerts, click here to disable the account: <%= disable_account_url %>
+
+<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/digest.html.eex
+++ b/apps/concierge_site/lib/mail_templates/digest.html.eex
@@ -14,7 +14,7 @@
     </style>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
 
     <h1 class="digest-title" style="margin: 0; padding: 36px 0px; font-size: 26px; text-align: center;">
       T-Alerts: Weekly Digest
@@ -64,7 +64,7 @@
         </div>
       </div>
 
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
     </center>
 	</div></body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/digest.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/digest.txt.eex
@@ -10,4 +10,4 @@ T-Alerts Weekly Digest:
 The digest of upcoming events has been personalized to you based on your
 subscription, for full list: https://t.mbta.com/
 
-If you no longer wish to receive any emails please unsubscribe: <%= unsubscribe_url %>
+<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -5,7 +5,7 @@
     <title>MBTA Alert</title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
     <div class="notification-content" style="padding: 32px 20px 24px 20px;">
       <h1 class="notification-service-effect" style="margin: 0; padding: 0; font-size: 26px; font-weight: bold; text-align: center; color: #000000; vertical-align: middle;">
         <span class="notification-logo" style="width: 24px; height: 24px;">
@@ -26,7 +26,7 @@
       </p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
     </center>
 	</body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.txt.eex
@@ -4,4 +4,4 @@
 
 <%= notification.description %>
 
-If you no longer wish to receive any emails please unsubscribe: <%= unsubscribe_url %>
+<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/password_reset.html.eex
+++ b/apps/concierge_site/lib/mail_templates/password_reset.html.eex
@@ -5,7 +5,7 @@
     <title>MBTA Alert</title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
     <div class="email-contents" style="padding: 16px;">
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">
         Hello,
@@ -28,7 +28,7 @@
       </p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.footer(unsubscribe_url, manage_subscriptions_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/password_reset.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/password_reset.txt.eex
@@ -11,6 +11,4 @@ Please note that this link will expire after one hour.
 
 If you have any questions or did not request this password reset, please contact MBTA Customer Support at https://t.mbta.com/customer-support.
 
-If you no longer wish to receive any emails please unsubscribe: <%= unsubscribe_url %>
-
-&copy; Massachusetts Bay Transportation Authority, all rights reserved.
+<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/targeted_notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/targeted_notification.html.eex
@@ -5,29 +5,12 @@
     <title><%= subject %></title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
     <div class="email-contents" style="padding: 16px;">
       <p style="margin: 0; padding: 0; margin-bottom: 16px;"><%= body %></p>
     </div>
     <center>
-      <div class="footer" style="background-color: #092e4d; padding-bottom: 1rem; width: 100%; overflow: hidden;">
-        <div class="footer-copyright" style="font-size: 16px; line-height: 1.5; text-align: center; color: #ffffff; padding: 25px 50px 15px 50px;">
-          &copy; Massachusetts Bay Transportation Authority, all rights reserved.
-        </div>
-        <table>
-          <tr>
-            <td style="border-collapse: collapse;">
-              <a class="footer-link" href="https://t.mbta.com/customer-support" style="font-size: .75rem; line-height: 1.6; text-align: center; color: #67a0d1; text-decoration: none;">Feedback</a>
-            </td>
-            <td class="footer-link-separator" style="border-collapse: collapse; width: 10px; height: 10px;">
-              <div class="footer-link-separator-bullet" style="height: 5px; width: 5px; border-radius: 100%; background-color: #ffffff;">
-            </div></td>
-            <td style="border-collapse: collapse;">
-              <a class="footer-link" href="<%= manage_subscriptions_url %>" style="font-size: .75rem; line-height: 1.6; text-align: center; color: #67a0d1; text-decoration: none;">Edit Your Subscriptions</a>
-            </td>
-          </tr>
-        </table>
-      </div>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/targeted_notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/targeted_notification.txt.eex
@@ -1,1 +1,5 @@
+<%= subject %>
+
 <%= body %>
+
+<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/unknown_password_reset.html.eex
+++ b/apps/concierge_site/lib/mail_templates/unknown_password_reset.html.eex
@@ -5,7 +5,7 @@
     <title>MBTA Alert</title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; margin: 0 auto; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; padding: 0px 10px; overflow-y: scroll; max-width: 800px;">
-    <%= ConciergeSite.Helpers.MailHelper.header() %>
+    <%= ConciergeSite.Helpers.MailHelper.html_header() %>
     <div class="email-contents" style="padding: 16px;">
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">Hello,</p>
 

--- a/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
@@ -49,7 +49,8 @@ defmodule ConciergeSite.Dissemination.DigestEmailTest do
     assert body =~ "Service Effect"
     assert body =~ "https://t.mbta.com/"
     assert body =~ "This Weekend, May 26 - 27"
- end
+    assert body =~ "mbtafeedback.com"
+  end
 
   test "html_email/1 has all content and link for alerts page" do
     user = %User{email: "abc@123.com"}
@@ -63,5 +64,6 @@ defmodule ConciergeSite.Dissemination.DigestEmailTest do
     assert body =~ "Service Effect"
     assert body =~ "href=\"https://t.mbta.com/\""
     assert body =~ "This Weekend, May 26 - 27"
+    assert body =~ "mbtafeedback.com"
   end
 end

--- a/apps/concierge_site/test/lib/dissemination/email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/email_test.exs
@@ -12,6 +12,7 @@ defmodule ConciergeSite.Dissemination.EmailTest do
     assert email.subject == "Reset Your MBTA Alerts Password"
     assert email.html_body =~ "Please click the link below and follow the instructions on the page to reset your password"
     assert email.html_body =~ "/unsubscribe"
+    assert email.html_body =~ "mbtafeedback.com"
   end
 
   test "unknown password reset email" do
@@ -33,6 +34,7 @@ defmodule ConciergeSite.Dissemination.EmailTest do
     assert email.html_body =~ "Congratulations, you have successfully subscribed to receive MBTA alerts."
     assert email.html_body =~ "/unsubscribe"
     assert email.html_body =~ "/my-account/confirm_disable?token="
+    assert email.html_body =~ "mbtafeedback.com"
   end
 
   test "send targeted notification email" do
@@ -45,5 +47,6 @@ defmodule ConciergeSite.Dissemination.EmailTest do
     assert email.to == subscriber.email
     assert email.subject == subject
     assert email.html_body =~ body
+    assert email.html_body =~ "mbtafeedback.com"
   end
 end

--- a/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
+++ b/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
@@ -172,4 +172,10 @@ defmodule ConcerigeSite.Helpers.MailHelperTest do
       assert url =~ ~r/my-subscriptions\?token=(.+)/
     end
   end
+
+  describe "feedback_url" do
+    test "fetches url from environment" do
+      assert MailHelper.feedback_url() == "http://mbtafeedback.com/"
+    end
+  end
 end


### PR DESCRIPTION
Add the feedback URL to the email footers.

Also refactor the text emails to use a `_footer` template like the HTML emails do.

Password reset email:

![password_reset](https://user-images.githubusercontent.com/3039310/34120487-df106eb8-e3f3-11e7-90ea-fad55864c71b.png)

Account confirmation email:

![account_confirmation](https://user-images.githubusercontent.com/3039310/34120488-df1b6566-e3f3-11e7-9bdb-7702c2e9ab0e.png)

Unknown password reset email:

![unknown_password_reset](https://user-images.githubusercontent.com/3039310/34120489-df2867a2-e3f3-11e7-928a-c95645e4d204.png)

Targeted notification email:

![targeted_notification](https://user-images.githubusercontent.com/3039310/34120490-df361a32-e3f3-11e7-896d-efa882225186.png)

Notification email:

![notification](https://user-images.githubusercontent.com/3039310/34120491-df41e1dc-e3f3-11e7-9afe-4f9589d4d48e.png)

---

Example where no `FEEDBACK_URL` is set:

![reset_without_feedback](https://user-images.githubusercontent.com/3039310/34120492-df4be75e-e3f3-11e7-9467-81cb265331e4.png)
