### PR TITLE
Estimated duration advance notice one hour

### DIFF
--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -182,20 +182,8 @@ defmodule AlertProcessor.Model.Alert do
     Enum.any?(ies, &InformedEntity.entity_type(&1) == :amenity)
   end
 
-  def advance_notice_in_seconds(%__MODULE__{duration_certainty: {:estimated, estimated_duration}, severity: :minor}) do
+  def advance_notice_in_seconds(%__MODULE__{duration_certainty: {:estimated, estimated_duration}}) do
     Enum.min([3600, estimated_duration])
-  end
-  def advance_notice_in_seconds(%__MODULE__{duration_certainty: {:estimated, estimated_duration}, severity: :moderate}) do
-    Enum.min([7200, estimated_duration])
-  end
-  def advance_notice_in_seconds(%__MODULE__{duration_certainty: {:estimated, estimated_duration}, severity: :severe}) do
-    Enum.min([14_400, estimated_duration])
-  end
-  def advance_notice_in_seconds(%__MODULE__{duration_certainty: {:estimated, estimated_duration}, severity: :extreme}) do
-    Enum.min([14_400, estimated_duration])
-  end
-  def advance_notice_in_seconds(%__MODULE__{}) do
-    86_400
   end
 
   def commuter_rail_alert?(%__MODULE__{informed_entities: ies}) when is_list(ies) do

--- a/apps/alert_processor/test/alert_processor/model/alert_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/alert_test.exs
@@ -51,58 +51,15 @@ defmodule AlertProcessor.Model.AlertTest do
     end
   end
 
-  describe "advance_notice_in_seconds/1 estimated minor" do
-    test "returns the default minor value if less than estimated duration" do
-      alert = %Alert{duration_certainty: {:estimated, 7200}, severity: :minor}
+  describe "advance_notice_in_seconds/1" do
+    test "returns the default value if less than estimated duration" do
+      alert = %Alert{duration_certainty: {:estimated, 7200}}
       assert 3600 = Alert.advance_notice_in_seconds(alert)
     end
 
     test "returns the estimated duration if lower than the default minor value" do
-      alert = %Alert{duration_certainty: {:estimated, 1800}, severity: :minor}
+      alert = %Alert{duration_certainty: {:estimated, 1800}}
       assert 1800 = Alert.advance_notice_in_seconds(alert)
-    end
-  end
-
-  describe "advance_notice_in_seconds/1 estimated moderate" do
-    test "returns the default moderate value if less than estimated duration" do
-      alert = %Alert{duration_certainty: {:estimated, 14_400}, severity: :moderate}
-      assert 7200 = Alert.advance_notice_in_seconds(alert)
-    end
-
-    test "returns the estimated duration if lower than the default moderate value" do
-      alert = %Alert{duration_certainty: {:estimated, 3600}, severity: :moderate}
-      assert 3600 = Alert.advance_notice_in_seconds(alert)
-    end
-  end
-
-  describe "advance_notice_in_seconds/1 estimated severe" do
-    test "returns the default severe value if less than estimated duration" do
-      alert = %Alert{duration_certainty: {:estimated, 28_800}, severity: :severe}
-      assert 14_400 = Alert.advance_notice_in_seconds(alert)
-    end
-
-    test "returns the estimated duration if lower than the default severe value" do
-      alert = %Alert{duration_certainty: {:estimated, 7200}, severity: :severe}
-      assert 7200 = Alert.advance_notice_in_seconds(alert)
-    end
-  end
-
-  describe "advance_notice_in_seconds/1 estimated extreme" do
-    test "returns the default extreme value if less than estimated duration" do
-      alert = %Alert{duration_certainty: {:estimated, 28_800}, severity: :extreme}
-      assert 14_400 = Alert.advance_notice_in_seconds(alert)
-    end
-
-    test "returns the estimated duration if lower than the default extreme value" do
-      alert = %Alert{duration_certainty: {:estimated, 3600}, severity: :extreme}
-      assert 3600 = Alert.advance_notice_in_seconds(alert)
-    end
-  end
-
-  describe "advance_notice_in_seconds/1 other" do
-    test "returns the default value" do
-      alert = %Alert{duration_certainty: "KNOWN", severity: :minor}
-      assert 86_400 = Alert.advance_notice_in_seconds(alert)
     end
   end
 


### PR DESCRIPTION
Update the advance notice logic for estimated duration alerts to work the way it does for minor alerts for all alerts.

It now sends the notification up to one hour before the subscription period starts.