### PR TITLE
re-enable email digests

### DIFF
--- a/apps/concierge_site/lib/dissemination/mailer_interface.ex
+++ b/apps/concierge_site/lib/dissemination/mailer_interface.ex
@@ -5,7 +5,7 @@ defmodule ConciergeSite.Dissemination.MailerInterface do
   """
   use GenServer
   require Logger
-  alias ConciergeSite.Dissemination.{DigestEmail, NotificationEmail, Mailer, DummyMailer}
+  alias ConciergeSite.Dissemination.{DigestEmail, NotificationEmail, Mailer}
 
   @lookup_tuple {:via, Registry, {:mailer_process_registry, :mailer}}
 
@@ -30,8 +30,8 @@ defmodule ConciergeSite.Dissemination.MailerInterface do
     response =
       digest_message
       |> DigestEmail.digest_email()
-      |> DummyMailer.deliver_later()
-    Logger.info(fn -> "Digest Email result (not sent): #{inspect(response)}, user_id: #{digest_message.user.id}" end)
+      |> Mailer.deliver_later()
+    Logger.info(fn -> "Digest Email result: #{inspect(response)}, user_id: #{digest_message.user.id}" end)
     {:reply, response, nil}
   end
 end


### PR DESCRIPTION
This had been disabled in the past due to some bugs that have subsequently been resolved.