### PR TITLE
Password format error message

### DIFF
--- a/apps/concierge_site/lib/templates/password/_password_entry_form_section.html.eex
+++ b/apps/concierge_site/lib/templates/password/_password_entry_form_section.html.eex
@@ -2,13 +2,21 @@
   <%= label @f, :password, "New password", class: "form-label" %>
   <%= label @f, :password, "Your new password must be at least 6 characters, with one number or special character (? & % $ # !, etc)", class: "form-sub-label" %>
   <%= error_tag @f, :password %>
-  <%= password_input @f, :password, placeholder: "Please enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
+  <%= password_input @f, :password, placeholder: "Please enter your password",
+                                    class: "form-control form-control-success form-control-danger",
+                                    pattern: password_regex_string(),
+                                    title: "At least 6 characters, with one number or special character",
+                                    required: true %>
   <span></span>
 </div>
 
 <div class="form-group <%= if :password_confirmation in @changeset.errors, do: "has-danger" %>">
   <%= label @f, :password_confirmation, "Re-enter new password", class: "form-label" %>
   <%= error_tag @f, :password_confirmation %>
-  <%= password_input @f, :password_confirmation, placeholder: "Please re-enter your password", class: "form-control form-control-success form-control-danger", pattern: password_regex_string(), required: true %>
+  <%= password_input @f, :password_confirmation, placeholder: "Please re-enter your password",
+                                                 class: "form-control form-control-success form-control-danger",
+                                                 pattern: password_regex_string(),
+                                                 title: "At least 6 characters, with one number or special character",
+                                                 required: true %>
   <span></span>
 </div>


### PR DESCRIPTION
When a user types a password with the incorrect format on a modern browser, the browser will reject it without submitting it to the server by using the `pattern` attribute.

The browser will then display an error message that includes the `title` attribute. When the `title` attribute it missing, the error message may look weird (see first MS Edge screenshot).

This PR adds that attribute, giving the user a more useful error message (see screenshots).

---

Before (Edge):

![before](https://user-images.githubusercontent.com/3039310/34306083-629e2036-e70f-11e7-9f99-3559fe3bd8f6.png)


---

After (Edge):

![after](https://user-images.githubusercontent.com/3039310/34306107-771d8380-e70f-11e7-91a3-301c47eee55d.png)


---

After (Chrome):

![screen shot 2017-12-22 at 11 51 53](https://user-images.githubusercontent.com/3039310/34306101-73278d34-e70f-11e7-8c09-155b6798d661.png)

