### PR TITLE
test case for closed alert

### DIFF
--- a/apps/concierge_site/test/support/alert_factory.ex
+++ b/apps/concierge_site/test/support/alert_factory.ex
@@ -8,17 +8,18 @@ defmodule ConciergeSite.AlertFactory do
 
   @one_day 86_400
 
-  def alert(alert_data) do
+  def alert(alert_data, opts \\ [ensure_keys: true]) do
     use_cassette "facilities_alerts", custom: true, clear_mock: true, match_requests_on: [:query] do
       with {:ok, facilities_map} <- ServiceInfoCache.get_facility_map() do
         alert_data
-        |> ensure_alert_data_keys()
+        |> ensure_alert_data_keys(opts[:ensure_keys])
         |> parse_alert(facilities_map, timestamp())
       end
     end
   end
 
-  defp ensure_alert_data_keys(alert_data) do
+  defp ensure_alert_data_keys(alert_data, false), do: alert_data
+  defp ensure_alert_data_keys(alert_data, true) do
     base = %{
       "id" => "1",
       "active_period" => [inclusive_active_period()],


### PR DESCRIPTION
[Confirm what current behavior is when a notification is sent for an alert being closed](https://app.asana.com/0/415342363785198/537317415945440/f)

- the current system does not parse the `closed_timestamp` when it is provided
- because closed notifications do not contain an `active_period` attribute, they get filtered out
- if they didn't get filtered out, the system would log a warning