### PR TITLE
create a subscription factory intended for use testing subscriptions

### DIFF
--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -1,0 +1,28 @@
+defmodule ConciergeSite.Integration.Matching do
+  use ExUnit.Case
+  import ConciergeSite.SubscriptionFactory
+  alias AlertProcessor.{Model.InformedEntity, Model.Subscription}
+
+  test "unified interface for creating subscriptions that matches front-end process" do
+    base_params = %{"alert_priority_type" => "medium", "departure_end" => ~T[08:30:00],
+                    "departure_start" => ~T[08:00:00], "relevant_days" => ["weekday"]}
+
+    subway_params = Map.merge(base_params, %{"destination" => "place-chncl", "origin" => "place-ogmnl",
+                                             "roaming" => "false"})
+    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:subway, subway_params)
+
+    bus_params = Map.merge(base_params, %{"routes" => ["57A - 0"]})
+    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:bus, bus_params)
+
+    commuter_rail_params = Map.merge(base_params, %{"destination" => "place-north", "direction_id" => "1",
+                                                    "origin" => "Melrose Highlands", "route_id" => "CR-Haverhill",
+                                                    "trips" => ["288"]})
+    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:commuter_rail, commuter_rail_params)
+
+    ferry_params = Map.merge(base_params, %{"destination" => "Boat-Long", "direction_id" => "1",
+                                            "origin" => "Boat-Charlestown", "route_id" => "Boat-F4",
+                                            "trips" => ["Boat-F4-Boat-Charlestown-08:00:00-weekday-1"]})
+    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:ferry, ferry_params)
+  end
+
+end

--- a/apps/concierge_site/test/support/subscription_factory.ex
+++ b/apps/concierge_site/test/support/subscription_factory.ex
@@ -1,0 +1,27 @@
+defmodule ConciergeSite.SubscriptionFactory do
+  @moduledoc """
+  Standard interface for generating subscriptions
+  """
+
+  alias AlertProcessor.Subscription.SubwayMapper
+  alias AlertProcessor.Subscription.BusMapper
+  alias AlertProcessor.Subscription.CommuterRailMapper
+  alias AlertProcessor.Subscription.FerryMapper
+
+  def subscription(:subway, params) do
+    SubwayMapper.map_subscriptions(params)
+  end
+  def subscription(:bus, params) do
+    BusMapper.map_subscription(params)
+  end
+  def subscription(:commuter_rail, params) do
+    %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
+    |> Map.merge(params)
+    |> CommuterRailMapper.map_subscriptions()
+  end
+  def subscription(:ferry, params) do
+    %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
+    |> Map.merge(params)
+    |> FerryMapper.map_subscriptions()
+  end
+end


### PR DESCRIPTION
This is a test helper to make it easier to generate subscriptions/informed entities that can later be matched against alerts that goes through the same pipeline as the a user would if they created their subscription on the website.