### PR TITLE
Fix preload bug in admin diagnostic

### DIFF
--- a/apps/alert_processor/lib/subscription/admin/diagnostic_query.ex
+++ b/apps/alert_processor/lib/subscription/admin/diagnostic_query.ex
@@ -7,7 +7,8 @@ defmodule AlertProcessor.Subscription.DiagnosticQuery do
     notification_query = from n in Notification,
       where: n.user_id == ^user_id,
       where: n.alert_id == ^alert_id,
-      select: n
+      select: n,
+      preload: [:subscriptions]
 
     Repo.all(notification_query)
   end


### PR DESCRIPTION
Preload subscriptions when finding notifications for the admin diagnostic. Without preloading, certain alerts cause errors on [this line](https://github.com/mbta/alerts_concierge/blob/d822db5fd940fbe6a45bf76b1d951d213dc26ffc/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex#L26)

https://app.asana.com/0/529741067494252/548409480717927/f