### PR TITLE
v2 help text

### DIFF
--- a/apps/concierge_site/assets/css/app_v2.scss
+++ b/apps/concierge_site/assets/css/app_v2.scss
@@ -9,6 +9,7 @@
 @import "v2/forms.scss";
 @import "vendor/select2/select2";
 @import "vendor/select2/select2-bootstrap4";
+@import "v2/help_text";
 
 body {
   -moz-osx-font-smoothing: grayscale;

--- a/apps/concierge_site/assets/css/v2/_help_text.scss
+++ b/apps/concierge_site/assets/css/v2/_help_text.scss
@@ -1,0 +1,32 @@
+.helptext__link {
+  display: none;
+}
+
+.helptext__link--icon {
+  color: $steel;
+  padding: .25rem;
+
+  &:hover {
+    color: $brand-primary;
+  }
+}
+
+.helptext__message {
+  background-color: $pale-grey;
+  padding: $base-spacing;
+}
+
+.helptext__message--close {
+  display: none;
+  float: right;
+}
+
+.helptext__message--close-icon {
+  background-color: $white;
+  border-radius: 50%;
+  color: $brand-primary;
+
+  &:hover {
+    color: $brand-navy-dark;
+  }
+}

--- a/apps/concierge_site/assets/js/app.js
+++ b/apps/concierge_site/assets/js/app.js
@@ -29,6 +29,7 @@ import subscriptionSearch from './subscription-search';
 import selectRoute from "./select-route";
 import selectStop from "./select-stop";
 import toggleInput from "./toggle-input";
+import helpText from "./help-text";
 
 selectEntity();
 selectMultipleEntity();
@@ -39,5 +40,6 @@ subscriptionSearch();
 selectRoute();
 selectStop();
 toggleInput();
+helpText();
 
 document.body.className = document.body.className.replace("no-js", "js");

--- a/apps/concierge_site/assets/js/help-text.js
+++ b/apps/concierge_site/assets/js/help-text.js
@@ -1,0 +1,32 @@
+export default ($) => {
+  $ = $ || window.jQuery;
+
+  const setMessageDisplay = (messageId, style) => $(`div[data-message-id='${messageId}']`).css({display: style});
+
+  // hide all help messages
+  $("div[data-type='help-message']").each(function() {
+    $(this).css({display: "none"});
+  });
+
+  // show all close buttons, attach event
+  $("a[data-type='close-help-text']").each(function() {
+    const $link = $(this);
+
+    $link.css({display: "inline-block"})
+    .click(e => {
+      e.preventDefault();
+      setMessageDisplay($link.data("message-id"), "none");
+    });
+  });
+
+  // show all help links, attach event
+  $("a[data-type='help-link']").each(function() {
+    const $link = $(this);
+
+    $link.css({display: "inline-block"})
+    .click(e => {
+      e.preventDefault();
+      setMessageDisplay($link.data("message-id"), "block");
+    });
+  });
+};

--- a/apps/concierge_site/lib/views/help_text_helper.ex
+++ b/apps/concierge_site/lib/views/help_text_helper.ex
@@ -1,0 +1,28 @@
+defmodule ConciergeSite.HelpTextHelper do
+  import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+  @spec link(String.t) :: Phoenix.HTML.safe
+  def link(id) do
+    content_tag :a, href: "#show", data: [type: "help-link", message_id: id], class: "helptext__link" do
+      content_tag :i, class: "fa fa-question-circle helptext__link--icon" do
+        ""
+      end
+    end
+  end
+
+  @spec message(String.t, String.t) :: Phoenix.HTML.safe
+  def message(id, message) do
+    content_tag :div, data: [type: "help-message", message_id: id], class: "helptext__message" do
+      [close_message(id), message]
+    end
+  end
+
+  @spec close_message(String.t) :: Phoenix.HTML.safe
+  defp close_message(id) do
+    content_tag :a, href: "#close", data: [type: "close-help-text", message_id: id], class: "helptext__message--close" do
+      content_tag :i, class: "fa fa-times-circle helptext__message--close-icon" do
+        ""
+      end
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/help_text_helper_test.exs
+++ b/apps/concierge_site/test/web/views/help_text_helper_test.exs
@@ -1,0 +1,15 @@
+defmodule ConciergeSite.HelpTextHelperTest do
+  @moduledoc false
+  use ExUnit.Case
+  alias ConciergeSite.HelpTextHelper
+
+  test "link/1" do
+    html = Phoenix.HTML.safe_to_string(HelpTextHelper.link("test"))
+    assert html == "<a class=\"helptext__link\" data-message-id=\"test\" data-type=\"help-link\" href=\"#show\"><i class=\"fa fa-question-circle helptext__link--icon\"></i></a>"
+  end
+
+  test "message/2" do
+    html = Phoenix.HTML.safe_to_string(HelpTextHelper.message("test", "This is a help message."))
+    assert html == "<div class=\"helptext__message\" data-message-id=\"test\" data-type=\"help-message\"><a class=\"helptext__message--close\" data-message-id=\"test\" data-type=\"close-help-text\" href=\"#close\"><i class=\"fa fa-times-circle helptext__message--close-icon\"></i></a>This is a help message.</div>"
+  end
+end


### PR DESCRIPTION
Ticket: [Helptext functionality](https://app.asana.com/0/415342363785198/570673981108056/f)

There are two helper functions: one to create the question mark link and another to create the message area.

For the no-JS case, the help box renders, but the question mark link and close link are not visible.

For the JS case, the message is hidden and the links appear and event handlers are attached.

---

### Usage
```
<%= ConciergeSite.HelpTextHelper.link("test") %>
<%= ConciergeSite.HelpTextHelper.message("test", "This is the help message. We hope you found it to be very helpful. Your welcome.") %>
```

---

### Without JS
![help-no-js](https://user-images.githubusercontent.com/988609/36871353-052f16e8-1d70-11e8-861e-d6983e87b040.png)

---

### With JS
![help-js](https://user-images.githubusercontent.com/988609/36871357-09a9bdd6-1d70-11e8-8756-34f15a24a326.png)
