### PR TITLE
Do not disturb overlap for amenities

### DIFF
--- a/apps/concierge_site/lib/views/time_helper.ex
+++ b/apps/concierge_site/lib/views/time_helper.ex
@@ -8,6 +8,8 @@ defmodule ConciergeSite.TimeHelper do
   alias AlertProcessor.Helpers.DateTimeHelper
   alias AlertProcessor.Model.{Subscription, User}
 
+  @all_day_subscription_types [:accessibility, :parking, :bike_storage]
+
   @doc """
   Returns stringified times to populate a dropdown list of a full day of times at
   fifteen-minute intervals
@@ -73,6 +75,7 @@ defmodule ConciergeSite.TimeHelper do
 
   @spec subscription_during_do_not_disturb?(Subscription.t, User.t) :: boolean
   def subscription_during_do_not_disturb?(_, %User{do_not_disturb_start: nil, do_not_disturb_end: nil}), do: false
+  def subscription_during_do_not_disturb?(%Subscription{type: type}, _) when type in @all_day_subscription_types, do: false
   def subscription_during_do_not_disturb?(%Subscription{start_time: start_time, end_time: end_time}, %User{do_not_disturb_start: dnd_start, do_not_disturb_end: dnd_end}) do
     if normalized_time_value(dnd_start) > normalized_time_value(dnd_end) do
       normalized_time_value(end_time) > normalized_time_value(dnd_start) || normalized_time_value(dnd_end) > normalized_time_value(start_time)

--- a/apps/concierge_site/test/web/views/time_helper_test.exs
+++ b/apps/concierge_site/test/web/views/time_helper_test.exs
@@ -62,6 +62,10 @@ defmodule ConciergeSite.TimeHelperTest do
       refute TimeHelper.subscription_during_do_not_disturb?(%Subscription{start_time: ~T[15:00:00], end_time: ~T[17:00:00]}, %User{do_not_disturb_start: ~T[09:00:00], do_not_disturb_end: ~T[14:00:00]})
     end
 
+    test "returns false if subscription is an accessibility, parking, or bike storage subscription" do
+      refute TimeHelper.subscription_during_do_not_disturb?(%Subscription{start_time: ~T[05:00:00], end_time: ~T[06:00:00], type: :accessibility}, %User{do_not_disturb_start: ~T[05:00:00], do_not_disturb_end: ~T[07:00:00]})
+    end
+
     test "handles overnight dnd periods" do
       assert TimeHelper.subscription_during_do_not_disturb?(%Subscription{start_time: ~T[18:00:00], end_time: ~T[22:00:00]}, %User{do_not_disturb_start: ~T[17:00:00], do_not_disturb_end: ~T[02:00:00]})
     end


### PR DESCRIPTION
For all-day accessibility, parking, and bike storage alerts, do not show the "do not disturb" overlap header.

https://app.asana.com/0/415342363785198/508261222608343/f