### PR TITLE
Remove Amber alerts code

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -10,8 +10,7 @@ defmodule AlertProcessor.Model.User do
     vacation_start: DateTime.t | nil,
     vacation_end: DateTime.t | nil,
     do_not_disturb_start: Time.t | nil,
-    do_not_disturb_end: Time.t | nil,
-    amber_alert_opt_in: boolean()
+    do_not_disturb_end: Time.t | nil
   }
 
   @type id :: String.t
@@ -37,14 +36,13 @@ defmodule AlertProcessor.Model.User do
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true
     field :sms_toggle, :boolean, virtual: true
-    field :amber_alert_opt_in, :boolean, default: true
 
     timestamps()
   end
 
   @permitted_fields ~w(email phone_number role vacation_start
     vacation_end do_not_disturb_start do_not_disturb_end password
-    password_confirmation amber_alert_opt_in)a
+    password_confirmation)a
   @required_fields ~w(email password)a
 
   @active_admin_roles ~w(customer_support application_administration)
@@ -154,7 +152,7 @@ defmodule AlertProcessor.Model.User do
   """
   def update_account_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, ~w(phone_number do_not_disturb_start do_not_disturb_end amber_alert_opt_in))
+    |> cast(params, ~w(phone_number do_not_disturb_start do_not_disturb_end))
     |> validate_format(:phone_number, ~r/^[0-9]{10}$/, message: "Phone number is not in a valid format.")
   end
 

--- a/apps/alert_processor/priv/repo/migrations/20180126151708_remove_amber_alerts_from_users.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180126151708_remove_amber_alerts_from_users.exs
@@ -1,0 +1,9 @@
+defmodule AlertProcessor.Repo.Migrations.RemoveAmberAlertsFromUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :amber_alert_opt_in
+    end
+  end
+end

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -217,8 +217,8 @@ defmodule AlertProcessor.Model.UserTest do
   describe "update_account" do
     test "updates account" do
       user = insert(:user)
-      assert {:ok, user} = User.update_account(user, %{"amber_alert_opt_in" => "true"}, user.id)
-      assert user.amber_alert_opt_in
+      assert {:ok, user} = User.update_account(user, %{"phone_number" => "5550000000"}, user.id)
+      assert user.phone_number == "5550000000"
     end
 
     test "opts in phone number when phone number changed" do
@@ -229,27 +229,27 @@ defmodule AlertProcessor.Model.UserTest do
 
     test "does not opt in phone number when phone number not changed" do
       user = insert(:user)
-      assert {:ok, _} = User.update_account(user, %{"amber_alert_opt_in" => "true"}, user.id)
+      assert {:ok, _} = User.update_account(user, %{"do_not_disturb_start" => ~T[23:00:00], "do_not_disturb_end" => ~T[05:00:00]}, user.id)
       refute_received :opt_in_phone_number
     end
 
     test "does not update account" do
       user = insert(:user)
-      assert {:error, changeset} = User.update_account(user, %{"amber_alert_opt_in" => "no way!"}, user.id)
+      assert {:error, changeset} = User.update_account(user, %{"phone_number" => "not a phone number"}, user.id)
       refute changeset.valid?
     end
 
     test "does not opt in phone number when does not save" do
       user = insert(:user)
-      assert {:error, _} = User.update_account(user, %{"amber_alert_opt_in" => "no way!", "phone_number" => "5550000000"}, user.id)
+      assert {:error, _} = User.update_account(user, %{"do_not_disturb_start" => "not a date", "phone_number" => "5550000000"}, user.id)
       refute_received :opt_in_phone_number
     end
 
     test "performed by admin" do
       admin_user = insert(:user, role: "application_administration")
       user = insert(:user)
-      assert {:ok, user} = User.update_account(user, %{"amber_alert_opt_in" => "true"}, admin_user.id)
-      assert user.amber_alert_opt_in
+      assert {:ok, user} = User.update_account(user, %{"phone_number" => "5550000000"}, admin_user.id)
+      assert user.phone_number == "5550000000"
       assert %{
         item_id: item_id,
         item_type: "User",

--- a/apps/concierge_site/lib/templates/my_account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/my_account/edit.html.eex
@@ -64,20 +64,6 @@
       </div>
     </div>
 
-    <h2>Amber Alerts</h2>
-    <div class="my-account-section">
-      <div class="my-account-section-prompt">
-      Would you like to receive Amber Alerts?
-      </div>
-      <label for="user_amber_alert_opt_in_true" class="my-account-radio-label">
-        <%= radio_button f, :amber_alert_opt_in, "true", checked: @user.amber_alert_opt_in, class: "my-account-radio-button" %>
-        Yes
-      </label>
-      <label for="user_amber_alert_opt_in_false" class="my-account-radio-label">
-        <%= radio_button f, :amber_alert_opt_in, "false", checked: !@user.amber_alert_opt_in, class: "my-account-radio-button" %>
-        No
-      </label>
-    </div>
     <div class="my-account-footer">
       <%= submit "Update account preferences", class: "btn btn-primary update-account" %>
     </div>

--- a/apps/concierge_site/lib/users/user_params.ex
+++ b/apps/concierge_site/lib/users/user_params.ex
@@ -29,8 +29,7 @@ defmodule ConciergeSite.UserParams do
         _ -> %{}
       end
 
-    params
-    |> Map.take(["amber_alert_opt_in"])
+    %{}
     |> Map.merge(phone_number)
     |> Map.merge(do_not_disturb)
   end

--- a/apps/concierge_site/test/web/controllers/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/account_controller_test.exs
@@ -15,8 +15,7 @@ defmodule ConciergeSite.AccountControllerTest do
         "password_confirmation" => "password1",
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
-        "phone_number" => "5551234567",
-        "amber_alert_opt_in" => "false"
+        "phone_number" => "5551234567"
       }}
 
       conn = post(conn, "/account", params)
@@ -31,8 +30,7 @@ defmodule ConciergeSite.AccountControllerTest do
         "password_confirmation" => "password1",
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
-        "phone_number" => "5551234567",
-        "amber_alert_opt_in" => "false"
+        "phone_number" => "5551234567"
       }}
 
       post(conn, "/account", params)
@@ -46,8 +44,7 @@ defmodule ConciergeSite.AccountControllerTest do
         "password_confirmation" => "password1",
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
-        "phone_number" => "",
-        "amber_alert_opt_in" => "false"
+        "phone_number" => ""
       }}
 
       post(conn, "/account", params)
@@ -64,8 +61,7 @@ defmodule ConciergeSite.AccountControllerTest do
         "password" => "",
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
-        "phone_number" => "5551234567",
-        "amber_alert_opt_in" => "false"
+        "phone_number" => "5551234567"
       }}
 
       conn = post(conn, "/account", params)
@@ -84,8 +80,7 @@ defmodule ConciergeSite.AccountControllerTest do
         "password_confirmation" => "password1",
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
-        "phone_number" => "5551234567",
-        "amber_alert_opt_in" => "false"
+        "phone_number" => "5551234567"
       }}
 
       conn = post(conn, "/account", params)

--- a/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
@@ -22,8 +22,7 @@ defmodule ConciergeSite.MyAccountControllerTest do
         "do_not_disturb_start" => "16:30:00",
         "do_not_disturb_end" => "18:30:00",
         "phone_number" => "5551234567",
-        "sms_toggle" => "true",
-        "amber_alert_opt_in" => "false"
+        "sms_toggle" => "true"
       }}
 
       conn = user
@@ -36,7 +35,6 @@ defmodule ConciergeSite.MyAccountControllerTest do
       assert updated_user.phone_number == "5551234567"
       assert updated_user.do_not_disturb_end == ~T[18:30:00.000000]
       assert updated_user.do_not_disturb_start == ~T[16:30:00.000000]
-      assert updated_user.amber_alert_opt_in == false
       assert :error = HoldingQueue.pop()
     end
 
@@ -46,8 +44,7 @@ defmodule ConciergeSite.MyAccountControllerTest do
         "do_not_disturb_end" => "23:45:00",
         "do_not_disturb_start" => "19:30:00",
         "phone_number" => "abc123",
-        "sms_toggle" => "true",
-        "amber_alert_opt_in" => "true"
+        "sms_toggle" => "true"
       }}
 
       conn = user


### PR DESCRIPTION
As far as I can tell, the `amber_alert_opt_in` field is only used on the user account page and not in any alerts matching logic.

This commit removes that column and any logic around it. (Users could still receive Amber alerts if they choose to sign up for moderate severity alerts, but that logic is unrelated.)

This mostly reverts https://github.com/mbta/alerts_concierge/pull/144

![screen shot 2018-01-26 at 10 37 14](https://user-images.githubusercontent.com/3039310/35450633-971f12c6-028e-11e8-851f-34e78dbda21f.png)
