### PR TITLE
Support all days of week in notification builder

### DIFF
--- a/apps/alert_processor/lib/helpers/date_time_helper.ex
+++ b/apps/alert_processor/lib/helpers/date_time_helper.ex
@@ -195,36 +195,67 @@ defmodule AlertProcessor.Helpers.DateTimeHelper do
     Calendar.Date.advance!(today_date, 7 - day_of_week)
   end
 
-  def determine_relevant_day_of_week(datetime, time_zone \\ @time_zone) do
+  def within_relevant_day_of_week?(relevant_days, datetime) do
+    Enum.any?(determine_relevant_days_of_week(datetime), fn day ->
+      Enum.member?(relevant_days, day)
+    end)
+  end
+
+  defp determine_relevant_days_of_week(datetime, time_zone \\ @time_zone) do
     {:ok, adjusted_datetime} = DT.shift_zone(datetime, time_zone)
     day_of_week = Date.day_of_week(adjusted_datetime)
     time = DateTime.to_time(adjusted_datetime)
-    do_determine_relevant_day_of_week(time, day_of_week)
+    do_determine_relevant_days_of_week(time, day_of_week)
   end
 
-  defp do_determine_relevant_day_of_week(time, 7) do
-    if in_current_service_date?(time) do
-      :sunday
-    else
-      :saturday
-    end
-  end
-  defp do_determine_relevant_day_of_week(time, 6) do
+  defp do_determine_relevant_days_of_week(time, 1) do
     if in_current_service_date?(time)do
-      :saturday
+      [:weekday, :monday]
     else
-      :weekday
+      [:sunday]
     end
   end
-  defp do_determine_relevant_day_of_week(time, 1) do
+  defp do_determine_relevant_days_of_week(time, 2) do
+    if in_current_service_date?(time)do
+      [:weekday, :tuesday]
+    else
+      [:weekday, :monday]
+    end
+  end
+  defp do_determine_relevant_days_of_week(time, 3) do
+    if in_current_service_date?(time)do
+      [:weekday, :wednesday]
+    else
+      [:weekday, :tuesday]
+    end
+  end
+  defp do_determine_relevant_days_of_week(time, 4) do
+    if in_current_service_date?(time)do
+      [:weekday, :thursday]
+    else
+      [:weekday, :wednesday]
+    end
+  end
+  defp do_determine_relevant_days_of_week(time, 5) do
+    if in_current_service_date?(time)do
+      [:weekday, :friday]
+    else
+      [:weekday, :thursday]
+    end
+  end
+  defp do_determine_relevant_days_of_week(time, 6) do
+    if in_current_service_date?(time)do
+      [:saturday]
+    else
+      [:weekday, :friday]
+    end
+  end
+  defp do_determine_relevant_days_of_week(time, 7) do
     if in_current_service_date?(time) do
-      :weekday
+      [:sunday]
     else
-      :sunday
+      [:saturday]
     end
-  end
-  defp do_determine_relevant_day_of_week(_, _) do
-    :weekday
   end
 
   defp in_current_service_date?(time) do

--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -29,7 +29,7 @@ defmodule AlertProcessor.NotificationBuilder do
         subscription_start_datetime = time_to_datetime(subscription.start_time, now)
         {
           DateTime.compare(subscription_start_datetime, now) == :lt,
-          Enum.member?(subscription.relevant_days, AlertProcessor.Helpers.DateTimeHelper.determine_relevant_day_of_week(subscription_start_datetime)),
+          DateTimeHelper.within_relevant_day_of_week?(subscription.relevant_days, subscription_start_datetime),
           DateTime.to_unix(subscription_start_datetime)
         }
       end)
@@ -63,7 +63,7 @@ defmodule AlertProcessor.NotificationBuilder do
   defp build_estimated_duration_notifications(user, subscriptions, alert, now, advance_notice_in_seconds) do
     Enum.flat_map(subscriptions, fn(sub) ->
       subscription_start_datetime = time_to_datetime(sub.start_time, now)
-      if Enum.member?(sub.relevant_days, DateTimeHelper.determine_relevant_day_of_week(subscription_start_datetime)) do
+      if DateTimeHelper.within_relevant_day_of_week?(sub.relevant_days, subscription_start_datetime) do
         do_build_notifications(user, [sub], alert, DT.subtract!(time_to_datetime(sub.start_time, now), advance_notice_in_seconds), 0)
       else
         []

--- a/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
+++ b/apps/alert_processor/test/alert_processor/helpers/date_time_helper_test.exs
@@ -124,40 +124,107 @@ defmodule AlertProcessor.Helpers.DateTimeHelperTest do
     end
   end
 
-  describe "determine_relevant_day_of_week" do
+  describe "within_relevant_day_of_week?" do
     test "handles weekday" do
       friday = DT.from_erl!({{2017, 10, 13}, {12, 0, 0}}, "Etc/UTC")
-      assert :weekday = DTH.determine_relevant_day_of_week(friday)
+      assert DTH.within_relevant_day_of_week?([:weekday], friday)
+      refute DTH.within_relevant_day_of_week?([:saturday], friday)
     end
 
     test "handles weekday early morning" do
       friday = DT.from_erl!({{2017, 10, 13}, {6, 0, 0}}, "Etc/UTC")
-      assert :weekday = DTH.determine_relevant_day_of_week(friday)
+      assert DTH.within_relevant_day_of_week?([:weekday], friday)
+      refute DTH.within_relevant_day_of_week?([:saturday], friday)
     end
 
-    test "handles monday early morning" do
-      monday = DT.from_erl!({{2017, 10, 9}, {6, 0, 0}}, "Etc/UTC")
-      assert :sunday = DTH.determine_relevant_day_of_week(monday)
+    test "handles weekend early morning" do
+      saturday = DT.from_erl!({{2017, 10, 14}, {6, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:weekday], saturday)
+      refute DTH.within_relevant_day_of_week?([:saturday], saturday)
+    end
+
+    test "handles monday" do
+      monday = DT.from_erl!({{2017, 10, 9}, {12, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:monday], monday)
+      refute DTH.within_relevant_day_of_week?([:sunday], monday)
+    end
+
+    test "handles tuesday" do
+      tuesday = DT.from_erl!({{2017, 10, 10}, {12, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:tuesday], tuesday)
+      refute DTH.within_relevant_day_of_week?([:monday], tuesday)
+    end
+
+    test "handles wednesday" do
+      wednesday = DT.from_erl!({{2017, 10, 11}, {12, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:wednesday], wednesday)
+      refute DTH.within_relevant_day_of_week?([:tuesday], wednesday)
+    end
+
+    test "handles thursday" do
+      thursday = DT.from_erl!({{2017, 10, 12}, {12, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:thursday], thursday)
+      refute DTH.within_relevant_day_of_week?([:wednesday], thursday)
+    end
+
+    test "handles friday" do
+      friday = DT.from_erl!({{2017, 10, 13}, {12, 0, 0}}, "Etc/UTC")
+      assert DTH.within_relevant_day_of_week?([:friday], friday)
+      refute DTH.within_relevant_day_of_week?([:thursday], friday)
     end
 
     test "handles saturday" do
       saturday = DT.from_erl!({{2017, 10, 14}, {12, 0, 0}}, "Etc/UTC")
-      assert :saturday = DTH.determine_relevant_day_of_week(saturday)
-    end
-
-    test "handles saturday early morning" do
-      saturday = DT.from_erl!({{2017, 10, 14}, {6, 30, 0}}, "Etc/UTC")
-      assert :weekday = DTH.determine_relevant_day_of_week(saturday)
+      assert DTH.within_relevant_day_of_week?([:saturday], saturday)
+      refute DTH.within_relevant_day_of_week?([:friday], saturday)
     end
 
     test "handles sunday" do
       sunday = DT.from_erl!({{2017, 10, 15}, {12, 0, 0}}, "Etc/UTC")
-      assert :sunday = DTH.determine_relevant_day_of_week(sunday)
+      assert DTH.within_relevant_day_of_week?([:sunday], sunday)
+      refute DTH.within_relevant_day_of_week?([:saturday], sunday)
+    end
+
+    test "handles monday early morning" do
+      monday = DT.from_erl!({{2017, 10, 9}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:monday], monday)
+      assert DTH.within_relevant_day_of_week?([:sunday], monday)
+    end
+
+    test "handles tuesday early morning" do
+      tuesday = DT.from_erl!({{2017, 10, 10}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:tuesday], tuesday)
+      assert DTH.within_relevant_day_of_week?([:monday], tuesday)
+    end
+
+    test "handles wednesday early morning" do
+      wednesday = DT.from_erl!({{2017, 10, 11}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:wednesday], wednesday)
+      assert DTH.within_relevant_day_of_week?([:tuesday], wednesday)
+    end
+
+    test "handles thursday early morning" do
+      thursday = DT.from_erl!({{2017, 10, 12}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:thursday], thursday)
+      assert DTH.within_relevant_day_of_week?([:wednesday], thursday)
+    end
+
+    test "handles friday early morning" do
+      friday = DT.from_erl!({{2017, 10, 13}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:friday], friday)
+      assert DTH.within_relevant_day_of_week?([:thursday], friday)
+    end
+
+    test "handles saturday early morning" do
+      saturday = DT.from_erl!({{2017, 10, 14}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:saturday], saturday)
+      assert DTH.within_relevant_day_of_week?([:friday], saturday)
     end
 
     test "handles sunday early morning" do
-      sunday = DT.from_erl!({{2017, 10, 15}, {5, 30, 0}}, "Etc/UTC")
-      assert :saturday = DTH.determine_relevant_day_of_week(sunday)
+      sunday = DT.from_erl!({{2017, 10, 15}, {6, 0, 0}}, "Etc/UTC")
+      refute DTH.within_relevant_day_of_week?([:sunday], sunday)
+      assert DTH.within_relevant_day_of_week?([:saturday], sunday)
     end
   end
 


### PR DESCRIPTION
The function `DateTimeHelper.determine_relevant_day_of_week/2` is used in building notifications. Previously it only worked with the values `[:weekday, :saturday, :sunday]`.

This commit changes the function to `within_relevant_day_of_week?/2` and allows it to work with any day of the week (`:monday`, `:tuesday`, etc.).

This is necessary because in v2, users will be able to select a subset of weekdays.

This is one part of https://app.asana.com/0/529741067494252/580915281467966/f (the other part is https://github.com/mbta/alerts_concierge/pull/612)