### PR TITLE
Do not ignore priv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,13 @@
-/_build
-/cover
+_build
+cover
 erl_crash.dump
 deps
 *.ez
 npm-debug.log
-/priv/static/
+priv/static/
 .deliver/releases/
-/devops/
-/test/fixture/vcr_cassettes/*
+devops/
+test/fixture/vcr_cassettes/*
 .iex.exs
 .DS_Store
 excoveralls.json
@@ -23,7 +23,7 @@ docker
 releases
 
 # Static artifacts if you're using Phoenix if it's an umbrella app change the paths
-/apps/alert_processor/assets/node_modules
-/apps/alert_processor/priv
-/apps/concierge_site/assets/node_modules
-/apps/concierge_site/priv
+apps/alert_processor/assets/node_modules
+apps/alert_processor/priv/static
+apps/concierge_site/assets/node_modules
+apps/concierge_site/priv/static


### PR DESCRIPTION
Do not ignore the `priv/` directory in `.dockerignore`. Ignoring this directory was causing the migrations to not be included in the build.

Also remove the leading `/` from each line. The documentation says that it should work the same with or without the slash, but in [some cases](https://stackoverflow.com/questions/36295418/dockerignore-mentioned-files-are-not-ignored) it doesn't work with the slash.

Asana ticket: https://app.asana.com/0/415342363785198/529810320822173/f