### PR TITLE
Toggle phone number field on account page

### DIFF
--- a/apps/concierge_site/lib/templates/my_account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/my_account/edit.html.eex
@@ -30,16 +30,12 @@
       <div class="my-account-section-prompt">
         We will automatically send your alerts to your email address. Would you like to receive text alerts instead?
       </div>
-      <label for="user_sms_toggle_true" class="my-account-radio-label">
-        <%= radio_button f, :sms_toggle, "true", checked: sms_messaging_checked?(@user),
-                                                 class: "my-account-radio-button toggle_show" %>
-        Yes - only send me text alerts
-      </label>
-      <label for="user_sms_toggle_false" class="my-account-radio-label">
-        <%= radio_button f, :sms_toggle, "false", checked: !sms_messaging_checked?(@user),
-                                                  class: "my-account-radio-button toggle_hide" %>
-        No - only send me email alerts
-      </label>
+
+      <%= radio_button f, :sms_toggle, "true", checked: sms_messaging_checked?(@user), class: "my-account-radio-button toggle_show" %>
+      <label for="user_sms_toggle_true" class="my-account-radio-label">Yes - only send me text alerts</label>
+      <%= radio_button f, :sms_toggle, "false", checked: !sms_messaging_checked?(@user), class: "my-account-radio-button toggle_hide" %>
+      <label for="user_sms_toggle_false" class="my-account-radio-label">No - only send me email alerts</label>
+
       <div class="wireless-number-section supporting-info-section toggleable">
         <label for="user_phone_number" class="form-label">Phone Number</label>
         <div class="form-sub-label">

--- a/apps/concierge_site/test/feature/update_account_test.exs
+++ b/apps/concierge_site/test/feature/update_account_test.exs
@@ -1,0 +1,26 @@
+defmodule ConciergeSite.UpdateAccountTest do
+  use ConciergeSite.FeatureCase, async: true
+
+  import AlertProcessor.Factory
+  import ConciergeSite.FeatureTestHelper
+  import Wallaby.Query, only: [css: 2, radio_button: 1, text_field: 1, button: 1, link: 1]
+
+  @password "p@ssw0rd"
+  @encrypted_password Comeonin.Bcrypt.hashpwsalt(@password)
+
+  test "switching to a text subscription", %{session: session} do
+    user = insert(:user, password: @password, encrypted_password: @encrypted_password)
+
+    session
+    |> log_in(user)
+    |> click(link("Menu"))
+    |> click(link("My Account"))
+    |> click(radio_button("Yes - only send me text alerts"))
+    |> fill_in(text_field("Phone Number"), with: "5554443333")
+    |> click(button("Update account preferences"))
+    |> assert_has(css(".header-container", text: "Create a new alert"))
+    |> click(link("Menu"))
+    |> click(link("My Account"))
+    |> assert_has(css("#user_phone_number", value: "5554443333"))
+  end
+end


### PR DESCRIPTION
On the edit account page, toggle the phone number text input when the user selects that they want to receive messages via text.

<img width="837" alt="screen shot 2018-01-24 at 09 33 24" src="https://user-images.githubusercontent.com/3039310/35337600-a9dc6d06-00e9-11e8-9a74-df39e374a6ca.png">

apps/concierge_site/test/feature/update_account_test.exs