### PR TITLE
Add user_id to notification struct

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -100,6 +100,7 @@ defmodule AlertProcessor.NotificationBuilder do
           notification = %Notification{
               alert_id: alert.id,
               user: user,
+              user_id: user.id,
               header: alert.header,
               service_effect: alert.service_effect,
               description: alert.description,


### PR DESCRIPTION
In `AlertProcessor.NotificationBuilder.build_notifications/1`, include the `user_id`. The `Notification` struct is expected to have a `user_id` so this makes it more predictable when used later in the code.

This also fixes a bug in `AlertProcessor.HoldingQueue.enqueue/2`. This function removes duplicates with the following code: `Enum.uniq_by(newstate, & {&1.user_id, &1.alert_id, &1.send_after})`. Since `user_id` wasn't being set, it was `nil`, and so every notification would always have the same `user_id`. Now that it's set, the uniqueness code will work correctly.