### PR TITLE
convert last updated time in notification email to local time

### DIFF
--- a/apps/concierge_site/lib/helpers/date_helper.ex
+++ b/apps/concierge_site/lib/helpers/date_helper.ex
@@ -5,5 +5,12 @@ defmodule ConciergeSite.Helpers.DateHelper do
 
   alias Calendar.Strftime
 
-  def format_datetime(date), do: Strftime.strftime!(date, "%b %d %Y %I:%M %p")
+  @time_zone "America/New_York"
+
+  def format_datetime(datetime), do: Strftime.strftime!(datetime, "%b %d %Y %I:%M %p")
+  def format_datetime(datetime, :local) do
+    datetime
+    |> Calendar.DateTime.shift_zone!(@time_zone)
+    |> format_datetime()
+  end
 end

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -22,7 +22,7 @@
       <% end %>
 
       <%= if notification.last_push_notification do %>
-        <p>Last Updated: <%= ConciergeSite.Helpers.DateHelper.format_datetime(notification.last_push_notification) %></p>
+        <p>Last Updated: <%= ConciergeSite.Helpers.DateHelper.format_datetime(notification.last_push_notification, :local) %></p>
       <% end %>
 
       <%= if notification.url do %>

--- a/apps/concierge_site/lib/mail_templates/notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.txt.eex
@@ -5,7 +5,7 @@
 <%= notification.description %>
 
 <%= if notification.last_push_notification do %>
-  Last Updated: <%= ConciergeSite.Helpers.DateHelper.format_datetime(notification.last_push_notification) %>
+  Last Updated: <%= ConciergeSite.Helpers.DateHelper.format_datetime(notification.last_push_notification, :local) %>
 <% end %>
 
 More information: <%= notification.url %>

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -20,7 +20,8 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     description: "There is a fire in at south station so it is closed",
     url: "http://www.example.com/alert-info",
     alert: @alert,
-    last_push_notification: ~N[2017-01-18 14:00:00]
+    last_push_notification: %DateTime{year: 2017, month: 1, day: 18, zone_abbr: "UTC", hour: 19, minute: 0, second: 0,
+                                      microsecond: {0, 0}, utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
   }
 
   test "text_email/1 has all necessary content" do


### PR DESCRIPTION
NO TICKET

Great catch @zfletch 

This was a testing failure on my part because I should have set the `last_push_notification` field to the appropriate date format to begin with.