### PR TITLE
Use eastern time in admin timestamps

### DIFF
--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -53,11 +53,20 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
     (hour * 3600) + (minute * 60) + second
   end
 
-  @spec format_date(NaiveDateTime.t, String.t) :: any
+  @spec format_date(NaiveDateTime.t, String.t) :: String.t
   def format_date(datetime, time_zone \\ @time_zone) do
     with {:ok, utc_datetime} <- DateTime.from_naive(datetime, "Etc/UTC"),
          {:ok, local_datetime} <- DT.shift_zone(utc_datetime, time_zone),
          {:ok, output} <- Strftime.strftime(local_datetime, "%m-%d-%Y") do
+      output
+    end
+  end
+
+  @spec format_time(NaiveDateTime.t, String.t) :: String.t
+  def format_time(datetime, time_zone \\ @time_zone) do
+    with {:ok, utc_datetime} <- DateTime.from_naive(datetime, "Etc/UTC"),
+         {:ok, local_datetime} <- DT.shift_zone(utc_datetime, time_zone),
+         {:ok, output} <- Strftime.strftime(local_datetime, "%l:%M%P") do
       output
     end
   end

--- a/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
@@ -110,6 +110,20 @@ defmodule AlertProcessor.Helpers.DateTimeHelperTest do
     end
   end
 
+  describe "format_time" do
+    test "returns time in %l:%M%P format in provided timezone" do
+      assert DTH.format_time(~N[2017-08-28 12:00:00], "America/New_York") == " 8:00am"
+    end
+
+    test "returns time in %l:%M%P format defaulting to Amerca/New_York" do
+      assert DTH.format_time(~N[2017-08-28 12:00:00]) == " 8:00am"
+    end
+
+    test "returns time in %l:%M%P format and adjusts time based on timezone" do
+      assert DTH.format_time(~N[2017-08-28 02:00:00]) == "10:00pm"
+    end
+  end
+
   describe "determine_relevant_day_of_week" do
     test "handles weekday" do
       friday = DT.from_erl!({{2017, 10, 13}, {12, 0, 0}}, "Etc/UTC")

--- a/apps/concierge_site/lib/users/subscriber_details.ex
+++ b/apps/concierge_site/lib/users/subscriber_details.ex
@@ -286,7 +286,7 @@ defmodule ConciergeSite.SubscriberDetails do
 
   defp date_and_time_values(inserted_at) do
     date = DateTimeHelper.format_date(inserted_at)
-    time = inserted_at |> NaiveDateTime.to_time() |> TimeHelper.format_time()
+    time = inserted_at |> DateTimeHelper.format_time()
     {date, time}
   end
 


### PR DESCRIPTION
On the admin page, use ET instead of UTC to generate the times that are displayed.