### PR TITLE
No headsigns for green line

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -362,7 +362,7 @@ defmodule AlertProcessor.Model.Subscription do
   for String.to_existing_atom calls.
   """
   def subscription_types do
-    [:bus, :subway, :commuter_rail, :boat, :accessibility, :parking, :parking_area, :bike_storage, :elevated_subplatform]
+    [:bus, :subway, :commuter_rail, :boat, :accessibility, :parking, :parking_area, :bike_storage, :elevated_subplatform, :portable_boarding_lift]
   end
 
   def subscription_type_from_route_type(route_type) do

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -285,6 +285,9 @@ defmodule ConciergeSite.SubscriptionView do
     end
   end
 
+  defp parse_headsign(%{type: :subway, route: "Green-" <> _}) do
+    ""
+  end
   defp parse_headsign(%{type: :subway} = subscription) do
     case parse_direction(subscription) do
       nil ->


### PR DESCRIPTION
On the `/my-subscriptions` page, show only "Westbound" or "Eastbound" for Green Line trips. This is because the headsigns are confusing.

Before this update the text would be something like `Eastbound to B, C, D, or E` Now it's simply `Eastbound.`

[Asana ticket](https://app.asana.com/0/415342363785198/476953637945378/f)

---

Before:

<img width="636" alt="screen shot 2017-12-22 at 16 03 17" src="https://user-images.githubusercontent.com/3039310/34312447-388c791e-e732-11e7-8116-85b39fc78f0f.png">

After:

<img width="667" alt="screen shot 2017-12-22 at 16 03 59" src="https://user-images.githubusercontent.com/3039310/34312451-3c96f124-e732-11e7-8cca-4258892641d2.png">
