### PR TITLE
avoid alert retry

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -434,4 +434,8 @@ defmodule AlertProcessor.Model.Subscription do
   def route_count(subscription) do
     Enum.count(subscription.informed_entities, &InformedEntity.entity_type(&1) == :route && &1.direction_id != nil)
   end
+
+  def get_last_inserted_timestamp() do
+    Repo.one(from s in __MODULE__, order_by: [desc: s.updated_at], select: s.updated_at, limit: 1)
+  end
 end

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -6,20 +6,32 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
   alias AlertProcessor.{ActivePeriodFilter, InformedEntityFilter, Model,
     Repo, Scheduler, SentAlertFilter, SeverityFilter}
   alias Model.{Alert, Notification, Subscription}
+  require Logger
 
-  @spec schedule_all_notifications([Alert.t]) :: Keyword.t
+  @spec schedule_all_notifications([Alert.t]) :: {integer, Keyword.t}
   def schedule_all_notifications(alerts) do
     all_subscriptions = Subscription
     |> Repo.all()
     |> Repo.preload(:user)
     |> Repo.preload(:informed_entities)
 
-    notifications = Notification.most_recent_for_subscriptions_and_alerts(all_subscriptions, alerts)
+    subscription_timestamp = Subscription.get_last_inserted_timestamp()
+    start_time = Time.utc_now()
 
-    for alert <- alerts do
-      matched_subscriptions = determine_recipients(alert, all_subscriptions, notifications)
-      schedule_distinct_notifications(alert, matched_subscriptions)
-    end
+    {skipped, matched_notifications} = Enum.reduce(alerts, {0, []}, fn(alert, {last_skipped, existing_notifications}) ->
+      {checked?, old_timestamp} = get_and_set_last_subscription_timestamp(alert, subscription_timestamp)
+      new_subscriptions = subscritptions_new_to_alert(checked?, all_subscriptions, subscription_timestamp, old_timestamp)
+      case new_subscriptions do
+        [] -> {last_skipped + 1, [{:ok, []}] ++ existing_notifications}
+        new_subscriptions ->
+          notifications = Notification.most_recent_for_subscriptions_and_alerts(new_subscriptions, [alert])
+          matched_subscriptions = determine_recipients(alert, new_subscriptions, notifications)
+          notifications = schedule_distinct_notifications(alert, matched_subscriptions)
+          {last_skipped, [notifications] ++ existing_notifications}
+      end
+    end)
+    Logger.info(fn -> "alert matching, time=#{Time.diff(Time.utc_now(), start_time, :millisecond)}, skipped: #{skipped}" end)
+    {skipped, matched_notifications}
   end
 
   @doc """
@@ -43,5 +55,28 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
     |> Enum.group_by(& &1.user)
     |> Map.to_list()
     |> Scheduler.schedule_notifications(alert)
+  end
+
+  defp get_and_set_last_subscription_timestamp(alert, new_timestamp) do
+    name = :subscription_filter
+    key = :erlang.phash2(alert)
+    case ConCache.get(name, key) do
+      nil ->
+        cache_alert(name, key, new_timestamp)
+        {false, nil}
+      old_timestamp ->
+        if old_timestamp != new_timestamp, do: cache_alert(name, key, new_timestamp)
+        {true, old_timestamp}
+    end
+  end
+
+  defp cache_alert(name, key, value) do
+    ConCache.put(name, key, %ConCache.Item{value: value, ttl: :timer.hours(12)})
+  end
+
+  defp subscritptions_new_to_alert(true, _subscriptions, last_timestamp, last_timestamp), do: []
+  defp subscritptions_new_to_alert(false, subscriptions, _, _), do: subscriptions
+  defp subscritptions_new_to_alert(true, subscriptions, _last_timestamp, cached_timestamp) do
+    Enum.filter(subscriptions, & &1.inserted_at > cached_timestamp)
   end
 end

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -37,6 +37,7 @@ defmodule AlertProcessor.Supervisor do
     children = [
       supervisor(Registry, [:unique, :mailer_process_registry]),
       supervisor(AlertProcessor.Repo, []),
+      supervisor(ConCache, [[ttl_check: :timer.minutes(10)], [name: :subscription_filter]]),
       worker(ServiceInfoCache, []),
       worker(AlertWorker, []),
       worker(AlertCache, []),

--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -32,6 +32,7 @@ defmodule AlertProcessor.Mixfile do
         :crypto,
         :calendar,
         :comeonin,
+        :con_cache,
         :sweet_xml, # Must come before ex_aws
         :ex_aws,
         :ex_rated,
@@ -61,6 +62,7 @@ defmodule AlertProcessor.Mixfile do
       {:bamboo_smtp, "~> 1.3.0", only: [:test]},
       {:calendar, "~> 0.17.2"},
       {:comeonin, "~> 3.0"},
+      {:con_cache, "~> 0.12.1"},
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.5.0", only: [:dev]},
       {:ecto, "~> 2.1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
-%{
-  "bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
+%{"bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "bamboo_smtp": {:hex, :bamboo_smtp, "1.3.0", "1e3f162a352b44cc528827a1a3ab2feb0a34592cd76b49b2570abd33accbece3", [:mix], [{:bamboo, "~> 0.8.0", [hex: :bamboo, optional: false]}, {:gen_smtp, "~> 0.11.0", [hex: :gen_smtp, optional: false]}]},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bodyguard": {:hex, :bodyguard, "1.0.0", "611f636762dadd706f166438cf59d7334ed3dc173cc9db26bacd114d7c051abf", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
@@ -7,6 +6,7 @@
   "calendar": {:hex, :calendar, "0.17.4", "22c5e8d98a4db9494396e5727108dffb820ee0d18fed4b0aa8ab76e4f5bc32f1", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "comeonin": {:hex, :comeonin, "3.2.0", "cb10995a22aed6812667efb3856f548818c85d85394d8132bc116fbd6995c1ef", [:make, :mix], [{:elixir_make, "~> 0.4", [repo: "hexpm", hex: :elixir_make, optional: false]}], "hexpm"},
+  "con_cache": {:hex, :con_cache, "0.12.1", "7553dcd51ee86fd52bd9ea9aa4b33e71bebf0b5fc5ab60e63d2e0bcaa260f937", [:mix], [{:exactor, "~> 2.2.0", [hex: :exactor, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
@@ -62,5 +62,4 @@
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], []},
   "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"},
-  "wallaby": {:hex, :wallaby, "0.17.0", "a5c348c7a4b203bb5abd53716a5cd81ad8b2545508fa5a6c90efe3daee3f5c5f", [:mix], [{:httpoison, "~> 0.11.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
-}
+  "wallaby": {:hex, :wallaby, "0.17.0", "a5c348c7a4b203bb5abd53716a5cd81ad8b2545508fa5a6c90efe3daee3f5c5f", [:mix], [{:httpoison, "~> 0.11.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
[Investigate ability to avoid rechecking the same subscription/alert pair](https://app.asana.com/0/529741067494252/556680119879530/f)

This caches a hash of each alert with the timestamp of the newest subscription as its value.

When it loops over alerts, it check the cache.

- If the value was not cached, it caches it and matches to all subscriptions.

- If the value was cached, but the timestamp is different, it updates the cache, and matches only to new subscriptions.

- If the value was cached, but the timestamps are the same, it does not match to any subscriptions.