### PR TITLE
fix small bugs with responsive CSS menu

### DIFF
--- a/apps/concierge_site/assets/css/_menu.scss
+++ b/apps/concierge_site/assets/css/_menu.scss
@@ -3,9 +3,9 @@
   font-size: 1.1rem;
   line-height: 1.1rem;
   padding: 1rem;
-  position: fixed;
-  right: 2px;
-  top: 2px;
+  position: absolute;
+  right: -1rem;
+  top: -.5rem;
 }
 
 .menu__toggle:hover,


### PR DESCRIPTION
No Asana Task

This corrects two small issues I observed:
- the link should be anchored to the top of the page
- the positioning of the link should not cause the page to jitter when the user is toggling the menu. This second issue may have only occurred once I switched it to position `absolute`.