### PR TITLE
Fix warning in mailer test

### DIFF
--- a/apps/alert_processor/test/alert_processor/dissemination/mailer_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/mailer_test.exs
@@ -24,6 +24,10 @@ end
 defmodule AlertProcessor.Dissemination.ResponseServer do
   use GenServer
 
+  def init(args) do
+    {:ok, args}
+  end
+
   def handle_call(msg, _from, state) do
     {:reply, {:ok, msg}, state}
   end


### PR DESCRIPTION
Fix the following warning:

```
warning: function init/1 required by behaviour GenServer is not implemented (in module AlertProcessor.Dissemination.ResponseServer).

We will inject a default implementation for now:

    def init(args) do
      {:ok, args}
    end

But you want to define your own implementation that converts the arguments given to GenServer.start_link/3 to the server state
```