### PR TITLE
Day selector widget

### DIFF
--- a/apps/concierge_site/assets/brunch-config.js
+++ b/apps/concierge_site/assets/brunch-config.js
@@ -82,7 +82,9 @@ exports.config = {
     enabled: true,
     globals: {
       $: 'jquery',
-      jQuery: 'jquery'
+      jQuery: 'jquery',
+      Tether: 'tether',
+      bootstrap: 'bootstrap'
     },
     static: [
       "node_modules/select2/dist/js/select2.js"

--- a/apps/concierge_site/assets/css/_bootstrap.scss
+++ b/apps/concierge_site/assets/css/_bootstrap.scss
@@ -25,7 +25,7 @@
 // Components
 // @import 'node_modules/bootstrap/scss/animation'; // has .collapse
 // @import 'node_modules/bootstrap/scss/dropdown';
-// @import 'node_modules/bootstrap/scss/button-group';
+@import 'node_modules/bootstrap/scss/button-group';
 // @import 'node_modules/bootstrap/scss/input-group';
 // @import 'node_modules/bootstrap/scss/custom-forms';
 @import 'node_modules/bootstrap/scss/nav';

--- a/apps/concierge_site/assets/css/app_v2.scss
+++ b/apps/concierge_site/assets/css/app_v2.scss
@@ -11,6 +11,7 @@
 @import "vendor/select2/select2";
 @import "vendor/select2/select2-bootstrap4";
 @import "v2/help_text";
+@import "v2/day_selector";
 
 body {
   -moz-osx-font-smoothing: grayscale;

--- a/apps/concierge_site/assets/css/v2/_day_selector.scss
+++ b/apps/concierge_site/assets/css/v2/_day_selector.scss
@@ -1,0 +1,76 @@
+.day-selector {
+  .invisible-no-js {
+    display: none;
+  }
+
+  .invisible-js {
+    display: none;
+  }
+
+  label.btn {
+    box-shadow: none !important;
+    border-color: $brand-primary;
+    border-radius: 0;
+    font-size: $font-size-xs;
+
+    @include media-breakpoint-up(sm) {
+      font-size: $font-size-base;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .title-part {
+    padding-bottom: 4px;
+    padding-left: 9px;
+
+    @include media-breakpoint-up(sm) {
+      padding-left: 15px;
+    }
+
+    .day-header {
+      width: 49px;
+      display: inline-block;
+      font-size: $font-size-xs;
+
+      @include media-breakpoint-up(sm) {
+        width: 69px;
+        font-size: $font-size-sm;
+      }
+    }
+  }
+
+  .day-part {
+    label.btn {
+      width: 50px;
+      color: $brand-primary;
+      margin-bottom: 0;
+
+      @include media-breakpoint-up(sm) {
+        width: 70px;
+      }
+    }
+  }
+  .group-part {
+    label.btn {
+      border-top: 0;
+      border-radius: 0;
+    }
+    .btn-weekdays {
+      width: 246px;
+
+      @include media-breakpoint-up(sm) {
+        width: 346px;
+      }
+    }
+    .btn-weekend {
+      width: 99px;
+
+      @include media-breakpoint-up(sm) {
+        width: 139px;
+      }
+    }
+  }
+}

--- a/apps/concierge_site/assets/js/app.js
+++ b/apps/concierge_site/assets/js/app.js
@@ -30,6 +30,7 @@ import selectRoute from "./select-route";
 import selectStop from "./select-stop";
 import toggleInput from "./toggle-input";
 import helpText from "./help-text";
+import daySelector from "./day-selector";
 
 selectEntity();
 selectMultipleEntity();
@@ -41,5 +42,6 @@ selectRoute();
 selectStop();
 toggleInput();
 helpText();
+daySelector();
 
 document.body.className = document.body.className.replace("no-js", "js");

--- a/apps/concierge_site/assets/js/day-selector.js
+++ b/apps/concierge_site/assets/js/day-selector.js
@@ -1,0 +1,158 @@
+export default function($) {
+  $ = $ || window.jQuery;
+
+  $("div[data-selector='date']").each(function (i, div) {
+    new DaySelector($(div));
+  });
+}
+
+function DaySelector($div) {
+  enable($div);
+
+  this.inputs = {
+    monday: getInput($div, "monday"),
+    tuesday: getInput($div, "tuesday"),
+    wednesday: getInput($div, "wednesday"),
+    thursday: getInput($div, "thursday"),
+    friday: getInput($div, "friday"),
+    saturday: getInput($div, "saturday"),
+    sunday: getInput($div, "sunday"),
+    weekdays: getInput($div, "weekdays"),
+    weekend: getInput($div, "weekend")
+  };
+  this.labels = {};
+  this.state = {};
+
+  this.labelsFromInputs();
+  this.stateFromHtml();
+  this.addListeners();
+}
+
+DaySelector.prototype.labelsFromInputs = function() {
+  for (var day in this.inputs) {
+    this.labels[day] = this.inputs[day].parent("label");
+  }
+};
+
+DaySelector.prototype.addListeners = function() {
+  var that = this;
+
+  for (var day in this.labels) this.labels[day].on("click", renderFn(this, day));
+
+  return this;
+};
+
+DaySelector.prototype.stateFromHtml = function() {
+  for (var day in this.labels) {
+    this.state[day] = isClicked(this.labels[day]);
+  }
+
+  return this;
+};
+
+DaySelector.prototype.htmlFromState = function() {
+  for (var day in this.state) {
+    if (this.state[day]) {
+      clickLabel(this.labels[day]);
+      check(this.inputs[day]);
+    }
+    else {
+      unclickLabel(this.labels[day]);
+      uncheck(this.inputs[day]);
+    }
+  }
+
+  return this;
+};
+
+DaySelector.prototype.toggleState = function(day) {
+  var state = this.state;
+
+  if (day === "weekdays") {
+    if (state.weekdays) {
+      state.monday = false;
+      state.tuesday = false;
+      state.wednesday = false;
+      state.thursday = false;
+      state.friday = false;
+      state.weekdays = false;
+    } else {
+      state.monday = true;
+      state.tuesday = true;
+      state.wednesday = true;
+      state.thursday = true;
+      state.friday = true;
+      state.weekdays = true;
+    }
+  } else if (day === "weekend") {
+    if (state.weekend) {
+      state.saturday = false;
+      state.sunday = false;
+      state.weekend = false;
+    } else {
+      state.saturday = true;
+      state.sunday = true;
+      state.weekend = true;
+    }
+  } else {
+    if (state[day]) {
+      state[day] = false;
+    } else {
+      state[day] = true;
+    }
+
+    if (state.monday && state.tuesday && state.wednesday && state.thursday && state.friday) {
+      state.weekdays = true;
+    } else {
+      state.weekdays = false;
+    }
+
+    if (state.saturday && state.sunday) {
+      state.weekend = true;
+    } else {
+      state.weekend = false;
+    }
+  }
+
+  return this;
+};
+
+function enable($div) {
+  $div.find(".btn-group-toggle").data("toggle", "buttons");
+  $div.find(".invisible-no-js").removeClass("invisible-no-js");
+  $div.find("input").addClass("invisible-js");
+}
+
+function getInput($div, value) {
+  return $div.find(`:input[value='${value}']`);
+}
+
+function renderFn(that, day) {
+  return function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    that.toggleState(day);
+    that.htmlFromState();
+  };
+}
+
+function clickLabel($label) {
+  if (!isClicked($label)) $label.button("toggle");
+}
+
+function unclickLabel($label) {
+  if (isClicked($label)) $label.button("toggle");
+}
+
+function check($input) {
+  $input.prop('checked', true);
+}
+
+function uncheck($input) {
+  $input.prop('checked', false);
+}
+
+function isClicked($label) {
+  return $label.hasClass("active");
+}

--- a/apps/concierge_site/lib/views/day_select_helper.ex
+++ b/apps/concierge_site/lib/views/day_select_helper.ex
@@ -1,0 +1,49 @@
+defmodule ConciergeSite.DaySelectHelper do
+  import Phoenix.HTML.Tag, only: [content_tag: 3, tag: 2]
+
+  @days ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+  @short_days ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+  @spec render(atom) :: Phoenix.HTML.safe
+  def render(input_name) do
+    content_tag :div, class: "day-selector", data: [selector: "date"] do
+      [title(), day(input_name), group()]
+    end
+  end
+
+  defp title do
+    content_tag :div, class: "title-part" do
+      Enum.map(@short_days, & content_tag(:div, &1, class: "day-header"))
+    end
+  end
+
+  defp day(input_name) do
+    content_tag :div, class: "day-part" do
+      content_tag :div, class: "btn-group btn-group-toggle" do
+        Enum.map(@days, & label(input_name, &1))
+      end
+    end
+  end
+
+  defp label(input_name, day) do
+    content_tag :label, class: "btn btn-secondary" do
+      [tag(:input, type: "checkbox", autocomplete: "off", value: day, name: "#{input_name}[days][]"),
+       content_tag(:i, "", class: "fa fa-check")]
+    end
+  end
+
+  defp group do
+    content_tag :div, class: "group-part invisible-no-js" do
+      content_tag :div, class: "btn-group btn-group-toggle" do
+        [content_tag :label, class: "btn btn-secondary btn-weekdays" do
+          [tag(:input, type: "checkbox", autocomplete: "off", value: "weekdays"),
+           "Weekdays"]
+        end,
+          content_tag :label, class: "btn btn-secondary btn-weekend" do
+            [tag(:input, type: "checkbox", autocomplete: "off", value: "weekend"),
+             "Weekend"]
+          end]
+      end
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/day_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/day_select_helper_test.exs
@@ -1,0 +1,15 @@
+defmodule ConciergeSite.DaySelectHelperTest do
+  @moduledoc false
+  use ExUnit.Case
+  alias ConciergeSite.DaySelectHelper
+
+  test "render/1" do
+    html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo))
+
+    assert html =~ "<div class=\"day-selector\" data-selector=\"date\">"
+    assert html =~ "<div class=\"day-header\">Mon</div>"
+    assert html =~ "<input autocomplete=\"off\" name=\"foo[days][]\" type=\"checkbox\" value=\"monday\">"
+    assert html =~ "<div class=\"group-part invisible-no-js\">"
+    assert html =~ "<input autocomplete=\"off\" type=\"checkbox\" value=\"weekdays\">"
+  end
+end


### PR DESCRIPTION
Create widget for selecting days of the week. It also has "Weekdays" and "Weekend" buttons that cause all of the weekdays or weekend days to be selected.

<img width="507" alt="screen shot 2018-03-07 at 11 48 11" src="https://user-images.githubusercontent.com/3039310/37105682-d1a0299c-21fd-11e8-947f-8c6d2109608d.png">

---

Small screen:

<img width="365" alt="screen shot 2018-03-07 at 11 48 25" src="https://user-images.githubusercontent.com/3039310/37105691-d85ffe6a-21fd-11e8-8e1f-81efcf632917.png">

---

Without JavaScript:

<img width="503" alt="screen shot 2018-03-07 at 11 49 38" src="https://user-images.githubusercontent.com/3039310/37105708-df86f9d2-21fd-11e8-8af7-c26a3c0d96a2.png">


https://app.asana.com/0/415342363785198/582941350001603/f