### PR TITLE
Make some v2/trip routes singular

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -1,6 +1,10 @@
 defmodule ConciergeSite.V2.TripController do
   use ConciergeSite.Web, :controller
 
+  def index(conn, _params) do
+    render conn, "index.html"
+  end
+
   def new(conn, _params) do
     render conn, "new.html"
   end
@@ -27,5 +31,9 @@ defmodule ConciergeSite.V2.TripController do
 
   def accessibility(conn, _params) do
     render conn, "accessibility.html"
+  end
+
+  def delete(conn, _params) do
+    redirect(conn, to: v2_trip_path(conn, :index))
   end
 end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -141,7 +141,8 @@ defmodule ConciergeSite.Router do
     pipe_through [:browser, :browser_auth, :subscription_auth]
 
     get "/account/options", V2.AccountController, :options
-    resources "/trip", V2.TripController, only: [:new, :create, :edit, :update] do
+    resources "/trips", V2.TripController, only: [:index, :edit, :update, :delete]
+    resources "/trip", V2.TripController, only: [:new, :create], singleton: true do
       resources "/leg", V2.LegController, only: [:new, :create]
       get "/times", V2.TripController, :new_times
       post "/times", V2.TripController, :create_times

--- a/apps/concierge_site/lib/templates/v2/trip/index.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/index.html.eex
@@ -1,0 +1,1 @@
+trip index

--- a/apps/concierge_site/test/feature/v2/create_subscription_test.exs
+++ b/apps/concierge_site/test/feature/v2/create_subscription_test.exs
@@ -30,7 +30,7 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
   test "new leg", %{session: session, user: user} do
     session
     |> log_in(user)
-    |> visit("/v2/trip/:id/leg/new")
+    |> visit("/v2/trip/leg/new")
     |> assert_has(css("#main", text: "new leg"))
   end
 
@@ -46,6 +46,13 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
     |> assert_has(css("#main", text: "new session"))
   end
 
+  test "trip index", %{session: session, user: user} do
+    session
+    |> log_in(user)
+    |> visit("/v2/trips")
+    |> assert_has(css("#main", text: "trip index"))
+  end
+
   test "new trip", %{session: session, user: user} do
     session
     |> log_in(user)
@@ -56,21 +63,21 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
   test "edit trip", %{session: session, user: user} do
     session
     |> log_in(user)
-    |> visit("/v2/trip/:id/edit")
+    |> visit("/v2/trips/:id/edit")
     |> assert_has(css("#main", text: "edit trip"))
   end
 
   test "trip times", %{session: session, user: user} do
     session
     |> log_in(user)
-    |> visit("/v2/trip/:id/times")
+    |> visit("/v2/trip/times")
     |> assert_has(css("#main", text: "new trip times"))
   end
 
   test "trip accessibility", %{session: session, user: user} do
     session
     |> log_in(user)
-    |> visit("/v2/trip/:id/accessibility")
+    |> visit("/v2/trip/accessibility")
     |> assert_has(css("#main", text: "accessibility"))
   end
 end

--- a/apps/concierge_site/test/web/controllers/v2/leg_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/leg_controller_test.exs
@@ -2,25 +2,25 @@ defmodule ConciergeSite.V2.LegControllerTest do
   use ConciergeSite.ConnCase
   import AlertProcessor.Factory
 
-  test "GET /v2/trip/:trip_id/leg/new", %{conn: conn} do
+  test "GET /v2/trip/leg/new", %{conn: conn} do
     user = insert(:user)
 
     conn = user
     |> guardian_login(conn)
-    |> get(v2_trip_leg_path(conn, :new, "trip_id"))
+    |> get(v2_trip_leg_path(conn, :new))
 
-    conn = get(conn, "/v2/trip/:trip_id/leg/new")
+    conn = get(conn, "/v2/trip/leg/new")
     assert html_response(conn, 200) =~ "new leg"
   end
 
-  test "POST /v2/trip/:trip_id/leg", %{conn: conn} do
+  test "POST /v2/trip/leg", %{conn: conn} do
     user = insert(:user)
 
     conn = user
     |> guardian_login(conn)
-    |> post(v2_trip_leg_path(conn, :create, "trip_id"))
+    |> post(v2_trip_leg_path(conn, :create))
 
-    conn = post(conn, "/v2/trip/:trip_id/leg", %{})
+    conn = post(conn, "/v2/trip/leg", %{})
     assert html_response(conn, 200) =~ "new leg"
   end
 end

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -8,12 +8,36 @@ defmodule ConciergeSite.V2.TripControllerTest do
     {:ok, user: user}
   end
 
-  test "GET /v2/trip/:id/edit", %{conn: conn, user: user} do
+  test "GET /v2/trips", %{conn: conn, user: user} do
+    conn = user
+    |> guardian_login(conn)
+    |> get(v2_trip_path(conn, :index))
+
+    assert html_response(conn, 200) =~ "trip index"
+  end
+
+  test "GET /v2/trips/:id/edit", %{conn: conn, user: user} do
     conn = user
     |> guardian_login(conn)
     |> get(v2_trip_path(conn, :edit, "id"))
 
     assert html_response(conn, 200) =~ "edit trip"
+  end
+
+  test "PATCH /v2/trips/:id", %{conn: conn, user: user} do
+    conn = user
+    |> guardian_login(conn)
+    |> patch(v2_trip_path(conn, :update, "id", %{}))
+
+    assert html_response(conn, 200) =~ "edit trip"
+  end
+
+  test "DELETE /v2/trips/:id", %{conn: conn, user: user} do
+    conn = user
+    |> guardian_login(conn)
+    |> delete(v2_trip_path(conn, :delete, "id"))
+
+    assert html_response(conn, 302) =~ v2_trip_path(conn, :index)
   end
 
   test "GET /v2/trip/new", %{conn: conn, user: user} do
@@ -32,34 +56,26 @@ defmodule ConciergeSite.V2.TripControllerTest do
     assert html_response(conn, 200) =~ "new trip"
   end
 
-  test "PATCH /v2/trip/:id", %{conn: conn, user: user} do
+  test "GET /v2/trip/times", %{conn: conn, user: user} do
     conn = user
     |> guardian_login(conn)
-    |> patch(v2_trip_path(conn, :update, "id", %{}))
-
-    assert html_response(conn, 200) =~ "edit trip"
-  end
-
-  test "GET /v2/trip/:trip_id/times", %{conn: conn, user: user} do
-    conn = user
-    |> guardian_login(conn)
-    |> get(v2_trip_trip_path(conn, :new_times, "id"))
+    |> get(v2_trip_trip_path(conn, :new_times))
 
     assert html_response(conn, 200) =~ "new trip times"
   end
 
-  test "POST /v2/trip/:trip_id/times", %{conn: conn, user: user} do
+  test "POST /v2/trip/times", %{conn: conn, user: user} do
     conn = user
     |> guardian_login(conn)
-    |> post(v2_trip_trip_path(conn, :create_times, "id", %{}))
+    |> post(v2_trip_trip_path(conn, :create_times, %{}))
 
     assert html_response(conn, 200) =~ "new trip times"
   end
 
-  test "GET /v2/trip/:trip_id/accessibility", %{conn: conn, user: user} do
+  test "GET /v2/trip/accessibility", %{conn: conn, user: user} do
     conn = user
     |> guardian_login(conn)
-    |> get(v2_trip_trip_path(conn, :accessibility, "id"))
+    |> get(v2_trip_trip_path(conn, :accessibility))
 
     assert html_response(conn, 200) =~ "accessibility"
   end


### PR DESCRIPTION
Since we won't actually have a trip id until the trip is saved, routes like `v2/trip/:trip_id/leg/new` don't really make sense. This change makes those routes `v2/trip/leg/new`.

The new routes are:

```
     v2_page_path  GET     /v2                                            ConciergeSite.V2.PageController :index
  v2_session_path  GET     /v2/login/new                                  ConciergeSite.V2.SessionController :new
  v2_session_path  POST    /v2/login                                      ConciergeSite.V2.SessionController :create
  v2_session_path  DELETE  /v2/login                                      ConciergeSite.V2.SessionController :delete
  v2_account_path  GET     /v2/account/new                                ConciergeSite.V2.AccountController :new
  v2_account_path  POST    /v2/account                                    ConciergeSite.V2.AccountController :create
  v2_account_path  GET     /v2/account/options                            ConciergeSite.V2.AccountController :options
     v2_trip_path  GET     /v2/trips                                      ConciergeSite.V2.TripController :index
     v2_trip_path  GET     /v2/trips/:id/edit                             ConciergeSite.V2.TripController :edit
     v2_trip_path  PATCH   /v2/trips/:id                                  ConciergeSite.V2.TripController :update
		   PUT     /v2/trips/:id                                  ConciergeSite.V2.TripController :update
     v2_trip_path  DELETE  /v2/trips/:id                                  ConciergeSite.V2.TripController :delete
     v2_trip_path  GET     /v2/trip/new                                   ConciergeSite.V2.TripController :new
     v2_trip_path  POST    /v2/trip                                       ConciergeSite.V2.TripController :create
 v2_trip_leg_path  GET     /v2/trip/leg/new                               ConciergeSite.V2.LegController :new
 v2_trip_leg_path  POST    /v2/trip/leg                                   ConciergeSite.V2.LegController :create
v2_trip_trip_path  GET     /v2/trip/times                                 ConciergeSite.V2.TripController :new_times
v2_trip_trip_path  POST    /v2/trip/times                                 ConciergeSite.V2.TripController :create_times
v2_trip_trip_path  GET     /v2/trip/accessibility                         ConciergeSite.V2.TripController :accessibility
```

This makes some changes on top of https://github.com/mbta/alerts_concierge/pull/579