### PR TITLE
Redirect to login after disable account

### DIFF
--- a/apps/concierge_site/lib/controllers/page_controller.ex
+++ b/apps/concierge_site/lib/controllers/page_controller.ex
@@ -8,6 +8,7 @@ defmodule ConciergeSite.PageController do
   def account_disabled(conn, _params) do
     conn
     |> Guardian.Plug.sign_out()
+    |> put_resp_header("refresh", "5;url=#{session_path(conn, :new)}")
     |> render("account_disabled.html")
   end
 end

--- a/apps/concierge_site/lib/templates/page/account_disabled.html.eex
+++ b/apps/concierge_site/lib/templates/page/account_disabled.html.eex
@@ -6,4 +6,10 @@
     and you will be unable to login into your account. Your account may be
     recovered by initiating a password reset.
   </p>
+  <p>
+  <%= link(to: session_path(@conn, :new)) do %>
+    Return to sign in page
+    <%= fa("arrow-right") %>
+  <% end %>
+  </p>
 <div>

--- a/apps/concierge_site/test/web/controllers/page_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/page_controller_test.exs
@@ -13,5 +13,6 @@ defmodule ConciergeSite.PageControllerTest do
       |> guardian_login(conn, :access, perms: %{default: [:disable_account]})
       |> get("/account_disabled")
     assert html_response(conn, 200) =~ "Account Disabled"
+    assert get_resp_header(conn, "refresh") == ["5;url=/login/new"]
   end
 end


### PR DESCRIPTION
When a user disables their account, they are sent to the `/account_disabled` page. This PR makes two changes:

* Add a link to `/login/new`
* Use a `refresh` header to automatically send the user to `/login/new` after five seconds

<img width="1009" alt="screen shot 2017-12-22 at 16 48 21" src="https://user-images.githubusercontent.com/3039310/34313490-6e0cfc24-e739-11e7-823b-f49805f6ef72.png">
