### PR TITLE
Fix crash for estimated alert diagnostic

### DIFF
--- a/apps/alert_processor/lib/subscription/admin/diagnostic.ex
+++ b/apps/alert_processor/lib/subscription/admin/diagnostic.ex
@@ -44,7 +44,7 @@ defmodule AlertProcessor.Subscription.Diagnostic do
       {:ok, snapshots} <- Snapshot.get_snapshots_by_datetime(user, datetime),
       {:ok, alert} <- DiagnosticQuery.get_alert(alert_id),
       {:ok, alert_versions} <- DiagnosticQuery.get_alert_versions(alert, datetime),
-      {:ok, alert_snapshot} <- Snapshot.serialize_alert_versions(alert_versions) do
+      {:ok, alert_snapshot} <- Snapshot.serialize_alert_versions(alert_versions, datetime) do
         result = snapshots
         |> Enum.map(fn(snap) ->
           build_diagnosis(alert_snapshot, notifications, [snap])

--- a/apps/alert_processor/lib/subscription/admin/snapshot.ex
+++ b/apps/alert_processor/lib/subscription/admin/snapshot.ex
@@ -89,14 +89,14 @@ defmodule AlertProcessor.Subscription.Snapshot do
     end)
   end
 
-  def serialize_alert_versions(alert_versions) do
+  def serialize_alert_versions(alert_versions, datetime) do
     alert =
       alert_versions
       |> Enum.sort_by(&(&1.inserted_at), &NaiveDT.before?/2)
       |> Enum.reduce(%{activities: []}, fn(%{item_changes: changes}, acc) ->
         Map.merge(acc, changes["data"])
       end)
-      |> AlertParser.parse_alert(ServiceInfoCache.get_facility_map(), nil)
+      |> AlertParser.parse_alert(ServiceInfoCache.get_facility_map(), DateTime.to_unix(datetime))
     {:ok, alert}
   end
 


### PR DESCRIPTION
Estimated alerts on the diagnostic page weren't working correctly. This is because a feed timestamp wasn't being passed in.

This PR uses the lookup time of the alert to supply the feed timestamp.