### PR TITLE
Show JSON on diagnostic page

### DIFF
--- a/apps/alert_processor/lib/subscription/admin/diagnostic.ex
+++ b/apps/alert_processor/lib/subscription/admin/diagnostic.ex
@@ -44,13 +44,13 @@ defmodule AlertProcessor.Subscription.Diagnostic do
       {:ok, snapshots} <- Snapshot.get_snapshots_by_datetime(user, datetime),
       {:ok, alert} <- DiagnosticQuery.get_alert(alert_id),
       {:ok, alert_versions} <- DiagnosticQuery.get_alert_versions(alert, datetime),
-      {:ok, alert_snapshot} <- Snapshot.serialize_alert_versions(alert_versions, datetime) do
+      {:ok, parsed_alert_snapshot, unparsed_alert_snapshot} <- Snapshot.serialize_alert_versions(alert_versions, datetime) do
         result = snapshots
         |> Enum.map(fn(snap) ->
-          build_diagnosis(alert_snapshot, notifications, [snap])
+          build_diagnosis(parsed_alert_snapshot, notifications, [snap])
         end)
         |> Enum.reject(&(is_nil(&1)))
-        {:ok, result}
+        {:ok, result, unparsed_alert_snapshot}
     else
       _ ->
         {:error, user}

--- a/apps/alert_processor/lib/subscription/admin/snapshot.ex
+++ b/apps/alert_processor/lib/subscription/admin/snapshot.ex
@@ -90,14 +90,16 @@ defmodule AlertProcessor.Subscription.Snapshot do
   end
 
   def serialize_alert_versions(alert_versions, datetime) do
-    alert =
+    unparsed_alert =
       alert_versions
       |> Enum.sort_by(&(&1.inserted_at), &NaiveDT.before?/2)
       |> Enum.reduce(%{activities: []}, fn(%{item_changes: changes}, acc) ->
         Map.merge(acc, changes["data"])
       end)
-      |> AlertParser.parse_alert(ServiceInfoCache.get_facility_map(), DateTime.to_unix(datetime))
-    {:ok, alert}
+
+    parsed_alert =
+      AlertParser.parse_alert(unparsed_alert, ServiceInfoCache.get_facility_map(), DateTime.to_unix(datetime))
+    {:ok, parsed_alert, unparsed_alert}
   end
 
   defp serialize_informed_entities(informed_entities) do

--- a/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
@@ -119,9 +119,10 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
       |> Notification.create_changeset(notification_params)
       |> Repo.insert!
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
 
       assert result.passed_sent_alert_filter? == false
+      assert alert_id == "114166"
     end
 
     test "alert did not match sent alert", %{user: user, alert: alert} do
@@ -136,8 +137,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passed_sent_alert_filter? == true
+      assert alert_id == "114166"
     end
 
     test "alert matched active period", %{alert: alert, user: user} do
@@ -152,8 +154,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passed_active_period_filter? == true
+      assert alert_id == "114166"
     end
 
     test "alert did not match active period", %{user: user} do
@@ -183,8 +186,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passed_active_period_filter? == false
+      assert alert_id == "114166"
     end
 
     test "alert severity is greater or equal to subscription", %{user: user} do
@@ -212,8 +216,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passed_severity_filter? == true
+      assert alert_id == "114166"
     end
 
     test "alert did not match severity", %{user: user} do
@@ -238,8 +243,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passed_severity_filter? == false
+      assert alert_id == "114166"
     end
 
     test "alert matched vacation period" do
@@ -282,8 +288,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passes_vacation_period? == false
+      assert alert_id == "114166"
     end
 
     test "alert did not match vacation period" do
@@ -324,8 +331,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passes_vacation_period? == true
+      assert alert_id == "114166"
     end
 
     test "alert did not match do not disturb" do
@@ -366,8 +374,9 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
       assert result.passes_do_not_disturb? == true
+      assert alert_id == "114166"
     end
 
     test "with no valid id", %{user: user} do
@@ -414,9 +423,10 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
 
       assert result.passed_informed_entity_filter? == false
+      assert alert_id == alert.alert_id
     end
 
     test "breaks out detailed matches", %{alert: alert} do
@@ -446,7 +456,7 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         "alert_id" => alert.alert_id
       }
 
-      {:ok, [result]} = Diagnostic.diagnose_alert(user, params)
+      {:ok, [result], %{"id" => alert_id}} = Diagnostic.diagnose_alert(user, params)
 
       assert result.matches_any_route_type? == false
       assert result.matches_any_route? == false
@@ -454,6 +464,7 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
       assert result.matches_any_facility? == false
       assert result.matches_any_stop? == false
       assert result.matches_any_trip? == false
+      assert alert_id == "114166"
     end
   end
 end

--- a/apps/concierge_site/assets/css/_admin.scss
+++ b/apps/concierge_site/assets/css/_admin.scss
@@ -414,3 +414,22 @@
     display: none;
   }
 }
+
+.alert-json-row {
+  display: flex;
+  padding: 0.25rem 1rem;
+  display: block;
+
+  @include media-breakpoint-up(sm) {
+    padding: 1rem 3rem;
+  }
+}
+
+.alert-json-info {
+  background-color: $pale-grey;
+  padding: 2px 10px;
+
+  &.hidden {
+    display: none;
+  }
+}

--- a/apps/concierge_site/lib/templates/admin/subscription_search/new.html.eex
+++ b/apps/concierge_site/lib/templates/admin/subscription_search/new.html.eex
@@ -41,6 +41,19 @@
       </div>
     <% else %>
       <%= alert_title(@diagnoses.all) %>
+
+      <div class="alert-json-row">
+        <div id="alert-json" class="alert-json-info hidden">
+          <pre>
+            <%= Poison.encode!(@unparsed_alert, pretty: true) %>
+          </pre>
+        </div>
+
+        <div data-target-sub-id="alert-json" class="diagnostic-result-toggle">
+          <span class="diagnostic-toggle-text alert-json">+ View JSON</span><span class="diagnostic-toggle-text alert-json hidden">- Hide JSON</span>
+        </div>
+      </div>
+
       <%= unless Enum.empty?(@diagnoses.succeeded) do %>
         <div class="diagnostic-subscription-match-title">
           <i class="fa fa-check-circle fa-2x sub-match-title success"></i>
@@ -77,7 +90,7 @@
                 <p><%= informed_entity_result(diagnosis) %></p>
               </div>
               <div data-target-sub-id="<%= diagnosis.subscription.id %>" class="diagnostic-result-toggle">
-                <span class="diagnostic-toggle-text <%= diagnosis.subscription.id %>">+ View Details</span><span class="diagnostic-toggle-text <%= diagnosis.subscription.id %> hidden">+ Hide Details</span>
+                <span class="diagnostic-toggle-text <%= diagnosis.subscription.id %>">+ View Details</span><span class="diagnostic-toggle-text <%= diagnosis.subscription.id %> hidden">- Hide Details</span>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
On the admin diagnostic page, show the alert JSON at the particular time. The JSON is hidden by default and can be shown/hidden by clicking "+ View JSON" or "- Hide JSON"

Also fix a small bug and show "- Hide Details" instead of "+ Hide Details"

https://app.asana.com/0/415342363785198/527321854579984/f

![screen shot 2018-02-02 at 13 10 04](https://user-images.githubusercontent.com/3039310/35748586-81ee9d02-081c-11e8-9ea4-d677de9c9756.png)

![screen shot 2018-02-02 at 13 10 08](https://user-images.githubusercontent.com/3039310/35748587-81f6e7a0-081c-11e8-8e23-4d812c4f4b7a.png)
