### PR TITLE
Show enter an origin on info page

### DIFF
--- a/apps/concierge_site/assets/js/select-entity.js
+++ b/apps/concierge_site/assets/js/select-entity.js
@@ -167,17 +167,17 @@ export default function($) {
   }
 
   function attachSuggestionInputs() {
-    attachStationInput("origin");
-    attachStationInput("destination");
+    attachStationInput("an", "origin");
+    attachStationInput("a", "destination");
     $(".trip-info-footer").before(renderHiddenStationInputs());
   }
 
-  function attachStationInput(originDestination) {
+  function attachStationInput(article, originDestination) {
     const preselectedValue = fetchPreselectedOption(originDestination);
     if (preselectedValue && preselectedValue.val()) {
-      $(`label[for='${originDestination}']`).after(renderStationInput(originDestination, stationInputClass(originDestination), preselectedValue.text()));
+      $(`label[for='${originDestination}']`).after(renderStationInput(article, originDestination, stationInputClass(originDestination), preselectedValue.text()));
     } else {
-      $(`label[for='${originDestination}']`).after(renderStationInput(originDestination, stationInputClass(originDestination), ""));
+      $(`label[for='${originDestination}']`).after(renderStationInput(article, originDestination, stationInputClass(originDestination), ""));
     }
   }
 

--- a/apps/concierge_site/assets/js/select-multiple-entity.js
+++ b/apps/concierge_site/assets/js/select-multiple-entity.js
@@ -47,7 +47,7 @@ export default function($) {
   function attachSuggestionInput() {
     const inputEntityType = $(".subscription-select").data("entity-type");
 
-    $(".entity-select-sub-label").after(renderStationInput(inputEntityType, "subscription-select-entity-input", ""));
+    $(".entity-select-sub-label").after(renderStationInput("a", inputEntityType, "subscription-select-entity-input", ""));
   }
 
   function renderRouteSuggestion(route, index) {

--- a/apps/concierge_site/assets/js/station-select-helpers.js
+++ b/apps/concierge_site/assets/js/station-select-helpers.js
@@ -1,6 +1,6 @@
-function renderStationInput(name, className, preselectedValue) {
+function renderStationInput(article, name, className, preselectedValue) {
     return `
-      <input type="text" name="${name}" placeholder="Enter a ${name}" autocomplete="off" class="${className}" value="${preselectedValue}"/>
+      <input type="text" name="${name}" placeholder="Enter ${article} ${name}" autocomplete="off" class="${className}" value="${preselectedValue}"/>
       <div class="suggestion-container"></div>
       <i class="fa fa-check-circle valid-checkmark-icon"></i>
     `


### PR DESCRIPTION
On `/subscriptions/subway/new/info`, the filler text for origin was "Enter a origin" and for destination, "Enter a destination"

This PR changes it to "Enter an origin"

<img width="810" alt="screen shot 2017-12-20 at 13 28 43" src="https://user-images.githubusercontent.com/3039310/34223306-d81067cc-e58c-11e7-9a99-7f7397bcb1bb.png">
