### PR TITLE
vacation preferences: prevent selection of past start date

### DIFF
--- a/apps/concierge_site/assets/js/vacation-datepicker.js
+++ b/apps/concierge_site/assets/js/vacation-datepicker.js
@@ -15,7 +15,8 @@ export default function($) {
   const now = moment().format("MM/DD/Y");
 
   const vacationStartConfig = objectAssign({}, flatpickrBaseConfig, {
-    defaultDate: now
+    defaultDate: now,
+    minDate: now
   });
 
   const vacationEndConfig = objectAssign({}, flatpickrBaseConfig, {


### PR DESCRIPTION
[Vacation mode start date allows you to select date in the past](https://app.asana.com/0/415342363785198/545185150548407/f)