### PR TITLE
Remove seeds.exs from ecto.setup alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule AlertsConcierge.Mixfile do
   end
 
   defp aliases do
-    ["ecto.setup": ["ecto.create", "ecto.migrate", "run apps/alert_processor/priv/repo/seeds.exs"],
+    ["ecto.setup": ["ecto.create", "ecto.migrate"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
      "test.all": ["ecto.create --quiet", "ecto.migrate", "mocha_test", "coveralls.json", "test"]]
   end


### PR DESCRIPTION
Why:

* The "seeds.exs" step in the `ecto.setup` alias is unused but causing
  pain during the on-boarding/setup process. When following the setup
  instructions in the README we hit a wall when running:

  ```
  env `cat .env` mix ecto.setup
  ```

  This seems to be because the

  ```
  echo 'API_KEY=<YOUR_MBTA_API_KEY>' >> .env
  ```

  step is after the `ecto.setup` step but the `API_KEY` is necessary for
  `seeds.exs` (in ecto.setup alias) to run. Regardless, `seeds.exs` is
  empty so it's not needed.
* Asana link: https://app.asana.com/0/529741067494252/586967872253750

This change addresses the need by:

* Removing the `seeds.exs` task from the `ecto.setup` alias.