### PR TITLE
Get rid of seeds

### DIFF
--- a/apps/alert_processor/priv/repo/seeds.exs
+++ b/apps/alert_processor/priv/repo/seeds.exs
@@ -9,12 +9,3 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
-alias AlertProcessor.{Model.User, Repo}
-
-encrypted_password = Comeonin.Bcrypt.hashpwsalt("password1")
-users = [
-  %User{email: "test_email1@example.com", role: "user", password: "password1", encrypted_password: encrypted_password},
-  %User{email: "test_email2@example.com", phone_number: "5555551234", role: "user", password: "password1", encrypted_password: encrypted_password}
-]
-
-users |> Enum.each(&Repo.insert!/1)


### PR DESCRIPTION
One reason that tests fail locally but work in CI is that running `mix ecto.reset` runs `seeds.exs` in development and test environment. This contaminates the test DB.

Since we're not using these users for anything, I got rid of the seeds entirely. If we ever add them back, we should make sure to do it conditionally on `Mix.env == :dev`

https://app.asana.com/0/529741067494252/565493839819343/f