### PR TITLE
don't fetch or display trip schedules for CR and Ferry on subscription homepage

### DIFF
--- a/apps/concierge_site/lib/controllers/subscription_controller.ex
+++ b/apps/concierge_site/lib/controllers/subscription_controller.ex
@@ -12,7 +12,6 @@ defmodule ConciergeSite.SubscriptionController do
         redirect(conn, to: subscription_path(conn, :new))
       subscriptions ->
         {:ok, station_display_names} = DisplayInfo.station_names_for_subscriptions(subscriptions)
-        {:ok, departure_time_map} = DisplayInfo.departure_times_for_subscriptions(subscriptions)
 
         dnd_overlap =
           Enum.any?(subscriptions, fn(subscription) ->
@@ -23,7 +22,7 @@ defmodule ConciergeSite.SubscriptionController do
           dnd_overlap: dnd_overlap,
           subscriptions: subscriptions,
           station_display_names: station_display_names,
-          departure_time_map: departure_time_map,
+          departure_time_map: %{},
           vacation_start: user.vacation_start,
           vacation_end: user.vacation_end
     end

--- a/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
@@ -58,14 +58,11 @@ defmodule ConciergeSite.SubscriptionControllerTest do
       assert html_response(conn, 200) =~ "Commuter Rail"
       assert html_response(conn, 200) =~ "Anderson/Woburn"
       assert html_response(conn, 200) =~ "North Station"
-      assert html_response(conn, 200) =~ "Train 331, Weekdays | Departs North Station at 5:10pm"
-      assert html_response(conn, 200) =~ "Train 221, Weekdays | Departs North Station at 6:55pm"
+      assert html_response(conn, 200) =~ "Weekdays from 10:00am to  2:00pm"
 
       assert html_response(conn, 200) =~ "Ferry"
       assert html_response(conn, 200) =~ "Boston (Long Wharf)"
       assert html_response(conn, 200) =~ "Charlestown"
-      assert html_response(conn, 200) =~ "5:00pm, Weekdays | Departs from Boston (Long Wharf)"
-      assert html_response(conn, 200) =~ "5:15pm, Weekdays | Departs from Boston (Long Wharf)"
     end
 
     test "GET /my-subscriptions with bus subscriptions", %{conn: conn} do


### PR DESCRIPTION
[Commuter rail subscriptions are slow to load](https://app.asana.com/0/415342363785198/508466365726547/f)