### PR TITLE
Use ferry for ferry subscriptions

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -8,7 +8,7 @@ defmodule AlertProcessor.Model.Subscription do
   import Ecto.Query
 
   @type id :: String.t
-  @type subscription_type :: :bus | :subway | :commuter_rail | :boat | :accessibility
+  @type subscription_type :: :bus | :subway | :commuter_rail | :ferry | :accessibility | :parking | :bike_storage
   @type subscription_info :: {__MODULE__.t, [InformedEntity.t]}
   @type relevant_day :: :weekday | :saturday | :sunday
   @type direction :: 0 | 1
@@ -362,7 +362,7 @@ defmodule AlertProcessor.Model.Subscription do
   for String.to_existing_atom calls.
   """
   def subscription_types do
-    [:bus, :subway, :commuter_rail, :boat, :accessibility, :parking, :parking_area, :bike_storage, :elevated_subplatform, :portable_boarding_lift]
+    [:bus, :subway, :commuter_rail, :ferry, :accessibility, :parking, :parking_area, :bike_storage, :elevated_subplatform, :portable_boarding_lift]
   end
 
   def subscription_type_from_route_type(route_type) do

--- a/apps/concierge_site/lib/views/subscription_view.ex
+++ b/apps/concierge_site/lib/views/subscription_view.ex
@@ -350,7 +350,7 @@ defmodule ConciergeSite.SubscriptionView do
   def subscription_edit_path(conn, %Subscription{type: :commuter_rail} = subscription) do
     Helpers.commuter_rail_subscription_path(conn, :edit, subscription)
   end
-  def subscription_edit_path(conn, %Subscription{type: :boat} = subscription) do
+  def subscription_edit_path(conn, %Subscription{type: :ferry} = subscription) do
     Helpers.ferry_subscription_path(conn, :edit, subscription)
   end
   def subscription_edit_path(conn, %Subscription{type: :accessibility} = subscription) do

--- a/apps/concierge_site/test/web/views/subscription_view_test.exs
+++ b/apps/concierge_site/test/web/views/subscription_view_test.exs
@@ -283,7 +283,7 @@ defmodule ConciergeSite.SubscriptionViewTest do
     end
 
     test "ferry subscription edit path", %{conn: conn} do
-      subscription = %Subscription{type: :boat, id: "abc"}
+      subscription = %Subscription{type: :ferry, id: "abc"}
 
       assert SubscriptionView.subscription_edit_path(conn, subscription) == "/subscriptions/ferry/abc/edit"
     end


### PR DESCRIPTION
This PR fixes two issues related to subscription type:

* The atom `:boat` was incorrectly used in the subscription view, preventing ferry subscriptions from being deleted.
* The list of subscription types was missing a parking and bike storage

https://app.asana.com/0/415342363785198/524320450497148/f