### PR TITLE
Add to the holding queue in groups

### DIFF
--- a/apps/alert_processor/lib/dissemination/holding_queue.ex
+++ b/apps/alert_processor/lib/dissemination/holding_queue.ex
@@ -26,11 +26,11 @@ defmodule AlertProcessor.HoldingQueue do
   end
 
   @doc """
-  Add notification to holding queue
+  Add list of notifications to holding queue
   """
-  @spec enqueue(Notification.t) :: :ok
-  def enqueue(name \\ __MODULE__, %Notification{} = notification) do
-    GenServer.call(name, {:push, notification})
+  @spec list_enqueue([Notification.t]) :: :ok
+  def list_enqueue(name \\ __MODULE__, notifications) do
+    GenServer.call(name, {:list_push, notifications})
   end
 
   @doc """
@@ -75,8 +75,8 @@ defmodule AlertProcessor.HoldingQueue do
     [notification | newstate] = notifications
     {:reply, {:ok, notification}, newstate}
   end
-  def handle_call({:push, notification}, _from, notifications) do
-    newstate = [notification | notifications]
+  def handle_call({:list_push, new_notifications}, _from, notifications) do
+    newstate = new_notifications ++ notifications
     {:reply, :ok, Enum.uniq_by(newstate, & {&1.user_id, &1.alert_id, &1.send_after})}
   end
   def handle_call({:remove, removed_alert_ids}, _from, notifications) do

--- a/apps/alert_processor/lib/rules_engine/scheduler.ex
+++ b/apps/alert_processor/lib/rules_engine/scheduler.ex
@@ -24,6 +24,6 @@ defmodule AlertProcessor.Scheduler do
 
   @spec enqueue_notifications([Notification.t]) :: :ok
   defp enqueue_notifications(notifications) do
-    Enum.each(notifications, &HoldingQueue.enqueue/1)
+    HoldingQueue.list_enqueue(notifications)
   end
 end

--- a/apps/alert_processor/test/alert_processor/dissemination/holding_queue_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/holding_queue_test.exs
@@ -29,9 +29,24 @@ defmodule AlertProcessor.HoldingQueueTest do
 
   test "Alert can be added to the queue", %{test: test, fn: future_notification} do
     HoldingQueue.start_link([], [name: test])
-    HoldingQueue.enqueue(test, future_notification)
+    HoldingQueue.list_enqueue(test, [future_notification])
 
     assert HoldingQueue.pop(test) == {:ok, future_notification}
+  end
+
+  test "Multiple alerts can be added to the queue", %{test: test} do
+    HoldingQueue.start_link([], [name: test])
+
+    notification1 = %Notification{alert_id: "1"}
+    notification2 = %Notification{alert_id: "2"}
+    notification3 = %Notification{alert_id: "3"}
+
+    HoldingQueue.list_enqueue(test, [notification1])
+    HoldingQueue.list_enqueue(test, [notification2, notification3])
+
+    assert HoldingQueue.pop(test) == {:ok, notification2}
+    assert HoldingQueue.pop(test) == {:ok, notification3}
+    assert HoldingQueue.pop(test) == {:ok, notification1}
   end
 
   test "messages_to_send/1 retains all notifications for the future", %{test: test} do
@@ -91,8 +106,7 @@ defmodule AlertProcessor.HoldingQueueTest do
     notification1 = %Notification{alert_id: "1", user_id: user.id, user: user, alert: alert1, send_after: send_after}
     notification2 = %Notification{alert_id: "1", user_id: user.id, user: user, alert: alert2, send_after: send_after}
     HoldingQueue.start_link([], [name: test])
-    HoldingQueue.enqueue(test, notification1)
-    HoldingQueue.enqueue(test, notification2)
+    HoldingQueue.list_enqueue(test, [notification2, notification1])
 
     {:ok, notification} = HoldingQueue.pop(test)
     assert notification == notification2

--- a/apps/alert_processor/test/alert_processor/dissemination/queue_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/queue_worker_test.exs
@@ -20,7 +20,7 @@ defmodule AlertProcessor.QueueWorkerTest do
 
     assert HoldingQueue.pop(hq_pid) == :error
     assert SendingQueue.pop(sq_pid) == :error
-    HoldingQueue.enqueue(hq_pid, notification)
+    HoldingQueue.list_enqueue(hq_pid, [notification])
 
     :timer.sleep(100)
 
@@ -36,13 +36,13 @@ defmodule AlertProcessor.QueueWorkerTest do
     assert HoldingQueue.pop(hq_pid) == :error
     assert SendingQueue.pop(sq_pid) == :error
 
-    HoldingQueue.enqueue(hq_pid, notification)
+    HoldingQueue.list_enqueue(hq_pid, [notification])
     :timer.sleep(50)
 
     assert SendingQueue.pop(sq_pid) == {:ok, notification}
     assert HoldingQueue.pop(hq_pid) == :error
 
-    HoldingQueue.enqueue(hq_pid, later_notification)
+    HoldingQueue.list_enqueue(hq_pid, [later_notification])
     :timer.sleep(50)
 
     assert SendingQueue.pop(sq_pid) == {:ok, later_notification}

--- a/apps/concierge_site/test/web/controllers/accessibility_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/accessibility_subscription_controller_test.exs
@@ -109,7 +109,7 @@ defmodule ConciergeSite.AccessibilitySubscriptionControllerTest do
 
     test "PATCH /subscriptions/accessibility/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, accessibility_subscription_entities())

--- a/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
@@ -95,7 +95,7 @@ defmodule ConciergeSite.BikeStorageSubscriptionControllerTest do
 
     test "PATCH /subscriptions/bike_storage/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, bike_storage_subscription_entities())

--- a/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
@@ -221,7 +221,7 @@ defmodule ConciergeSite.BusSubscriptionControllerTest do
 
     test "PATCH /subscriptions/bus/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> bus_subscription()

--- a/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
@@ -140,7 +140,7 @@ defmodule ConciergeSite.CommuterRailSubscriptionControllerTest do
 
     test "PATCH /subscriptions/commuter_rail/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, commuter_rail_subscription_entities())

--- a/apps/concierge_site/test/web/controllers/ferry_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/ferry_subscription_controller_test.exs
@@ -144,7 +144,7 @@ defmodule ConciergeSite.FerrySubscriptionControllerTest do
 
     test "PATCH /subscriptions/ferry/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, ferry_subscription_entities())

--- a/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
@@ -16,7 +16,7 @@ defmodule ConciergeSite.MyAccountControllerTest do
 
     test "PATCH /my-account/ with valid params", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       params = %{"user" => %{
         "dnd_toggle" => "true",
         "do_not_disturb_start" => "16:30:00",

--- a/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
@@ -95,7 +95,7 @@ defmodule ConciergeSite.ParkingSubscriptionControllerTest do
 
     test "PATCH /subscriptions/parking/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, parking_subscription_entities())

--- a/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
@@ -131,7 +131,7 @@ defmodule ConciergeSite.SubscriptionControllerTest do
       user = insert(:user)
       {:ok, subscription} = insert_bus_subscription_for_user(user)
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
 
       conn = user
       |> guardian_login(conn)

--- a/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
@@ -142,7 +142,7 @@ defmodule ConciergeSite.SubwaySubscriptionControllerTest do
 
     test "PATCH /subscriptions/subway/:id", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> subway_subscription()

--- a/apps/concierge_site/test/web/controllers/vacation_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/vacation_controller_test.exs
@@ -16,7 +16,7 @@ defmodule ConciergeSite.VacationControllerTest do
 
     test "PATCH /my-account/vacation with a valid submission", %{conn: conn, user: user} do
       notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.enqueue(notification)
+      :ok = HoldingQueue.list_enqueue([notification])
       params = %{"user" => %{
         "vacation_start" => "09/01/2017",
         "vacation_end" => "09/01/2035"


### PR DESCRIPTION
Instead of adding to the holding queue and then calling `uniq_by/2` on everything individually, add everything to the holding queue at once.

In my tests this made things slightly faster. It brought the 5m14s in https://github.com/mbta/alerts_concierge/pull/570 (when rebased off of that code) down to around 4m45s.