### PR TITLE
Give people 30 days to unsubscribe

### DIFF
--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -134,7 +134,7 @@ defmodule ConciergeSite.Helpers.MailHelper do
   end
 
   def unsubscribe_url(user) do
-    {:ok, token, _permissions} = Token.issue(user, [:unsubscribe])
+    {:ok, token, _permissions} = Token.issue(user, [:unsubscribe], {30, :days})
     Helpers.unsubscribe_url(ConciergeSite.Endpoint, :unsubscribe, token)
   end
 


### PR DESCRIPTION
The unsubscribe link sent in email footers should expire after 30 days, just like the disable account link and the manage subscriptions link.

Previously people could only unsubscribe up to 60 minutes after receiving an email.

https://app.asana.com/0/415342363785198/528951420816965/f