### PR TITLE
Remove phone number on SMS opt-out

### DIFF
--- a/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
+++ b/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
@@ -100,7 +100,7 @@ defmodule AlertProcessor.SmsOptOutWorker do
 
   @spec update_users_opted_out([User.id]) :: [User.id]
   defp update_users_opted_out(user_ids) do
-    User.put_users_on_indefinite_vacation(user_ids, "sms-opt-out")
+    User.remove_users_phone_number(user_ids, "sms-opt-out")
     Enum.map(user_ids, &HoldingQueue.remove_user_notifications/1)
   end
 end

--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -350,14 +350,14 @@ defmodule AlertProcessor.Model.User do
   @doc """
   Takes a list of user ids and puts on vacation mode ending in the year 9999
   """
-  def put_users_on_indefinite_vacation(user_ids, origin \\ "unknown") do
+  def remove_users_phone_number(user_ids, origin) do
     user_ids
     |> Enum.with_index()
     |> Enum.reduce(Multi.new(), fn({user_id, index}, acc) ->
           Multi.run(acc, {:user, index}, fn _ ->
             __MODULE__
             |> Repo.get(user_id)
-            |> update_vacation_changeset(%{vacation_start: DateTime.utc_now(), vacation_end: DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC")})
+            |> update_account_changeset(%{phone_number: nil})
             |> PaperTrail.update(origin: origin)
           end)
         end)

--- a/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
@@ -4,12 +4,12 @@ defmodule AlertProcessor.SmsOptOutWorkerTest do
   alias AlertProcessor.Model.User
   alias AlertProcessor.SmsOptOutWorker
 
-  test "worker fetches list of opted out phone numbers from aws sns and update vacation time for new numbers" do
+  test "worker fetches list of opted out phone numbers from aws sns and removes the phone numbers from the accounts" do
     user = insert(:user, phone_number: "9999999999")
     {:noreply, _} = SmsOptOutWorker.handle_info(:work, [])
     assert_received :list_phone_numbers_opted_out
     reloaded_user = Repo.one(from u in User, where: u.id == ^user.id)
-    assert :eq = DateTime.compare(reloaded_user.vacation_end, DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC"))
+    assert reloaded_user.phone_number == nil
   end
 
   test "worker fetches list of opted out phone numbers from aws sns and doesnt update for numbers not in list" do
@@ -17,15 +17,15 @@ defmodule AlertProcessor.SmsOptOutWorkerTest do
     {:noreply, _} = SmsOptOutWorker.handle_info(:work, [])
     assert_received :list_phone_numbers_opted_out
     reloaded_user = Repo.one(from u in User, where: u.id == ^user.id)
-    assert reloaded_user.vacation_end == nil
+    assert reloaded_user.phone_number == "5555551234"
   end
 
-  test "worker fetches list of opted out phone numbers from aws sns and update vacation time for new numbers with existing state" do
+  test "worker fetches list of opted out phone numbers from aws sns and removes numbers for users with existing state" do
     user = insert(:user, phone_number: "9999999999")
     {:noreply, new_state} = SmsOptOutWorker.handle_info(:work, ["2222222222", "3333333333"])
     assert_received :list_phone_numbers_opted_out
     reloaded_user = Repo.one(from u in User, where: u.id == ^user.id)
-    assert :eq = DateTime.compare(reloaded_user.vacation_end, DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC"))
+    assert reloaded_user.phone_number == nil
     assert new_state == ["9999999999", "5555555555"]
   end
 end

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -450,22 +450,23 @@ defmodule AlertProcessor.Model.UserTest do
     end
   end
 
-  describe "put_users_on_indefinite_vacation" do
-    test "it sets list of users on vacation with an end time in the year 9999" do
+  describe "remove_users_phone_number" do
+    test "removes the phone numbers from the users" do
       user0 = insert(:user)
       user1 = insert(:user)
+
       {:ok,
         %{
           {:user, 0} => %{model: user_0},
           {:user, 1} => %{model: user_1},
         }
-      } = User.put_users_on_indefinite_vacation([user0.id, user1.id])
-      assert DateTime.compare(user_0.vacation_end, DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC")) == :eq
-      assert DateTime.compare(user_1.vacation_end, DateTime.from_naive!(~N[9999-12-25 23:59:59], "Etc/UTC")) == :eq
+      } = User.remove_users_phone_number([user0.id, user1.id], "sms-opt-out")
+      assert user_0.phone_number == nil
+      assert user_1.phone_number == nil
     end
 
     test "doesnt do anything if no users are passed" do
-      assert {:ok, %{}} = User.put_users_on_indefinite_vacation([])
+      assert {:ok, %{}} = User.remove_users_phone_number([], "sms-opt-out")
     end
   end
 

--- a/apps/concierge_site/test/web/users/subscriber_details_test.exs
+++ b/apps/concierge_site/test/web/users/subscriber_details_test.exs
@@ -62,7 +62,7 @@ defmodule ConciergeSite.SubscriberDetailsTest do
     end
 
     test "maps sms opt out", %{user: user} do
-      User.put_users_on_indefinite_vacation([user.id], "sms-opt-out")
+      User.remove_users_phone_number([user.id], "sms-opt-out")
       changelog = user.id |> SubscriberDetails.changelog() |> changelog_to_binary()
       assert changelog =~ "Account put in indefinite vacation mode due to sms opt out."
     end


### PR DESCRIPTION
When a user sends the text message "STOP" to the phone number they've been getting MBTA alerts from, remove their phone number so that they receive email alerts instead.

The previous behavior was to put the user on "indefinite vacation" but we're changing that because we still want them to receive alerts, just not SMS.