### PR TITLE
Redirect cancel delete to edit page

### DIFF
--- a/apps/concierge_site/lib/templates/subscription/confirm_delete.html.eex
+++ b/apps/concierge_site/lib/templates/subscription/confirm_delete.html.eex
@@ -6,5 +6,5 @@
   <%= form_for @conn, subscription_path(@conn, :delete, @subscription), [as: :subscription, method: :delete, class: "single-submit-form"], fn _f -> %>
     <%= submit("Yes, delete this subscription", class: "btn btn-primary btn-wide") %>
   <% end %>
-  <%= link("Cancel", to: subscription_path(@conn, :index)) %>
+  <%= link("Cancel", to: subscription_edit_path(@conn, @subscription)) %>
 </div>

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -8,6 +8,7 @@ defmodule ConciergeSite.SubscriptionView do
   alias Model.{InformedEntity, Route, Subscription}
   alias ConciergeSite.{AccessibilitySubscriptionView, ParkingSubscriptionView, BikeStorageSubscriptionView,
     BusSubscriptionView, SubscriptionHelper, TimeHelper}
+  alias ConciergeSite.Router.Helpers
 
   import SubscriptionHelper,
     only: [direction_id: 1, relevant_days: 1]
@@ -335,5 +336,27 @@ defmodule ConciergeSite.SubscriptionView do
     else
      _ -> false
     end
+  end
+
+  def subscription_edit_path(conn, %Subscription{type: :bus} = subscription) do
+    Helpers.bus_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :subway} = subscription) do
+    Helpers.subway_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :commuter_rail} = subscription) do
+    Helpers.commuter_rail_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :boat} = subscription) do
+    Helpers.ferry_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :accessibility} = subscription) do
+    Helpers.accessibility_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :parking} = subscription) do
+    Helpers.parking_subscription_path(conn, :edit, subscription)
+  end
+  def subscription_edit_path(conn, %Subscription{type: :bike_storage} = subscription) do
+    Helpers.bike_storage_subscription_path(conn, :edit, subscription)
   end
 end

--- a/apps/concierge_site/test/web/views/subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subscription_view_test.exs
@@ -262,4 +262,48 @@ defmodule ConciergeSite.SubscriptionViewTest do
     assert Regex.scan(~r/pm, Weekdays \| Departs from Boston \(Long Wharf\)/, binary) |> Enum.count == 1
     assert binary =~ "5:15pm, Weekdays | Departs from Boston (Long Wharf)"
   end
+
+  describe "subscription_edit_path/2" do
+    test "bus subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :bus, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/bus/abc/edit"
+    end
+
+    test "subway subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :subway, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/subway/abc/edit"
+    end
+
+    test "commuter rail subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :commuter_rail, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/commuter_rail/abc/edit"
+    end
+
+    test "ferry subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :boat, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/ferry/abc/edit"
+    end
+
+    test "accessibility subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :accessibility, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/accessibility/abc/edit"
+    end
+
+    test "parking subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :parking, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/parking/abc/edit"
+    end
+
+    test "bike storage subscription edit path", %{conn: conn} do
+      subscription = %Subscription{type: :bike_storage, id: "abc"}
+
+      assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/bike_storage/abc/edit"
+    end
+  end
 end


### PR DESCRIPTION
Previously going to delete a subscription and then canceling it went to the index page. Change that so it goes to the edit page. Since each subscription type has its own edit page, this is done using a helper function instead of just redirecting to `/edit`.