### PR TITLE
Filter estimated notifications time zones

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -40,7 +40,7 @@ defmodule AlertProcessor.NotificationBuilder do
     # create notifications for all remaining mapping subscriptions for current day
     today_subscriptions =
       Enum.reject(sorted_subscriptions, fn(sub) ->
-        Time.compare(sub.start_time, sub.end_time) == :lt && Time.compare(sub.end_time, DateTime.to_time(now)) == :lt
+        Time.compare(sub.start_time, sub.end_time) == :lt && Time.compare(sub.end_time, datetime_to_time(now)) == :lt
       end)
     today_notifications = build_estimated_duration_notifications(user, today_subscriptions, alert, start_datetime, advance_notice_in_seconds)
 
@@ -241,6 +241,13 @@ defmodule AlertProcessor.NotificationBuilder do
     erl_date
     |> DT.from_date_and_time_and_zone!(erl_time, "America/New_York")
     |> DT.shift_zone!("Etc/UTC")
+  end
+
+  @spec datetime_to_time(DateTime.t) :: Time.t
+  defp datetime_to_time(datetime) do
+    datetime
+    |> DT.shift_zone!("America/New_York")
+    |> DateTime.to_time
   end
 
   defp before_or_equal(first_dt, second_dt) do

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -254,7 +254,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
       created_at: utc_time.now
     }
 
-    [s4_notification_2, s1_notification, s4_notification_1] = NotificationBuilder.build_notifications({user, [sub1, sub3, sub2, sub4]}, alert, utc_time.now)
+    [s4_notification_2, s1_notification, s4_notification_1, s2_notification] = NotificationBuilder.build_notifications({user, [sub1, sub3, sub2, sub4]}, alert, utc_time.now)
 
     sub1_id = sub1.id
     sub4_id = sub4.id
@@ -263,6 +263,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
     assert %{notification_subscriptions: [%{subscription_id: ^sub1_id}]} = s1_notification
     assert %{notification_subscriptions: [%{subscription_id: ^sub4_id}]} = s4_notification_1
 
+    assert DT.same_time?(DT.add!(utc_time.now, 60), s2_notification.send_after)
     assert DT.same_time?(DT.add!(utc_time.now, (86_400 * 2) - 655 - (12 * 60 * 60)), s4_notification_2.send_after)
     assert DT.same_time?(DT.add!(utc_time.now, 86_400 - 655 - (3 * 60 * 60)), s1_notification.send_after)
     assert DT.same_time?(DT.add!(utc_time.now, 86_400 - 655 - (12 * 60 * 60)), s4_notification_1.send_after)


### PR DESCRIPTION
The code that filters whether a notification with estimated duration certainty is sent today or tomorrow compares the end time of the subscription to the current time. However it was doing these comparisons in different time zones. This resulted in estimated alerts not being sent when they should have been.

https://app.asana.com/0/415342363785198/542068382161219/f