### PR TITLE
Update to newer version of calendar

### DIFF
--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -59,7 +59,7 @@ defmodule AlertProcessor.Mixfile do
     [
       {:bamboo, "~> 0.8", only: [:test]},
       {:bamboo_smtp, "~> 1.3.0", only: [:test]},
-      {:calendar, "~> 0.16.1"},
+      {:calendar, "~> 0.17.2"},
       {:comeonin, "~> 3.0"},
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.5.0", only: [:dev]},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bodyguard": {:hex, :bodyguard, "1.0.0", "611f636762dadd706f166438cf59d7334ed3dc173cc9db26bacd114d7c051abf", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "calendar": {:hex, :calendar, "0.16.1", "782327ad8bae7c797b887840dc4ddb933f05ce6e333e5b04964d7a5d5f79bde3", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, optional: false]}]},
+  "calendar": {:hex, :calendar, "0.17.4", "22c5e8d98a4db9494396e5727108dffb820ee0d18fed4b0aa8ab76e4f5bc32f1", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "comeonin": {:hex, :comeonin, "3.2.0", "cb10995a22aed6812667efb3856f548818c85d85394d8132bc116fbd6995c1ef", [:make, :mix], [{:elixir_make, "~> 0.4", [repo: "hexpm", hex: :elixir_make, optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
@@ -60,7 +60,7 @@
   "scrivener_ecto": {:hex, :scrivener_ecto, "1.2.3", "3255aee5cabfccedcb350f7e5f9f540fb72b8705a763612399264b11ae34faa9", [:mix], [{:ecto, "~> 2.0", [repo: "hexpm", hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0", [repo: "hexpm", hex: :postgrex, optional: true]}, {:scrivener, "~> 2.3", [repo: "hexpm", hex: :scrivener, optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], []},
-  "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [repo: "hexpm", hex: :hackney, optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"},
   "wallaby": {:hex, :wallaby, "0.17.0", "a5c348c7a4b203bb5abd53716a5cd81ad8b2545508fa5a6c90efe3daee3f5c5f", [:mix], [{:httpoison, "~> 0.11.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/scripts/match_alerts.exs
+++ b/scripts/match_alerts.exs
@@ -26,41 +26,45 @@ defmodule MatchAlerts do
     end_time = %DateTime{year: now.year, month: now.month, day: now.day, zone_abbr: "EST", hour: 23, minute: 59, second: 0,
                          microsecond: {0, 0}, utc_offset: -5, std_offset: 0, time_zone: "America/New_York"}
 
-    alerts = Enum.flat_map(1..number_of_alerts, fn (count) ->
-      [
-        %Alert{
-          active_period: [%{end: end_time, start: start_time}],
-          created_at: now,
-          duration_certainty: :known,
-          effect_name: "Service Change",
-          header: "Header Text",
-          id: "matching-#{count}",
-          informed_entities: [%InformedEntity{
-            activities: ["BOARD"], direction_id: 0, inserted_at: nil, route: "Red", route_type: 1, stop: "place-alfcl"}],
-          last_push_notification: now,
-          recurrence: nil,
-          service_effect: "Service Effect",
-          severity: :moderate,
-          timeframe: nil,
-          url: nil},
-        %Alert{
-          active_period: [%{end: end_time, start: start_time}],
-          created_at: now,
-          duration_certainty: :known,
-          effect_name: "Service Change",
-          header: "Header Text",
-          id: "non-matching-#{count}",
-          informed_entities: [%InformedEntity{
-            activities: ["BOARD"], direction_id: 0, inserted_at: nil, route: "Blue", route_type: 1, stop: "place-wondl"}],
-          last_push_notification: now,
-          recurrence: nil,
-          service_effect: "Service Effect",
-          severity: :moderate,
-          timeframe: nil,
-          url: nil
-        }
-      ]
-    end)
+    alerts = if number_of_alerts == 0 do
+      []
+    else
+      Enum.flat_map(1..number_of_alerts, fn (count) ->
+        [
+          %Alert{
+            active_period: [%{end: end_time, start: start_time}],
+            created_at: now,
+            duration_certainty: :known,
+            effect_name: "Service Change",
+            header: "Header Text",
+            id: "matching-#{count}",
+            informed_entities: [%InformedEntity{
+              activities: ["BOARD"], direction_id: 0, inserted_at: nil, route: "Red", route_type: 1, stop: "place-alfcl"}],
+            last_push_notification: now,
+            recurrence: nil,
+            service_effect: "Service Effect",
+            severity: :moderate,
+            timeframe: nil,
+            url: nil},
+          %Alert{
+            active_period: [%{end: end_time, start: start_time}],
+            created_at: now,
+            duration_certainty: :known,
+            effect_name: "Service Change",
+            header: "Header Text",
+            id: "non-matching-#{count}",
+            informed_entities: [%InformedEntity{
+              activities: ["BOARD"], direction_id: 0, inserted_at: nil, route: "Blue", route_type: 1, stop: "place-wondl"}],
+            last_push_notification: now,
+            recurrence: nil,
+            service_effect: "Service Effect",
+            severity: :moderate,
+            timeframe: nil,
+            url: nil
+          }
+        ]
+      end)
+    end
 
     IO.puts "Begin Matching"
     start_notification_count = number_of_sent_notifications()


### PR DESCRIPTION
* Update to new version of Calendar (see the [changelog](https://github.com/lau/calendar/blob/master/CHANGELOG.md) for differences)
* Update alert matching script to account for 0 alerts

In my testing, this didn't affect performance. However the performance issues [are known](https://github.com/lau/tzdata/issues/31) and are hopefully being addressed.

It's also possible that the timezone code will be much faster when `MIX_ENV` is `prod`. Currently the benchmarking scripts only run in `dev`, but that's something we should work on.