### PR TITLE
Do not send notification if invalid

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_worker.ex
+++ b/apps/alert_processor/lib/dissemination/notification_worker.ex
@@ -37,8 +37,8 @@ defmodule AlertProcessor.NotificationWorker do
 
   defp send_notification(notification) do
     with :ok <- RateLimiter.check_rate_limit(notification.user.id),
+      {:ok, notification} <- Notification.save(notification, :sent),
       {:ok, _} <- Dispatcher.send_notification(notification) do
-        Notification.save(notification, :sent)
     else
       {:error, :rate_exceeded} -> Logger.warn("Sending rate exceeded for user: #{notification.user.id}")
       {:error, _} -> Notification.save(notification, :failed)


### PR DESCRIPTION
If a notification cannot be saved, then do not send it to the user. This prevents infinite loops where invalid notifications were sent, not persisted, then sent again.