### PR TITLE
small change to data format to make matching alerts to subscriptions easier

### DIFF
--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -9,20 +9,19 @@ defmodule ConciergeSite.Integration.Matching do
 
     subway_params = Map.merge(base_params, %{"destination" => "place-chncl", "origin" => "place-ogmnl",
                                              "roaming" => "false"})
-    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:subway, subway_params)
+    assert [%Subscription{informed_entities: [%InformedEntity{} | _]} | _] = subscription(:subway, subway_params)
 
     bus_params = Map.merge(base_params, %{"routes" => ["57A - 0"]})
-    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:bus, bus_params)
+    assert [%Subscription{informed_entities: [%InformedEntity{} | _]} | _] = subscription(:bus, bus_params)
 
     commuter_rail_params = Map.merge(base_params, %{"destination" => "place-north", "direction_id" => "1",
                                                     "origin" => "Melrose Highlands", "route_id" => "CR-Haverhill",
                                                     "trips" => ["288"]})
-    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:commuter_rail, commuter_rail_params)
+    assert [%Subscription{informed_entities: [%InformedEntity{} | _]} | _] = subscription(:commuter_rail, commuter_rail_params)
 
     ferry_params = Map.merge(base_params, %{"destination" => "Boat-Long", "direction_id" => "1",
                                             "origin" => "Boat-Charlestown", "route_id" => "Boat-F4",
                                             "trips" => ["Boat-F4-Boat-Charlestown-08:00:00-weekday-1"]})
-    assert {:ok, [{%Subscription{}, [%InformedEntity{} | _]} | _]} = subscription(:ferry, ferry_params)
+    assert [%Subscription{informed_entities: [%InformedEntity{} | _]} | _] = subscription(:ferry, ferry_params)
   end
-
 end

--- a/apps/concierge_site/test/support/subscription_factory.ex
+++ b/apps/concierge_site/test/support/subscription_factory.ex
@@ -10,18 +10,31 @@ defmodule ConciergeSite.SubscriptionFactory do
 
   def subscription(:subway, params) do
     SubwayMapper.map_subscriptions(params)
+    |> to_subscriptions
   end
   def subscription(:bus, params) do
     BusMapper.map_subscription(params)
+    |> to_subscriptions
   end
   def subscription(:commuter_rail, params) do
     %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
     |> Map.merge(params)
     |> CommuterRailMapper.map_subscriptions()
+    |> to_subscriptions
   end
   def subscription(:ferry, params) do
     %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
     |> Map.merge(params)
     |> FerryMapper.map_subscriptions()
+    |> to_subscriptions
+  end
+
+  defp to_subscriptions (response) do
+    with {:ok, subscriptions_and_informed_entities} <- response do
+      subscriptions_and_informed_entities
+      |> Enum.map(fn {subscription, informed_entities} ->
+        %{subscription | informed_entities: informed_entities}
+      end)
+    end
   end
 end


### PR DESCRIPTION
The mapper functions each return a list of tuples containing a `%Subscription` and a list of associated `%InformedEntities`.  The `SubscriptionFilterEngine` expects a list of `%Subscriptions` that have their `informed_entities` key set.

This change will make it easier to generate data that can be directly sent to test matches against `Alerts`.