### PR TITLE
Rename Trip TripInfo

### DIFF
--- a/apps/alert_processor/lib/api/api_client.ex
+++ b/apps/alert_processor/lib/api/api_client.ex
@@ -4,7 +4,7 @@ defmodule AlertProcessor.ApiClient do
   """
   use HTTPoison.Base
 
-  alias AlertProcessor.Model.{Route, Trip}
+  alias AlertProcessor.Model.{Route, TripInfo}
   alias AlertProcessor.Helpers.ConfigHelper
 
   @doc """
@@ -122,7 +122,7 @@ defmodule AlertProcessor.ApiClient do
     |> parse_response()
   end
 
-  @spec schedule_for_trip(Trip.id) :: {:ok, [map]} | {:error, String.t}
+  @spec schedule_for_trip(TripInfo.id) :: {:ok, [map]} | {:error, String.t}
   def schedule_for_trip(trip_id) do
     "/schedules"
     |> api_get(trip: trip_id)

--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -3,7 +3,7 @@ defmodule AlertProcessor.Model.Subscription do
   Set of criteria on which a user wants to be sent alerts.
   """
 
-  alias AlertProcessor.{Helpers.DateTimeHelper, Model.InformedEntity, Model.Trip, Model.User, Repo, TimeFrameComparison}
+  alias AlertProcessor.{Helpers.DateTimeHelper, Model.InformedEntity, Model.TripInfo, Model.User, Repo, TimeFrameComparison}
   import Ecto.Query
 
   @type id :: String.t
@@ -353,7 +353,7 @@ defmodule AlertProcessor.Model.Subscription do
     [:bus, :subway, :commuter_rail, :ferry, :accessibility, :parking, :parking_area, :bike_storage, :elevated_subplatform, :portable_boarding_lift]
   end
 
-  @spec subscription_trip_ids(__MODULE__.t) :: [Trip.id]
+  @spec subscription_trip_ids(__MODULE__.t) :: [TripInfo.id]
   def subscription_trip_ids(subscription) do
     subscription.informed_entities
     |> Enum.filter(fn(informed_entity) ->

--- a/apps/alert_processor/lib/model/trip_info.ex
+++ b/apps/alert_processor/lib/model/trip_info.ex
@@ -1,4 +1,4 @@
-defmodule AlertProcessor.Model.Trip do
+defmodule AlertProcessor.Model.TripInfo do
   @moduledoc """
   Module used for storing information
   about trips for displaying

--- a/apps/alert_processor/lib/subscription/ferry_mapper.ex
+++ b/apps/alert_processor/lib/subscription/ferry_mapper.ex
@@ -5,7 +5,7 @@ defmodule AlertProcessor.Subscription.FerryMapper do
   """
 
   import AlertProcessor.Subscription.Mapper
-  alias AlertProcessor.{ApiClient, Helpers.DateTimeHelper, Model.Route, Model.Subscription, Model.Trip, ServiceInfoCache}
+  alias AlertProcessor.{ApiClient, Helpers.DateTimeHelper, Model.Route, Model.Subscription, Model.TripInfo, ServiceInfoCache}
 
   defdelegate build_subscription_transaction(subscriptions, user, originator), to: AlertProcessor.Subscription.Mapper
   defdelegate build_update_subscription_transaction(subscription, user, originator), to: AlertProcessor.Subscription.Mapper
@@ -49,7 +49,7 @@ defmodule AlertProcessor.Subscription.FerryMapper do
   which consists of a trip number and the description text to be displayed to the user for selecting
   specific trips for their subscription.
   """
-  @spec map_trip_options(String.t, String.t, Subscription.relevant_day) :: :error | {:ok, [Trip.t]}
+  @spec map_trip_options(String.t, String.t, Subscription.relevant_day) :: :error | {:ok, [TripInfo.t]}
   def map_trip_options(origin, destination, relevant_days, today_date \\ Calendar.Date.today!("America/New_York")) do
     {:ok, ferry_info} = ServiceInfoCache.get_ferry_info()
     routes = Enum.filter(ferry_info, fn(%Route{stop_list: stop_list}) -> List.keymember?(stop_list, origin, 1) && List.keymember?(stop_list, destination, 1) end)
@@ -65,7 +65,7 @@ defmodule AlertProcessor.Subscription.FerryMapper do
           {:ok, schedules, _trips} ->
             {:ok, origin_stop} = ServiceInfoCache.get_stop(origin)
             {:ok, destination_stop} = ServiceInfoCache.get_stop(destination)
-            trip = %Trip{origin: origin_stop, destination: destination_stop, direction_id: direction_id}
+            trip = %TripInfo{origin: origin_stop, destination: destination_stop, direction_id: direction_id}
             {:ok, map_common_trips(schedules, trip)}
           _ -> :error
         end
@@ -102,14 +102,14 @@ defmodule AlertProcessor.Subscription.FerryMapper do
 
         %{trip | arrival_time: map_schedule_time(arrival_timestamp), departure_time: map_schedule_time(departure_timestamp), trip_number: generalized_trip_id, route: route}
       end)
-    |> Enum.sort_by(fn(%Trip{departure_time: departure_time}) -> {~T[05:00:00] > departure_time, departure_time} end)
+    |> Enum.sort_by(fn(%TripInfo{departure_time: departure_time}) -> {~T[05:00:00] > departure_time, departure_time} end)
   end
 
   defp map_schedule_time(schedule_datetime) do
     schedule_datetime |> NaiveDateTime.from_iso8601! |> NaiveDateTime.to_time()
   end
 
-  @spec trip_schedule_info_map(String.t, String.t, Subscription.relevant_day) :: %{optional({Route.stop_id, Trip.id}) => DateTime.t}
+  @spec trip_schedule_info_map(String.t, String.t, Subscription.relevant_day) :: %{optional({Route.stop_id, TripInfo.id}) => DateTime.t}
   def trip_schedule_info_map(origin, destination, relevant_days, today_date \\ Calendar.Date.today!("America/New_York")) do
     relevant_date = DateTimeHelper.determine_date(relevant_days, today_date)
     {:ok, data, includes} = ApiClient.schedules(origin, destination, nil, [], relevant_date)

--- a/apps/alert_processor/lib/subscription/mapper.ex
+++ b/apps/alert_processor/lib/subscription/mapper.ex
@@ -3,12 +3,12 @@ defmodule AlertProcessor.Subscription.Mapper do
   Module for common subscription mapping functions to be imported into
   mode-specific mapper modules.
   """
-  alias AlertProcessor.{Helpers.DateTimeHelper, Model.InformedEntity, Model.Route, Model.Subscription, Model.Trip, Model.User, Repo}
+  alias AlertProcessor.{Helpers.DateTimeHelper, Model.InformedEntity, Model.Route, Model.Subscription, Model.TripInfo, Model.User, Repo}
   import Ecto.Query
   alias Ecto.Multi
   alias AlertProcessor.ServiceInfoCache
 
-  @type map_trip_info_fn :: (String.t, String.t, Subscription.relevant_day -> :error | {:ok, [Trip.t]})
+  @type map_trip_info_fn :: (String.t, String.t, Subscription.relevant_day -> :error | {:ok, [TripInfo.t]})
 
   def create_subscriptions(%{"return_start" => nil, "return_end" => nil} = params), do: [do_create_subscription(params)]
   def create_subscriptions(%{"origin" => origin, "destination" => destination} = params) do
@@ -454,7 +454,7 @@ defmodule AlertProcessor.Subscription.Mapper do
     end
   end
 
-  @spec get_trip_info(Route.stop_id, Route.stop_id, Subscription.relevant_day, [Trip.id] | String.t, map_trip_info_fn) :: {:ok, [Trip.t]} | :error
+  @spec get_trip_info(Route.stop_id, Route.stop_id, Subscription.relevant_day, [TripInfo.id] | String.t, map_trip_info_fn) :: {:ok, [TripInfo.t]} | :error
   def get_trip_info(origin, destination, relevant_days, selected_trip_numbers, map_trip_options_fn) when is_list(selected_trip_numbers) do
     case map_trip_options_fn.(origin, destination, relevant_days) do
       {:ok, trips} ->
@@ -497,7 +497,7 @@ defmodule AlertProcessor.Subscription.Mapper do
     abs(departure_start - departure_time)
   end
 
-  @spec get_trip_info_from_subscription(Subscription.t, map_trip_info_fn) :: {:ok, [Trip.t]} | :error
+  @spec get_trip_info_from_subscription(Subscription.t, map_trip_info_fn) :: {:ok, [TripInfo.t]} | :error
   def get_trip_info_from_subscription(subscription, map_trip_options_fn) do
     with [relevant_days] <- subscription.relevant_days,
          selected_trips <- Subscription.subscription_trip_ids(subscription) do

--- a/apps/alert_processor/test/alert_processor/subscription/commuter_rail_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/commuter_rail_mapper_test.exs
@@ -2,7 +2,7 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
   use AlertProcessor.DataCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   import AlertProcessor.Factory
-  alias AlertProcessor.{Model.InformedEntity, Model.Trip, Subscription.CommuterRailMapper}
+  alias AlertProcessor.{Model.InformedEntity, Model.TripInfo, Subscription.CommuterRailMapper}
 
   describe "map_subscriptions one way" do
     @one_way_params %{
@@ -429,49 +429,49 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
     test "returns inbound results for origin destination" do
       use_cassette "north_to_anderson_woburn_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = CommuterRailMapper.map_trip_options("place-north", "Anderson/ Woburn", :weekday, @test_date)
-        assert [%Trip{trip_number: "301", departure_time: ~T[05:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[05:59:00]},
-                %Trip{trip_number: "303", departure_time: ~T[06:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[06:34:00]},
-                %Trip{trip_number: "305", departure_time: ~T[06:37:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[07:01:00]},
-                %Trip{trip_number: "307", departure_time: ~T[07:21:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[07:45:00]},
-                %Trip{trip_number: "391", departure_time: ~T[07:42:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[08:02:00]},
-                %Trip{trip_number: "309", departure_time: ~T[08:16:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[08:40:00]},
-                %Trip{trip_number: "311", departure_time: ~T[09:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[09:39:00]},
-                %Trip{trip_number: "313", departure_time: ~T[10:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[10:39:00]},
-                %Trip{trip_number: "315", departure_time: ~T[11:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[11:39:00]},
-                %Trip{trip_number: "317", departure_time: ~T[12:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[12:39:00]},
-                %Trip{trip_number: "319", departure_time: ~T[13:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[13:39:00]} | rest] = trips
+        assert [%TripInfo{trip_number: "301", departure_time: ~T[05:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[05:59:00]},
+                %TripInfo{trip_number: "303", departure_time: ~T[06:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[06:34:00]},
+                %TripInfo{trip_number: "305", departure_time: ~T[06:37:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[07:01:00]},
+                %TripInfo{trip_number: "307", departure_time: ~T[07:21:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[07:45:00]},
+                %TripInfo{trip_number: "391", departure_time: ~T[07:42:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[08:02:00]},
+                %TripInfo{trip_number: "309", departure_time: ~T[08:16:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[08:40:00]},
+                %TripInfo{trip_number: "311", departure_time: ~T[09:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[09:39:00]},
+                %TripInfo{trip_number: "313", departure_time: ~T[10:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[10:39:00]},
+                %TripInfo{trip_number: "315", departure_time: ~T[11:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[11:39:00]},
+                %TripInfo{trip_number: "317", departure_time: ~T[12:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[12:39:00]},
+                %TripInfo{trip_number: "319", departure_time: ~T[13:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[13:39:00]} | rest] = trips
 
 
-        assert [%Trip{trip_number: "321", departure_time: ~T[14:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[14:39:00]},
-                %Trip{trip_number: "323", departure_time: ~T[15:00:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[15:24:00]},
-                %Trip{trip_number: "325", departure_time: ~T[15:40:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[16:05:00]},
-                %Trip{trip_number: "327", departure_time: ~T[16:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[16:40:00]},
-                %Trip{trip_number: "329", departure_time: ~T[16:45:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:10:00]},
-                %Trip{trip_number: "331", departure_time: ~T[17:10:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:35:00]},
-                %Trip{trip_number: "333", departure_time: ~T[17:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:54:00]},
-                %Trip{trip_number: "335", departure_time: ~T[17:50:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[18:15:00]},
-                %Trip{trip_number: "337", departure_time: ~T[18:30:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[18:55:00]},
-                %Trip{trip_number: "221", departure_time: ~T[18:55:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[19:20:00]},
-                %Trip{trip_number: "339", departure_time: ~T[19:25:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[19:49:00]},
-                %Trip{trip_number: "341", departure_time: ~T[20:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[20:59:00]},
-                %Trip{trip_number: "343", departure_time: ~T[21:45:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[22:09:00]},
-                %Trip{trip_number: "345", departure_time: ~T[22:55:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[23:19:00]},
-                %Trip{trip_number: "347", departure_time: ~T[00:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[00:39:00]}] = rest
+        assert [%TripInfo{trip_number: "321", departure_time: ~T[14:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[14:39:00]},
+                %TripInfo{trip_number: "323", departure_time: ~T[15:00:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[15:24:00]},
+                %TripInfo{trip_number: "325", departure_time: ~T[15:40:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[16:05:00]},
+                %TripInfo{trip_number: "327", departure_time: ~T[16:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[16:40:00]},
+                %TripInfo{trip_number: "329", departure_time: ~T[16:45:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:10:00]},
+                %TripInfo{trip_number: "331", departure_time: ~T[17:10:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:35:00]},
+                %TripInfo{trip_number: "333", departure_time: ~T[17:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[17:54:00]},
+                %TripInfo{trip_number: "335", departure_time: ~T[17:50:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[18:15:00]},
+                %TripInfo{trip_number: "337", departure_time: ~T[18:30:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[18:55:00]},
+                %TripInfo{trip_number: "221", departure_time: ~T[18:55:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[19:20:00]},
+                %TripInfo{trip_number: "339", departure_time: ~T[19:25:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[19:49:00]},
+                %TripInfo{trip_number: "341", departure_time: ~T[20:35:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[20:59:00]},
+                %TripInfo{trip_number: "343", departure_time: ~T[21:45:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[22:09:00]},
+                %TripInfo{trip_number: "345", departure_time: ~T[22:55:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[23:19:00]},
+                %TripInfo{trip_number: "347", departure_time: ~T[00:15:00], direction_id: 0, origin: {"North Station", "place-north", {42.365577, -71.06129}}, destination: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, arrival_time: ~T[00:39:00]}] = rest
       end
     end
 
     test "returns outbound results for origin destination" do
       use_cassette "anderson_woburn_to_north_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = CommuterRailMapper.map_trip_options("Anderson/ Woburn", "place-north", :weekday, @test_date)
-        assert [%Trip{trip_number: "300", departure_time: ~T[05:56:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[06:22:00]},
-                %Trip{trip_number: "302", departure_time: ~T[06:36:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:01:00]},
-                %Trip{trip_number: "304", departure_time: ~T[07:01:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:27:00]},
-                %Trip{trip_number: "306", departure_time: ~T[07:19:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:47:00]},
-                %Trip{trip_number: "308", departure_time: ~T[07:41:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:06:00]},
-                %Trip{trip_number: "310", departure_time: ~T[08:01:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:21:00]},
-                %Trip{trip_number: "392", departure_time: ~T[08:21:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:47:00]},
-                %Trip{trip_number: "312", departure_time: ~T[08:41:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[09:06:00]},
-                %Trip{trip_number: "314", departure_time: ~T[09:06:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[09:31:00]} | _t] = trips
+        assert [%TripInfo{trip_number: "300", departure_time: ~T[05:56:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[06:22:00]},
+                %TripInfo{trip_number: "302", departure_time: ~T[06:36:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:01:00]},
+                %TripInfo{trip_number: "304", departure_time: ~T[07:01:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:27:00]},
+                %TripInfo{trip_number: "306", departure_time: ~T[07:19:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[07:47:00]},
+                %TripInfo{trip_number: "308", departure_time: ~T[07:41:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:06:00]},
+                %TripInfo{trip_number: "310", departure_time: ~T[08:01:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:21:00]},
+                %TripInfo{trip_number: "392", departure_time: ~T[08:21:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[08:47:00]},
+                %TripInfo{trip_number: "312", departure_time: ~T[08:41:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[09:06:00]},
+                %TripInfo{trip_number: "314", departure_time: ~T[09:06:00], direction_id: 1, origin: {"Anderson/Woburn", "Anderson/ Woburn", {42.516987, -71.144475}}, destination: {"North Station", "place-north", {42.365577, -71.06129}}, arrival_time: ~T[09:31:00]} | _t] = trips
       end
     end
 
@@ -482,26 +482,26 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
     test "returns saturday results" do
       use_cassette "waltham_to_porter_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = CommuterRailMapper.map_trip_options("Waltham", "place-portr", :saturday, @test_date)
-        assert [%Trip{trip_number: "1400", departure_time: ~T[07:38:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[07:50:00]},
-                %Trip{trip_number: "1402", departure_time: ~T[09:53:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[10:05:00]},
-                %Trip{trip_number: "1404", departure_time: ~T[11:58:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[12:10:00]},
-                %Trip{trip_number: "1406", departure_time: ~T[14:23:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[14:35:00]},
-                %Trip{trip_number: "1408", departure_time: ~T[16:48:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[17:00:00]},
-                %Trip{trip_number: "1410", departure_time: ~T[19:18:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[19:30:00]},
-                %Trip{trip_number: "1412", departure_time: ~T[22:53:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[23:05:00]} | _t] = trips
+        assert [%TripInfo{trip_number: "1400", departure_time: ~T[07:38:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[07:50:00]},
+                %TripInfo{trip_number: "1402", departure_time: ~T[09:53:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[10:05:00]},
+                %TripInfo{trip_number: "1404", departure_time: ~T[11:58:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[12:10:00]},
+                %TripInfo{trip_number: "1406", departure_time: ~T[14:23:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[14:35:00]},
+                %TripInfo{trip_number: "1408", departure_time: ~T[16:48:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[17:00:00]},
+                %TripInfo{trip_number: "1410", departure_time: ~T[19:18:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[19:30:00]},
+                %TripInfo{trip_number: "1412", departure_time: ~T[22:53:00], direction_id: 1, origin: {"Waltham", "Waltham", {42.374269, -71.235598}}, destination: {"Porter", "place-portr", {42.3884, -71.119149}}, arrival_time: ~T[23:05:00]} | _t] = trips
       end
     end
 
     test "returns sunday results" do
       use_cassette "porter_to_waltham_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = CommuterRailMapper.map_trip_options("place-portr", "Waltham", :sunday, @test_date)
-        assert [%Trip{trip_number: "2401", departure_time: ~T[08:45:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[08:57:00]},
-                %Trip{trip_number: "2403", departure_time: ~T[10:55:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[11:07:00]},
-                %Trip{trip_number: "2405", departure_time: ~T[13:20:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[13:32:00]},
-                %Trip{trip_number: "2407", departure_time: ~T[15:40:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[15:52:00]},
-                %Trip{trip_number: "2409", departure_time: ~T[17:55:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[18:07:00]},
-                %Trip{trip_number: "2411", departure_time: ~T[20:05:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[20:17:00]},
-                %Trip{trip_number: "2413", departure_time: ~T[23:40:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[23:52:00]}] = trips
+        assert [%TripInfo{trip_number: "2401", departure_time: ~T[08:45:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[08:57:00]},
+                %TripInfo{trip_number: "2403", departure_time: ~T[10:55:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[11:07:00]},
+                %TripInfo{trip_number: "2405", departure_time: ~T[13:20:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[13:32:00]},
+                %TripInfo{trip_number: "2407", departure_time: ~T[15:40:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[15:52:00]},
+                %TripInfo{trip_number: "2409", departure_time: ~T[17:55:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[18:07:00]},
+                %TripInfo{trip_number: "2411", departure_time: ~T[20:05:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[20:17:00]},
+                %TripInfo{trip_number: "2413", departure_time: ~T[23:40:00], direction_id: 0, origin: {"Porter", "place-portr", {42.3884, -71.119149}}, destination: {"Waltham", "Waltham", {42.374269, -71.235598}}, arrival_time: ~T[23:52:00]}] = trips
       end
     end
   end
@@ -509,42 +509,42 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
   describe "get_trip_info" do
     test "returns trip options with closest trip preselected" do
       {:ok, trips} = CommuterRailMapper.get_trip_info("Reading", "place-north", :weekday, "10:00:00")
-      assert [%AlertProcessor.Model.Trip{trip_number: "200", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "202", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "204", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "286", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "288", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "290", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "210", selected: true},
-              %AlertProcessor.Model.Trip{trip_number: "212", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "214", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "216", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "292", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "294", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "296", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "298", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "226", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "228", selected: false}] = trips
+      assert [%AlertProcessor.Model.TripInfo{trip_number: "200", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "202", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "204", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "286", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "288", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "290", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "210", selected: true},
+              %AlertProcessor.Model.TripInfo{trip_number: "212", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "214", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "216", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "292", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "294", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "296", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "298", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "226", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "228", selected: false}] = trips
     end
 
     test "returns trip options with preselected values" do
       {:ok, trips} = CommuterRailMapper.get_trip_info("Reading", "place-north", :weekday, ["286", "298"])
-      assert [%AlertProcessor.Model.Trip{trip_number: "200", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "202", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "204", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "286", selected: true},
-              %AlertProcessor.Model.Trip{trip_number: "288", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "290", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "210", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "212", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "214", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "216", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "292", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "294", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "296", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "298", selected: true},
-              %AlertProcessor.Model.Trip{trip_number: "226", selected: false},
-              %AlertProcessor.Model.Trip{trip_number: "228", selected: false}] = trips
+      assert [%AlertProcessor.Model.TripInfo{trip_number: "200", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "202", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "204", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "286", selected: true},
+              %AlertProcessor.Model.TripInfo{trip_number: "288", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "290", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "210", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "212", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "214", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "216", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "292", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "294", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "296", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "298", selected: true},
+              %AlertProcessor.Model.TripInfo{trip_number: "226", selected: false},
+              %AlertProcessor.Model.TripInfo{trip_number: "228", selected: false}] = trips
     end
 
     test "returns error if origin/destination are not on the same route" do
@@ -564,7 +564,7 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
       }
       {:ok, %{departure_trips: departure_trips}} = CommuterRailMapper.populate_trip_options(params)
       selected_trips = Enum.filter(departure_trips, & &1.selected)
-      assert [%Trip{trip_number: "316", departure_time: ~T[09:36:00], selected: true}] = selected_trips
+      assert [%TripInfo{trip_number: "316", departure_time: ~T[09:36:00], selected: true}] = selected_trips
     end
 
     test "one_way with trip_ids returns trip options with preselected trips" do
@@ -578,8 +578,8 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
       {:ok, %{departure_trips: departure_trips}} = CommuterRailMapper.populate_trip_options(params)
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "316", selected: true},
-        %Trip{trip_number: "318", selected: true}
+        %TripInfo{trip_number: "316", selected: true},
+        %TripInfo{trip_number: "318", selected: true}
       ] = selected_trips
     end
 
@@ -624,10 +624,10 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       selected_return_trips = Enum.filter(return_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "316", departure_time: ~T[09:36:00], selected: true},
+        %TripInfo{trip_number: "316", departure_time: ~T[09:36:00], selected: true},
       ] = selected_trips
       assert [
-        %Trip{trip_number: "327", departure_time: ~T[16:15:00], selected: true}
+        %TripInfo{trip_number: "327", departure_time: ~T[16:15:00], selected: true}
       ] = selected_return_trips
     end
 
@@ -648,12 +648,12 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       selected_return_trips = Enum.filter(return_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "316", selected: true},
-        %Trip{trip_number: "318", selected: true}
+        %TripInfo{trip_number: "316", selected: true},
+        %TripInfo{trip_number: "318", selected: true}
       ] = selected_trips
       assert [
-        %Trip{trip_number: "331", selected: true},
-        %Trip{trip_number: "221", selected: true}
+        %TripInfo{trip_number: "331", selected: true},
+        %TripInfo{trip_number: "221", selected: true}
       ] = selected_return_trips
     end
 

--- a/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
@@ -2,7 +2,7 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
   use AlertProcessor.DataCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   import AlertProcessor.Factory
-  alias AlertProcessor.{Model.InformedEntity, Model.Trip, Subscription.FerryMapper}
+  alias AlertProcessor.{Model.InformedEntity, Model.TripInfo, Subscription.FerryMapper}
 
   describe "map_subscriptions one way" do
     @one_way_params %{
@@ -236,14 +236,14 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
     test "returns inbound results for origin destination" do
       use_cassette "long_wharf_to_hingham_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = FerryMapper.map_trip_options("Boat-Long", "Boat-Hingham", :weekday, @test_date)
-        assert Enum.all?(trips, &match?(&1, %Trip{destination: {"Hingham (Hewitt's Cove)", "Boat-Hingham"}, direction_id: 0, origin: {"Boston (Long Wharf)", "Boat-Long"}}))
+        assert Enum.all?(trips, &match?(&1, %TripInfo{destination: {"Hingham (Hewitt's Cove)", "Boat-Hingham"}, direction_id: 0, origin: {"Boston (Long Wharf)", "Boat-Long"}}))
       end
     end
 
     test "returns outbound results for origin destination" do
       use_cassette "hingham_to_long_wharf_schedules", custom: true, clear_mock: true, match_requests_on: [:query] do
         {:ok, trips} = FerryMapper.map_trip_options("Boat-Hingham", "Boat-Long", :weekday, @test_date)
-        assert Enum.all?(trips, &match?(&1, %Trip{destination: {"Boston (Long Wharf)", "Boat-Long"}, direction_id: 1, origin: {"Hingham (Hewitt's Cove)", "Boat-Hingham"}}))
+        assert Enum.all?(trips, &match?(&1, %TripInfo{destination: {"Boston (Long Wharf)", "Boat-Long"}, direction_id: 1, origin: {"Hingham (Hewitt's Cove)", "Boat-Hingham"}}))
       end
     end
 
@@ -287,7 +287,7 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
       }
       {:ok, %{departure_trips: departure_trips}} = FerryMapper.populate_trip_options(params)
       selected_trips = Enum.filter(departure_trips, & &1.selected)
-      assert [%Trip{departure_time: ~T[10:00:00], selected: true}] = selected_trips
+      assert [%TripInfo{departure_time: ~T[10:00:00], selected: true}] = selected_trips
     end
 
     test "one_way with trip_ids returns trip options with preselected trips" do
@@ -301,8 +301,8 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
       {:ok, %{departure_trips: departure_trips}} = FerryMapper.populate_trip_options(params)
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "Boat-F1-Boat-Hingham-13:00:00-weekday-1", selected: true},
-        %Trip{trip_number: "Boat-F1-Boat-Hingham-15:00:00-weekday-1", selected: true}
+        %TripInfo{trip_number: "Boat-F1-Boat-Hingham-13:00:00-weekday-1", selected: true},
+        %TripInfo{trip_number: "Boat-F1-Boat-Hingham-15:00:00-weekday-1", selected: true}
       ] = selected_trips
     end
 
@@ -347,10 +347,10 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       selected_return_trips = Enum.filter(return_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "Boat-F1-Boat-Hingham-10:00:00-weekday-1", selected: true},
+        %TripInfo{trip_number: "Boat-F1-Boat-Hingham-10:00:00-weekday-1", selected: true},
       ] = selected_trips
       assert [
-        %Trip{trip_number: "Boat-F1-Boat-Long-15:40:00-weekday-0", selected: true}
+        %TripInfo{trip_number: "Boat-F1-Boat-Long-15:40:00-weekday-0", selected: true}
       ] = selected_return_trips
     end
 
@@ -371,12 +371,12 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
       selected_trips = Enum.filter(departure_trips, & &1.selected)
       selected_return_trips = Enum.filter(return_trips, & &1.selected)
       assert [
-        %Trip{trip_number: "Boat-F1-Boat-Hingham-13:00:00-weekday-1", selected: true},
-        %Trip{trip_number: "Boat-F1-Boat-Hingham-15:00:00-weekday-1", selected: true}
+        %TripInfo{trip_number: "Boat-F1-Boat-Hingham-13:00:00-weekday-1", selected: true},
+        %TripInfo{trip_number: "Boat-F1-Boat-Hingham-15:00:00-weekday-1", selected: true}
       ] = selected_trips
       assert [
-        %Trip{trip_number: "Boat-F1-Boat-Long-14:00:00-weekday-0", selected: true},
-        %Trip{trip_number: "Boat-F1-Boat-Long-16:30:00-weekday-0", selected: true}
+        %TripInfo{trip_number: "Boat-F1-Boat-Long-14:00:00-weekday-0", selected: true},
+        %TripInfo{trip_number: "Boat-F1-Boat-Long-16:30:00-weekday-0", selected: true}
       ] = selected_return_trips
     end
 

--- a/apps/concierge_site/lib/views/commuter_rail_subscription_view.ex
+++ b/apps/concierge_site/lib/views/commuter_rail_subscription_view.ex
@@ -5,7 +5,7 @@ defmodule ConciergeSite.CommuterRailSubscriptionView do
            do_hidden_form_inputs: 2, formatted_day: 1]
   import ConciergeSite.TimeHelper,
     only: [travel_time_options: 0]
-  alias AlertProcessor.Model.Trip
+  alias AlertProcessor.Model.TripInfo
 
   @type trip_type :: :one_way | :round_trip
   @type step :: :trip_type | :trip_info | :train | :preferences
@@ -43,7 +43,7 @@ defmodule ConciergeSite.CommuterRailSubscriptionView do
   def params_for_step(:preferences), do: ["alert_priority_type" | params_for_step(:train)]
   def params_for_step(_), do: []
 
-  @spec trip_option(Trip.t, :depart | :return) :: Phoenix.HTML.safe
+  @spec trip_option(TripInfo.t, :depart | :return) :: Phoenix.HTML.safe
   def trip_option(trip, trip_type) do
     content_tag :div, class: trip_option_classes(trip) do
       [

--- a/apps/concierge_site/lib/views/ferry_subscription_view.ex
+++ b/apps/concierge_site/lib/views/ferry_subscription_view.ex
@@ -1,6 +1,6 @@
 defmodule ConciergeSite.FerrySubscriptionView do
   use ConciergeSite.Web, :view
-  alias AlertProcessor.Model.Trip
+  alias AlertProcessor.Model.TripInfo
   import ConciergeSite.SubscriptionHelper,
     only: [progress_link_class: 3, do_query_string_params: 2,
            do_hidden_form_inputs: 2, formatted_day: 1]
@@ -42,7 +42,7 @@ defmodule ConciergeSite.FerrySubscriptionView do
   def params_for_step(:preferences), do: ["alert_priority_type" | params_for_step(:ferry)]
   def params_for_step(_), do: []
 
-  @spec trip_option(Trip.t, :depart | :return) :: Phoenix.HTML.safe
+  @spec trip_option(TripInfo.t, :depart | :return) :: Phoenix.HTML.safe
   def trip_option(trip, trip_type) do
     content_tag :div, class: trip_option_classes(trip) do
       [


### PR DESCRIPTION
Rename the `Trip` model `TripInfo`. This is because we now have an actual table in the database called `trips` which should have a model called `Trip`.

This is the first part of https://app.asana.com/0/529741067494252/569223392611767/f