### PR TITLE
Opt in phone number on account update

### DIFF
--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -221,10 +221,28 @@ defmodule AlertProcessor.Model.UserTest do
       assert user.amber_alert_opt_in
     end
 
+    test "opts in phone number when phone number changed" do
+      user = insert(:user)
+      assert {:ok, user} = User.update_account(user, %{"phone_number" => "5550000000"}, user.id)
+      assert_received :opt_in_phone_number
+    end
+
+    test "does not opt in phone number when phone number not changed" do
+      user = insert(:user)
+      assert {:ok, user} = User.update_account(user, %{"amber_alert_opt_in" => "true"}, user.id)
+      refute_received :opt_in_phone_number
+    end
+
     test "does not update account" do
       user = insert(:user)
       assert {:error, changeset} = User.update_account(user, %{"amber_alert_opt_in" => "no way!"}, user.id)
       refute changeset.valid?
+    end
+
+    test "does not opt in phone number when does not save" do
+      user = insert(:user)
+      assert {:error, changeset} = User.update_account(user, %{"amber_alert_opt_in" => "no way!", "phone_number" => "5550000000"}, user.id)
+      refute_received :opt_in_phone_number
     end
 
     test "performed by admin" do


### PR DESCRIPTION
Previously, phone numbers were being opted in on [account create](https://github.com/mbta/alerts_concierge/blob/c0c5c3e8b1b6007fa43a91b05f7455f8cf3a4b83/apps/alert_processor/lib/model/user.ex#L69) but not account update. This commit opts in accounts on update so it behaves the same as create.