### PR TITLE
Fix test with hard-coded date

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/scheduler_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/scheduler_test.exs
@@ -6,7 +6,7 @@ defmodule AlertProcessor.SchedulerTest do
   alias Calendar.DateTime, as: DT
 
   setup_all do
-    now = DT.from_date_and_time_and_zone!({2018, 1, 8}, {14, 10, 55}, "Etc/UTC")
+    now = Calendar.DateTime.now!("Etc/UTC")
     two_days_from_now = DT.add!(now, 172_800)
     three_days_from_now = DT.add!(now, 172_800)
 


### PR DESCRIPTION
This test was written in such a way that `now` eventually became "then" and the test stopped working.