### PR TITLE
Add logger_splunk_backend

### DIFF
--- a/apps/concierge_site/config/prod.exs
+++ b/apps/concierge_site/config/prod.exs
@@ -30,12 +30,20 @@ config :logger,
   level: :info,
   truncate: :infinity,
   handle_sasl_reports: true,
-  backends: [:console]
+  backends: [{Logger.Backend.Splunk, :splunk}, :console]
 
 config :logger, :console,
   level: :info,
   format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
   metadata: [:request_id, :ip]
+
+config :logger, :splunk,
+  connector: Logger.Backend.Splunk.Output.Http,
+  host: 'https://http-inputs-mbta.splunkcloud.com/services/collector/event',
+  token: {:system, "SPLUNK_TOKEN"},
+  level: :debug,
+  format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
+  metadata: [:request_id]
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 

--- a/apps/concierge_site/mix.exs
+++ b/apps/concierge_site/mix.exs
@@ -72,7 +72,10 @@ defmodule ConciergeSite.Mixfile do
       {:wallaby, "~> 0.15", only: :test},
       {:logster, "~> 0.4.0"},
       {:ehmon, git: "https://github.com/heroku/ehmon.git", tag: "v4", only: :prod},
-      {:diskusage_logger, "~> 0.2.0", only: :prod}
+      {:diskusage_logger, "~> 0.2.0", only: :prod},
+      {:logger_splunk_backend, git: "https://github.com/mbta/logger_splunk_backend"},
+      {:httpoison, "~> 0.1", override: true},
+      {:poison, "~> 2.0", override: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -37,6 +37,7 @@
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], [], "hexpm"},
+  "logger_splunk_backend": {:git, "https://github.com/mbta/logger_splunk_backend", "1057b0090db96d2cb078c3e1d37b9e4408a09501", []},
   "logster": {:hex, :logster, "0.4.3", "a20e9c60e94847e60064d99042d10b1d03abac354c2b360842bf9b3386e56b4a", [], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "meck": {:hex, :meck, "0.8.8", "eeb3efe811d4346e1a7f65b2738abc2ad73cbe1a2c91b5dd909bac2ea0414fa6", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},


### PR DESCRIPTION
Add `logger_splunk_backend`. This is largely based on the work in https://github.com/mbta/train_loc/pull/17

I locked in the versions of HTTPoison and Poison because otherwise there was a conflict. Hopefully in a month or so all of our dependencies will be able to use the new version of HTTPoison.