### PR TITLE
test that redline subscriptions are matched correctly to active period

### DIFF
--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -231,11 +231,4 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
       _ -> :error
     end
   end
-
-  @spec naive_to_local(NaiveDateTime.t) :: DateTime.t
-  def naive_to_local(naive_datetime) do
-    naive_datetime
-    |> DateTime.from_naive!("Etc/UTC")
-    |> Calendar.DateTime.shift_zone!(@time_zone)
-  end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -1,7 +1,7 @@
 defmodule AlertProcessor.SubscriptionFilterEngineTest do
   use AlertProcessor.DataCase
   import AlertProcessor.Factory
-  import AlertProcessor.Helpers.DateTimeHelper, only: [naive_to_local: 1]
+  import AlertProcessor.DateHelper
   alias AlertProcessor.{Model.Alert, Model.InformedEntity, Model.Subscription, SubscriptionFilterEngine}
 
   setup_all do
@@ -78,11 +78,11 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
         last_push_notification: date_2017_01_18__09_00
       }
 
-      alert_evening = struct(alert_morning, %{active_period: [%{start: date_2017_01_18__16_00,
-                                                                end: date_2017_01_18__17_00}], id: "2"})
+      alert_evening = %{alert_morning | active_period: [%{start: date_2017_01_18__16_00,
+                                                                end: date_2017_01_18__17_00}], id: "2"}
 
-      alert_late = struct(alert_morning, %{active_period: [%{start: date_2017_01_18__20_00,
-                                                             end: date_2017_01_18__21_00}], id: "3"})
+      alert_late = %{alert_morning | active_period: [%{start: date_2017_01_18__20_00,
+                                                             end: date_2017_01_18__21_00}], id: "3"}
 
       user_morning = insert(:user, phone_number: nil, email: "redline|weekdays|low|morning@test.com")
       subscription_morning = :subscription

--- a/apps/alert_processor/test/support/date_helper.ex
+++ b/apps/alert_processor/test/support/date_helper.ex
@@ -1,0 +1,13 @@
+defmodule AlertProcessor.DateHelper do
+  @moduledoc """
+  Useful date transformations for tests.
+  """
+  @time_zone "America/New_York"
+
+  @spec naive_to_local(NaiveDateTime.t) :: DateTime.t
+  def naive_to_local(naive_datetime) do
+    naive_datetime
+    |> DateTime.from_naive!("Etc/UTC")
+    |> Calendar.DateTime.shift_zone!(@time_zone)
+  end
+end


### PR DESCRIPTION
- [Investigate bug report: red line alert not received (morning)](https://app.asana.com/0/415342363785198/518725951480400/f)
- [Investigate bug report: red line alert not received (afternoon)](https://app.asana.com/0/415342363785198/522901619667645/f)
- [Bug report: received Red Line alerts after travel period](https://app.asana.com/0/415342363785198/522901619667646/f)

The bug that we think caused these reports was resolved in a previous commit (pertaining to date conversion). This ticket demonstrates the expected matches.

#### Overview
- create 3 alerts: one in the morning, evening and night
- create 2 users-subscriptions: morning and evening
- user the same informed entities for all alerts and subscriptions, but vary the active period
- show that a morning subscription matches only the morning alert
- show that an evening subscription matches only the evening alert
- show that a night time alert does not match either subscription