### PR TITLE
Fix AlertProcessor.AlertWorker terminating error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 ALERT_FETCH_INTERVAL=10000
 API_URL=https://dev.api.mbtace.com/
-ALERT_API_URL=http://s3.amazonaws.com/mbta-realtime-test-v2/alerts_enhanced.json
+ALERT_API_URL=http://s3.amazonaws.com/mbta-realtime-test/alerts_enhanced.json
 DATABASE_URL_TEST=postgresql://__username__:password@localhost:5432/alert_concierge_test
 DATABASE_URL_DEV=postgresql://__username__:password@localhost:5432/alert_concierge_dev
 DATABASE_URL_PROD=


### PR DESCRIPTION
Why:

* After following the setup instructions in the README we noticed the
  following errors after running:
  ```
  `env `cat .env` mix phx.server
  ```

  The error:
  ```
  [error] GenServer AlertProcessor.AlertWorker terminating
  ** (Poison.SyntaxError) Unexpected token: <
    (poison) lib/poison/parser.ex:56: Poison.Parser.parse!/2
    (poison) lib/poison.ex:83: Poison.decode!/2
    (httpoison) lib/httpoison/base.ex:471: HTTPoison.Base.response/6
    (alert_processor) lib/api/alerts_client.ex:13:
  AlertProcessor.AlertsClient.get_alerts/0
    (alert_processor) lib/alert_parsing/alert_parser.ex:20:
  AlertProcessor.AlertParser.process_alerts/0
    (alert_processor) lib/alert_parsing/alert_worker.ex:28:
  AlertProcessor.AlertWorker.handle_info/2
    (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
  Last message: :work

  ```
* Asana link: https://app.asana.com/0/529741067494252/586967872253746

This change addresses the need by:

* Editing `.env.example.` to include an up to date `ALERT_API_URL`. The
  "old" `ALERT_API_URL` was returning unexpected values which were
  causing the errors. If you're seeing these errors make sure you update
  your `.env` file with the new `ALERT_API_URL` in `.env.example`.