### PR TITLE
Replace t.mbta.com with www.mbta.com

### DIFF
--- a/apps/concierge_site/lib/mail_templates/digest.html.eex
+++ b/apps/concierge_site/lib/mail_templates/digest.html.eex
@@ -56,7 +56,7 @@
         </div>
 
         <div class="digest-footer-link-wrapper" style="width: 290px; height: 40px;">
-          <a class="digest-footer-link" href="https://t.mbta.com/" style="width: 290px; height: 40px; text-decoration: none;">
+          <a class="digest-footer-link" href="https://www.mbta.com/" style="width: 290px; height: 40px; text-decoration: none;">
             <div class="digest-footer-button" style="width: 244px; padding: 6px 0px; border-radius: 5px; vertical-align: middle; background-color: #1c77c3; font-size: 16px; line-height: 1.75; text-align: center; color: #ffffff;">
               View All Alerts
             </div>

--- a/apps/concierge_site/lib/mail_templates/digest.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/digest.txt.eex
@@ -8,6 +8,6 @@ T-Alerts Weekly Digest:
 <% end %>
 
 The digest of upcoming events has been personalized to you based on your
-subscription, for full list: https://t.mbta.com/
+subscription, for full list: https://www.mbta.com/
 
 <%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -28,7 +28,7 @@
       <% end %>
 
       <p class="notification-link-wrapper" style="margin: 0; padding: 0; text-align: right; padding-top: 10px;">
-        <a class="notification-link" href="https://t.mbta.com/" style="font-size: 16px; line-height: 1.5; color: #1c77c3; padding-top: 24px; text-decoration: none;">View all alerts &rarr;</a>
+        <a class="notification-link" href="https://www.mbta.com/" style="font-size: 16px; line-height: 1.5; color: #1c77c3; padding-top: 24px; text-decoration: none;">View all alerts &rarr;</a>
       </p>
     </div>
     <center>

--- a/apps/concierge_site/lib/templates/layout/app.html.eex
+++ b/apps/concierge_site/lib/templates/layout/app.html.eex
@@ -25,7 +25,7 @@
     <header class="header">
       <nav class="navbar navbar-toggleable-sm navbar-default">
         <div class="container">
-          <a href="https://t.mbta.com/"><%= img_tag(static_url(@conn, "/images/mbta-beta-logo.png"), class: "mbta-beta-logo navbar-brand") %></a>
+          <a href="https://www.mbta.com/"><%= img_tag(static_url(@conn, "/images/mbta-beta-logo.png"), class: "mbta-beta-logo navbar-brand") %></a>
           <div class="collapse navbar-collapse justify-content-end">
 
             <div>

--- a/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/digest_email_test.exs
@@ -47,7 +47,7 @@ defmodule ConciergeSite.Dissemination.DigestEmailTest do
     assert email.to == user.email
     assert body =~ "This is a Test"
     assert body =~ "Service Effect"
-    assert body =~ "https://t.mbta.com/"
+    assert body =~ "https://www.mbta.com/"
     assert body =~ "This Weekend, May 26 - 27"
     assert body =~ "mbtafeedback.com"
   end
@@ -62,7 +62,7 @@ defmodule ConciergeSite.Dissemination.DigestEmailTest do
     assert email.to == user.email
     assert body =~ "This is a Test"
     assert body =~ "Service Effect"
-    assert body =~ "href=\"https://t.mbta.com/\""
+    assert body =~ "href=\"https://www.mbta.com/\""
     assert body =~ "This Weekend, May 26 - 27"
     assert body =~ "mbtafeedback.com"
   end

--- a/apps/concierge_site/test/lib/dissemination/mailer_interface_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/mailer_interface_test.exs
@@ -66,7 +66,7 @@ defmodule ConciergeSite.Dissemination.MailerInterfaceTest do
       assert sent_email.to == [{nil, user.email}]
       assert sent_email.text_body =~ "This is a Test"
       assert sent_email.text_body =~ "Service Effect"
-      assert sent_email.text_body =~ "https://t.mbta.com/"
+      assert sent_email.text_body =~ "https://www.mbta.com/"
       assert sent_email.text_body =~ "This Weekend, May 26 - 27"
     end
   end

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -40,7 +40,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     assert email.to == @email
     assert body =~ "Red line delay"
     assert body =~ "Red line inbound from Alewife station closure"
-    assert body =~ "href=\"https://t.mbta.com/\""
+    assert body =~ "href=\"https://www.mbta.com/\""
     assert body =~ "http://www.example.com/alert-info"
   end
 


### PR DESCRIPTION
Replace all instances of `https://t.mbta.com/` with `https://www.mbta.com/`.

https://app.asana.com/0/415342363785198/527686111780278/f