### PR TITLE
V2 Edit subscription frontend

### DIFF
--- a/apps/alert_processor/lib/model/trip.ex
+++ b/apps/alert_processor/lib/model/trip.ex
@@ -88,4 +88,13 @@ defmodule AlertProcessor.Model.Trip do
   def delete(%Trip{} = trip) do
     Repo.delete(trip)
   end
+
+  def find_by_id(id) do
+    query =
+      from t in __MODULE__,
+        left_join: s in assoc(t, :subscriptions),
+        where: t.id == ^id,
+        preload: [subscriptions: s]
+    Repo.one(query)
+  end
 end

--- a/apps/alert_processor/test/alert_processor/model/trip_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/trip_test.exs
@@ -112,4 +112,10 @@ defmodule AlertProcessor.Model.TripTest do
       assert [] = Repo.all(Subscription)
     end
   end
+
+  test "find_by_id/1 returns trip for valid id", %{user: user} do
+    trip = insert(:trip, %{user_id: user.id})
+    found_trip = Trip.find_by_id(trip.id)
+    assert found_trip.id == trip.id
+  end
 end

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -2,7 +2,7 @@ defmodule AlertProcessor.Factory do
   @moduledoc false
   use ExMachina.Ecto, repo: AlertProcessor.Repo
 
-  alias AlertProcessor.Model.{InformedEntity, Notification, Subscription, User, PasswordReset}
+  alias AlertProcessor.Model.{InformedEntity, Notification, Subscription, User, PasswordReset, Trip}
   alias Calendar.DateTime
 
   def informed_entity_factory do
@@ -179,6 +179,17 @@ defmodule AlertProcessor.Factory do
       expired_at: DateTime.add!(DateTime.now_utc, 3600),
       redeemed_at: nil,
       user: build(:user)
+    }
+  end
+
+  def trip_factory do
+    %Trip{
+      alert_priority_type: :low,
+      relevant_days: [:monday],
+      start_time: ~T[12:00:00],
+      end_time: ~T[18:00:00],
+      notification_time: ~T[11:00:00],
+      station_features: [:accessibility]
     }
   end
 end

--- a/apps/concierge_site/lib/controllers/v2/fallback_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/fallback_controller.ex
@@ -1,0 +1,11 @@
+defmodule ConciergeSite.V2.FallbackController do
+  use ConciergeSite.Web, :controller
+  alias ConciergeSite.ErrorView
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(ErrorView)
+    |> render(:"404")
+  end
+end

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -1,1 +1,58 @@
-edit trip
+<h1 class="heading__title">Edit Subscription</h1>
+<%= flash_error(@conn) %>
+
+<div class="my-4">
+  <%= ConciergeSite.TripCardHelper.render(@conn, @trip) %>
+</div>
+
+<div class="my-4 text-center">
+  <%= link to: "/" do %>
+    <i aria-hidden="true" class="fa fa-trash"></i>
+    Delete this subscription
+  <% end %>
+</div>
+
+<%= form_for @conn, v2_trip_path(@conn, :update, @trip), [as: :trip], fn form -> %>
+  <div class="form-group my-4">
+    <%= label form, :notification_time_drift, "When would you like to start receiving alerts for your trips?", class: "form__label" %>
+    <p>
+      <%= select form, :notification_time_drift, ["30 minutes", "1 hour", "2 hours"], class: "custom-select" %>
+      <em> before my trip</em>
+    </p>
+  </div>
+
+  <div class="form-group my-4">
+    <%= label form, :days, "What days do you take this trip?", class: "form__label" %>
+    <%= ConciergeSite.DaySelectHelper.render(:trip, @trip.relevant_days) %>
+  </div>
+
+  <div class="form-group my-4">
+    <span class="form__label">My first trip is usually at this time:</span>
+    <div class="form-group form-inline form__group--inline">
+      <%= label form, :start_time, "Departing around", class: "form__label--inline" %>
+      <%= text_input form, :start_time, type: "time", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.start_time, :second) %>
+    </div>
+    <div class="form-group form-inline form__group--inline">
+      <%= label form, :end_time, "Arriving around", class: "form__label--inline" %>
+      <%= text_input form, :end_time, type: "time", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.end_time, :second) %>
+    </div>
+  </div>
+
+  <%= if @trip.roundtrip do %>
+  <div class="form-group my-4">
+    <span class="form__label">My return trip is usually at this time:</span>
+    <div class="form-group form-inline form__group--inline">
+      <%= label form, :return_start_time, "Departing around", class: "form__label--inline" %>
+      <%= text_input form, :return_start_time, type: "time", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.return_start_time, :second) %>
+    </div>
+    <div class="form-group form-inline form__group--inline">
+      <%= label form, :return_end_time, "Arriving around", class: "form__label--inline" %>
+      <%= text_input form, :return_end_time, type: "time", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.return_end_time, :second) %>
+    </div>
+  </div>
+<% end %>
+
+  <div class="my-5">
+    <%= submit "Update subscription", class: "btn btn-primary btn-login btn-block" %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/views/day_select_helper.ex
+++ b/apps/concierge_site/lib/views/day_select_helper.ex
@@ -6,11 +6,19 @@ defmodule ConciergeSite.DaySelectHelper do
 
   @spec render(atom) :: Phoenix.HTML.safe
   def render(input_name, checked \\ []) do
-    checked_set = MapSet.new(checked)
+    checked_set = checked |> ensure_days_as_string() |> MapSet.new()
     content_tag :div, class: "day-selector", data: [selector: "date"] do
       [title(), day(input_name, checked_set), group(checked_set)]
     end
   end
+
+  defp ensure_days_as_string([]), do: []
+
+  defp ensure_days_as_string(days), do: Enum.map(days, &ensure_day_as_string/1)
+
+  defp ensure_day_as_string(day) when is_atom(day), do: Atom.to_string(day)
+
+  defp ensure_day_as_string(day) when is_binary(day), do: day
 
   defp title do
     content_tag :div, class: "title-part" do

--- a/apps/concierge_site/test/feature/v2/create_subscription_test.exs
+++ b/apps/concierge_site/test/feature/v2/create_subscription_test.exs
@@ -63,10 +63,11 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
   end
 
   test "edit trip", %{session: session, user: user} do
+    trip = insert(:trip, %{user_id: user.id})
     session
     |> log_in(user)
-    |> visit("/v2/trips/:id/edit")
-    |> assert_has(css("#main", text: "edit trip"))
+    |> visit("/v2/trips/#{trip.id}/edit")
+    |> assert_has(css("#main", text: "Edit Subscription"))
   end
 
   test "trip accessibility", %{session: session, user: user} do

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -16,20 +16,46 @@ defmodule ConciergeSite.V2.TripControllerTest do
     assert html_response(conn, 200) =~ "My account"
   end
 
-  test "GET /v2/trips/:id/edit", %{conn: conn, user: user} do
-    conn = user
-    |> guardian_login(conn)
-    |> get(v2_trip_path(conn, :edit, "id"))
+  describe "GET /v2/trips/:id/edit" do
+    test "with valid trip", %{conn: conn, user: user} do
+      trip = insert(:trip, %{user_id: user.id})
+      conn =
+        user
+        |> guardian_login(conn)
+        |> get(v2_trip_path(conn, :edit, trip.id))
 
-    assert html_response(conn, 200) =~ "edit trip"
+      assert html_response(conn, 200) =~ "Edit Subscription"
+    end
+
+    test "returns 404 with non-existent trip", %{conn: conn, user: user} do
+      non_existent_trip_id = "ba51f08c-ad36-4dd5-a81a-557168c42f51"
+      conn =
+        user
+        |> guardian_login(conn)
+        |> get(v2_trip_path(conn, :edit, non_existent_trip_id))
+
+      assert html_response(conn, 404) =~ "cannot be found"
+    end
+
+    test "returns 404 if user doesn't own trip", %{conn: conn, user: user} do
+      sneaky_user = insert(:user, email: "sneaky_user@emailprovider.com")
+      trip = insert(:trip, user_id: user.id)
+      conn =
+        sneaky_user
+        |> guardian_login(conn)
+        |> get(v2_trip_path(conn, :edit, trip.id))
+
+      assert html_response(conn, 404) =~ "cannot be found"
+    end
   end
 
   test "PATCH /v2/trips/:id", %{conn: conn, user: user} do
+    trip = insert(:trip, %{user_id: user.id})
     conn = user
     |> guardian_login(conn)
-    |> patch(v2_trip_path(conn, :update, "id", %{}))
+    |> patch(v2_trip_path(conn, :update, trip.id, %{}))
 
-    assert html_response(conn, 200) =~ "edit trip"
+    assert html_response(conn, 200) =~ "Edit Subscription"
   end
 
   test "DELETE /v2/trips/:id", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/views/day_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/day_select_helper_test.exs
@@ -19,5 +19,9 @@ defmodule ConciergeSite.DaySelectHelperTest do
 
     assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[days][]\" type=\"checkbox\" value=\"monday\">"
     assert html =~ "<input autocomplete=\"off\" name=\"foo[days][]\" type=\"checkbox\" value=\"tuesday\">"
+
+    html_2 = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, [:monday]))
+
+    assert html == html_2
   end
 end


### PR DESCRIPTION
Why:

* V2 needs a page where users can edit their subscription details.
* Asana link: https://app.asana.com/0/529741067494252/570673981108064

This change addresses the need by:

* Adding `Trip.find_by_id/1` to load a trip and it's subscriptions with
a given trip id. Depending on the authorization strategy we've decided
to use on this project, we might want to edit this function to also
accept a `user_id` and only return the trip with a valid `user_id`.
* Editing V2.TripController edit action to pull a trip using
`Trip.find_by_id/1`
* Adding basic HTML to v2 trip edit page:
`templates/v2/trip/edit.html.eex`.

------------------------------------------------------------------------------------

## Screen shots

### 1. one-way trip:
![screencapture-localhost-4005-v2-trips-6e5dae87-a4e7-4626-8931-a9b759b66c09-edit-2018-03-14-16_45_06](https://user-images.githubusercontent.com/1958868/37429924-1be3d900-27a7-11e8-9d37-9727be4f8a37.png)




### 2. round-trip:
![screencapture-localhost-4005-v2-trips-6e5dae87-a4e7-4626-8931-a9b759b66c09-edit-2018-03-14-19_42_29](https://user-images.githubusercontent.com/1958868/37436833-55abd232-27c0-11e8-98fe-071aa4008599.png)
