### PR TITLE
Add alert_time_difference_in_minutes column

### DIFF
--- a/apps/alert_processor/lib/model/trip.ex
+++ b/apps/alert_processor/lib/model/trip.ex
@@ -19,9 +19,9 @@ defmodule AlertProcessor.Model.Trip do
     end_time: Time.t | nil,
     return_start_time: Time.t | nil,
     return_end_time: Time.t | nil,
-    notification_time: Time.t | nil,
     station_features: [station_feature] | nil,
-    roundtrip: boolean
+    roundtrip: boolean,
+    alert_time_difference_in_minutes: integer
   }
 
   use Ecto.Schema
@@ -40,15 +40,22 @@ defmodule AlertProcessor.Model.Trip do
     field :end_time, :time, null: false
     field :return_start_time, :time, null: true
     field :return_end_time, :time, null: true
-    field :notification_time, :time, null: false
     field :station_features, {:array, AlertProcessor.AtomType}, null: false
     field :roundtrip, :boolean, null: false
+    field :alert_time_difference_in_minutes, :integer, default: 60
 
     timestamps()
   end
 
-  @required_fields ~w(user_id alert_priority_type relevant_days start_time end_time
-    notification_time station_features)a
+  @required_fields ~w(
+    user_id
+    alert_priority_type
+    relevant_days
+    start_time
+    end_time
+    station_features
+    alert_time_difference_in_minutes
+  )a
   @valid_relevant_days ~w(monday tuesday wednesday thursday friday saturday sunday)a
   @valid_station_features ~w(accessibility parking bike_storage)a
   @valid_alert_priority_types ~w(low high)a

--- a/apps/alert_processor/priv/repo/migrations/20180320154509_add_alert_time_difference_in_minutes_to_trips_table.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180320154509_add_alert_time_difference_in_minutes_to_trips_table.exs
@@ -1,0 +1,48 @@
+defmodule AlertProcessor.Repo.Migrations.AddAlertTimeDifferenceInMinutesToTripsTable do
+  use Ecto.Migration
+
+  def up do
+    alter table(:trips) do
+      add :alert_time_difference_in_minutes, :integer, null: false, default: 60
+      remove :notification_time
+    end
+
+    drop_trip_subscriptions_update_trigger()
+  end
+
+  def down do
+    alter table(:trips) do
+      add :notification_time, :time
+      remove :alert_time_difference_in_minutes
+    end
+
+    create_trip_subscriptions_update_trigger()
+  end
+
+  defp drop_trip_subscriptions_update_trigger do
+    execute "DROP TRIGGER IF EXISTS set_subscriptions_to_trip_trigger ON trips;"
+    execute "DROP FUNCTION IF EXISTS set_subscriptions_to_trip();"
+  end
+
+  defp create_trip_subscriptions_update_trigger do
+    execute """
+    CREATE OR REPLACE FUNCTION set_subscriptions_to_trip() RETURNS TRIGGER AS $$
+      BEGIN
+        UPDATE subscriptions SET alert_priority_type = NEW.alert_priority_type,
+                                 relevant_days = NEW.relevant_days,
+                                 start_time = NEW.start_time,
+                                 end_time = NEW.end_time,
+                                 notification_time = NEW.notification_time
+        WHERE trip_id = NEW.id;
+        RETURN NEW;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER set_subscriptions_to_trip_trigger
+      AFTER UPDATE ON trips
+      FOR EACH ROW EXECUTE PROCEDURE set_subscriptions_to_trip();
+    """
+  end
+end

--- a/apps/alert_processor/test/alert_processor/model/trip_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/trip_test.exs
@@ -12,7 +12,6 @@ defmodule AlertProcessor.Model.TripTest do
     relevant_days: [:monday],
     start_time: ~T[12:00:00],
     end_time: ~T[18:00:00],
-    notification_time: ~T[11:00:00],
     station_features: [:accessibility]
   }
 
@@ -74,7 +73,7 @@ defmodule AlertProcessor.Model.TripTest do
   test "get_trips_by_user/1" do
     user = Repo.insert!(%User{email: "test@email.com", role: "user", encrypted_password: @encrypted_password})
     Repo.insert!(%Trip{user_id: user.id, alert_priority_type: :low, relevant_days: [:monday], start_time: ~T[12:00:00],
-                       end_time: ~T[18:00:00], notification_time: ~T[11:00:00], station_features: [:accessibility]})
+                       end_time: ~T[18:00:00], station_features: [:accessibility]})
 
     assert [trip] = Trip.get_trips_by_user(user.id)
     assert trip.user_id == user.id

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -188,8 +188,8 @@ defmodule AlertProcessor.Factory do
       relevant_days: [:monday],
       start_time: ~T[12:00:00],
       end_time: ~T[18:00:00],
-      notification_time: ~T[11:00:00],
-      station_features: [:accessibility]
+      station_features: [:accessibility],
+      alert_time_difference_in_minutes: 60
     }
   end
 end

--- a/apps/concierge_site/test/web/controllers/v2/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/session_controller_test.exs
@@ -21,7 +21,7 @@ defmodule ConciergeSite.V2.SessionControllerTest do
   test "POST /v2/login with trips", %{conn: conn} do
     user = Repo.insert!(%User{email: "test@email.com", role: "user", encrypted_password: @encrypted_password})
     Repo.insert!(%Trip{user_id: user.id, alert_priority_type: :low, relevant_days: [:monday], start_time: ~T[12:00:00],
-                       end_time: ~T[18:00:00], notification_time: ~T[11:00:00], station_features: [:accessibility]})
+                       end_time: ~T[18:00:00], station_features: [:accessibility]})
     params = %{"user" => %{"email" => user.email,"password" => @password}}
     conn = post(conn, v2_session_path(conn, :create), params)
     assert html_response(conn, 302) =~ "<a href=\"/v2/trips\">"

--- a/apps/concierge_site/test/web/views/trip_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_card_helper_test.exs
@@ -10,7 +10,7 @@ defmodule ConciergeSite.TripCardHelperTest do
   test "render/2", %{conn: conn} do
     user = Repo.insert!(%User{email: "test@email.com", role: "user", encrypted_password: @encrypted_password})
     trip = Repo.insert!(%Trip{user_id: user.id, alert_priority_type: :low, relevant_days: [:monday], start_time: ~T[09:00:00],
-                       end_time: ~T[10:00:00], notification_time: ~T[08:00:00], roundtrip: false})
+                       end_time: ~T[10:00:00], roundtrip: false})
     trip_with_subscriptions = %{trip | subscriptions: [
       add_subscription_for_trip(trip, %{type: :subway, route: "Red", origin: "place-alfcl", destination: "place-portr",
                                         direction_id: 0, rank: 1}),
@@ -60,8 +60,14 @@ defmodule ConciergeSite.TripCardHelperTest do
   defp add_subscription_for_trip(trip, params) do
     Repo.insert!(%Subscription{user_id: trip.user_id, trip_id: trip.id, alert_priority_type: trip.alert_priority_type,
                                relevant_days: trip.relevant_days, start_time: trip.start_time, end_time: trip.end_time,
-                               notification_time: trip.notification_time, type: params.type, route: params.route,
+                               notification_time: notification_time(trip), type: params.type, route: params.route,
                                origin: params[:origin], destination: params[:destination],
                                direction_id: params.direction_id, rank: params.rank})
+  end
+
+  defp notification_time(%{start_time: start_time}) do
+    hour = start_time.hour - 1
+    {:ok, time} = Time.new(hour, start_time.minute, start_time.second)
+    time
   end
 end


### PR DESCRIPTION
Why:

* Currently we don't have a column in the trips table to store the
desired notification time for a return trip. Instead of creating a new
return_notification_time column for round-trips, we want to remove the
existing notification_time column and replace it with an
alert_time_difference_in_minutes column that would work for both one-way
trips and round-trips. Note that the design for the edit
trips/subscription page allows users to edit this value.
* Asana link: https://app.asana.com/0/529741067494252/599283856113910

This change addresses the need by:

* Adding migration to add `alert_time_difference_in_minutes` column and
remove `notification_time` from trips table. Note that this migrations
also removes a function and trigger that was there to keep trips and
subscriptions in-sync. In an upcoming commit we'll introduce changes to
handle this on the Elixir side.
* Editing `Trip` model and `TripTest` module to use
`alert_time_difference_in_minutes` instead of `notification_time`.
* Editing `Factory` module's `trip_factory/0` by removing
`notification_time` and adding `alert_time_difference_in_minutes`