### PR TITLE
Wire up trip delete functionality

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -76,8 +76,15 @@ defmodule ConciergeSite.V2.TripController do
     render conn, "accessibility.html"
   end
 
-  def delete(conn, _params, _user, _claims) do
-    redirect(conn, to: v2_trip_path(conn, :index))
+  def delete(conn, %{"id" => id}, user, _claims) do
+    with %Trip{} = trip <- Trip.find_by_id(id),
+         true <- user.id == trip.user_id,
+         {:ok, %Trip{}} <- Trip.delete(trip) do
+      redirect(conn, to: v2_trip_path(conn, :index))
+    else
+      _ ->
+        {:error, :not_found}
+    end
   end
 
   defp leg_list(%{"legs" => legs}), do: legs

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -6,7 +6,7 @@
 </div>
 
 <div class="my-4 text-center">
-  <%= link to: "/" do %>
+  <%= link to: v2_trip_path(@conn, :delete, @trip), method: :delete, data: [confirm: "Really?"] do %>
     <i aria-hidden="true" class="fa fa-trash"></i>
     Delete this subscription
   <% end %>


### PR DESCRIPTION
Why:

* We want to allow users to delete trips they no longer care about.
* Asana link: https://app.asana.com/0/529741067494252/570673981108066

This change addresses the need by:

* Editing the trip controller delete action to actually delete trips.
Before this commit it wasn't doing deletions. It was there as a
placeholder.
* Editing the delete button in the trip edit page to hit the trip
controller's delete action.