### PR TITLE
Generate InformedEntitys from Subscriptions

### DIFF
--- a/apps/alert_processor/lib/model/route.ex
+++ b/apps/alert_processor/lib/model/route.ex
@@ -31,4 +31,5 @@ defmodule AlertProcessor.Model.Route do
 
   def name(%__MODULE__{long_name: "", short_name: name}), do: name
   def name(%__MODULE__{long_name: name}), do: name
+
 end

--- a/apps/alert_processor/lib/model/subscription/params.ex
+++ b/apps/alert_processor/lib/model/subscription/params.ex
@@ -1,0 +1,143 @@
+defmodule AlertProcessor.Model.Subscription.Params do
+  alias AlertProcessor.{Model.Subscription, ServiceInfoCache}
+
+  defstruct [
+    return_start: nil,
+    return_end: nil,
+    departure_start: nil,
+    departure_end: nil,
+    is_return_trip?: false,
+    origin: nil,
+    destination: nil,
+    route: nil,
+    direction_id: nil,
+    relevant_days: [],
+  ]
+
+  def create_subscriptions(%{"return_start" => nil, "return_end" => nil} = params) do
+    [do_create_subscription(params)]
+  end
+  def create_subscriptions(%{"origin" => origin, "destination" => destination} = params) do
+    import Map, only: [put: 3]
+    return_params =
+      params
+      |> put("destination", origin)
+      |> put("origin", destination)
+      |> put("departure_start", params["return_start"])
+      |> put("departure_end", params["return_end"])
+      |> put("direction", flip_direction(params["direction"]))
+    IO.inspect(params, label: "WTF_man")
+    [do_create_subscription(params), do_create_subscription(return_params)]
+  end
+  def create_subscriptions(_), do: :error
+
+  defp flip_direction(0), do: 1
+  defp flip_direction(1), do: 0
+  defp flip_direction(_), do: nil
+
+  defp do_create_subscription(params) do
+    subscription = %Subscription{
+      start_time: params["departure_start"],
+      end_time: params["departure_end"],
+      relevant_days: relevant_days_to_atoms(params),
+      origin: params["origin"],
+      destination: params["destination"],
+      route: params["route"],
+      direction_id: params["direction"]
+    }
+    case {get_latlong_from_stop(params["origin"]), get_latlong_from_stop(params["destination"])} do
+      {nil, nil} -> subscription
+      {{origin_lat, origin_long}, {destination_lat, destination_long}} ->
+        %{subscription | origin_lat: origin_lat, origin_long: origin_long, destination_lat: destination_lat,
+                         destination_long: destination_long}
+    end
+  end
+
+  defp get_latlong_from_stop(nil), do: nil
+  defp get_latlong_from_stop(stop_id) do
+    case ServiceInfoCache.get_stop(stop_id) do
+      {:ok, stop} -> elem(stop, 2)
+      _ -> nil
+    end
+  end
+
+
+  # def from_json(%{"return_start" => nil, "return_end" => nil} = params) do
+  #   [struct_from_json(params)]
+  # end
+  # def from_json(%{} = params) do
+  #   forward_trip = struct_from_json(params)
+  #   reverse_trip = struct_from_json(params) |> to_return_trip
+  #   [forward_trip, reverse_trip]
+  # end
+
+  # def to_subscription_struct(%__MODULE__{} = params) do
+  #   {origin_lat, origin_long} = get_latlong_from_stop(params.origin)
+  #   {destination_lat, destination_long} = get_latlong_from_stop(params.destination)
+  #   %Subscription{
+  #     start_time: params.departure_start,
+  #     end_time: params.departure_end,
+  #     relevant_days: params.relevant_days,
+  #     origin: params.origin,
+  #     destination: params.destination,
+  #     route: params.route,
+  #     direction_id: params.direction_id,
+  #     origin_lat: origin_lat,
+  #     origin_long: origin_long,
+  #     destination_lat: destination_lat,
+  #     destination_long: destination_long,
+  #   }
+  # end
+
+  # defp get_latlong_from_stop(nil) do
+  #   {nil, nil}
+  # end
+  # defp get_latlong_from_stop(stop_id) do
+  #   case ServiceInfoCache.get_stop(stop_id) do
+  #     {:ok, stop} ->
+  #       {_, _} = elem(stop, 2)
+  #     _ ->
+  #       {nil, nil}
+  #   end
+  # end
+
+  # defp struct_from_json(params) do
+  #   %__MODULE__{
+  #     return_start:     params["return_start"],
+  #     return_end:       params["return_end"],
+  #     departure_start:  params["departure_start"],
+  #     departure_end:    params["departure_end"],
+  #     origin:           params["origin"],
+  #     destination:      params["destination"],
+  #     route:            params["route"],
+  #     direction_id:     params["direction"],
+  #     relevant_days: relevant_days_to_atoms(params),
+  #   }
+  # end
+
+  # defp to_return_trip(%__MODULE__{} = params) do
+  #   %{
+  #     params |
+  #     is_return_trip?: true,
+  #     origin: params.destination,
+  #     destination: params.origin,
+  #     direction_id: flip_direction_id(params),
+  #     # return_start: params.return_start,
+  #     # return_end: params.return_end,
+  #     departure_start: params.return_start,
+  #     departure_end: params.return_end,
+  #   }
+  # end
+
+  def relevant_days_to_atoms(params) do
+    params
+    |> Map.get("relevant_days", [])
+    |> Enum.map(&String.to_existing_atom/1)
+  end
+
+
+  # defp flip_direction_id(0), do: 1
+  # defp flip_direction_id(1), do: 0
+  # defp flip_direction_id(_), do: nil
+
+end

--- a/apps/alert_processor/lib/model/subscription/route_type.ex
+++ b/apps/alert_processor/lib/model/subscription/route_type.ex
@@ -1,0 +1,74 @@
+defmodule AlertProcessor.Model.Subscription.RouteType do
+  @moduledoc """
+  This module is for conversion of `route_type` integers into
+  meaningful, human-intelligible names.
+  """
+  @numbers_to_names %{
+    0 => :light_rail,
+    1 => :heavy_rail,
+    2 => :commuter_rail,
+    3 => :bus,
+    4 => :ferry,
+  }
+
+  @doc """
+  Turns a number into a name (atom) or nil.
+
+  iex> RouteType.number_to_name(0)
+  :light_rail
+
+  iex> RouteType.number_to_name(1)
+  :heavy_rail
+
+  iex> RouteType.number_to_name(2)
+  :commuter_rail
+
+  iex> RouteType.number_to_name(3)
+  :bus
+
+  iex> RouteType.number_to_name(4)
+  :ferry
+
+  iex> RouteType.number_to_name(-1)
+  nil
+  """
+  def number_to_name(num) when is_integer(num) do
+    Map.get(@numbers_to_names, num)
+  end
+  def number_to_name(_) do
+    nil
+  end
+
+  @doc """
+  Turns a name into a number that represent a route_type's name.
+
+  iex> RouteType.name_to_number(:subway)
+  0
+
+  iex> RouteType.name_to_number(:light_rail)
+  0
+
+  iex> RouteType.name_to_number(:ferry)
+  4
+
+  iex> RouteType.name_to_number(:other)
+  nil
+  """
+  def name_to_number(:subway) do
+    0  
+  end
+  def name_to_number(name) when is_atom(name) do
+    @numbers_to_names
+    |> Enum.find(fn {_, transport_name} -> name == transport_name end)
+    |> case do
+      nil ->
+        nil
+      {num, _} when is_integer(num) ->
+        num
+    end  
+  end
+  def name_to_number(_) do
+    nil
+  end
+  
+end

--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -3,7 +3,11 @@ defmodule AlertProcessor.InformedEntityFilter do
   Filter users based on informed entity records tied to subscriptions.
   """
 
-  alias AlertProcessor.Model.{Alert, InformedEntity, Subscription}
+  alias AlertProcessor.Model.{
+    Alert,
+    InformedEntity,
+    Subscription,
+  }
 
   @doc """
   filter/1 takes a tuple including a subquery which represents the
@@ -28,7 +32,8 @@ defmodule AlertProcessor.InformedEntityFilter do
       end)
 
     Enum.filter(subscriptions, fn(sub) ->
-      sub.informed_entities
+      sub
+      |> Subscription.to_informed_entities
       |> Enum.any?(
         fn(sub_ie) ->
           ie = Map.take(sub_ie, InformedEntity.queryable_fields)

--- a/apps/alert_processor/lib/subscription/accessibility_mapper.ex
+++ b/apps/alert_processor/lib/subscription/accessibility_mapper.ex
@@ -28,6 +28,30 @@ defmodule AlertProcessor.Subscription.AccessibilityMapper do
     |> map_entities(params)
   end
 
+  def subscription_to_informed_entities(%Subscription{route: route_id} = sub) do
+    params = %{
+      "origin" => sub.origin,
+      "destination" => sub.destination,
+      "direction" => sub.direction_id,
+      "route" => route_id, 
+      "relevant_days" => sub.relevant_days,
+      "alert_priority_type" => sub.alert_priority_type,
+      "trips" => [],
+    }
+    |> map_stop_names()
+    |> set_alert_priority()
+    |> map_timeframe
+
+    [sub]
+    |> map_priority(params)
+    |> map_type(:accessibility)
+    |> map_entities(params)
+    |> case do
+      [{_subscription, informed_entities}] ->
+        informed_entities
+    end
+  end
+
   defp set_alert_priority(params) do
     Map.put(params, "alert_priority_type", "low")
   end

--- a/apps/alert_processor/lib/subscription/bus_mapper.ex
+++ b/apps/alert_processor/lib/subscription/bus_mapper.ex
@@ -40,6 +40,28 @@ defmodule AlertProcessor.Subscription.BusMapper do
     {:ok, subscription_infos}
   end
 
+
+  def subscription_to_informed_entities(%Subscription{route: route_id} = sub) do
+    {:ok, route} = ServiceInfoCache.get_route(route_id)
+    params = %{
+      "origin" => nil,
+      "destination" =>  nil,
+      "direction" => sub.direction_id,
+      "route" => route_id, 
+      "alert_priority_type" => sub.alert_priority_type,
+      # "trips" => [],
+    }
+    
+    [sub]
+    |> map_priority(params)
+    |> map_type(:bus)
+    |> map_entities(params, route)
+    |> case do
+      [{_subscription, informed_entities}] ->
+        informed_entities
+    end
+  end
+
   defp map_entities(subscriptions, params, route) do
     subscriptions
     |> map_route_type(route)

--- a/apps/alert_processor/lib/subscription/mapper.ex
+++ b/apps/alert_processor/lib/subscription/mapper.ex
@@ -58,7 +58,7 @@ defmodule AlertProcessor.Subscription.Mapper do
 
   def map_priority(subscriptions, %{"alert_priority_type" => alert_priority_type}) when is_list(subscriptions) do
     Enum.map(subscriptions, fn(subscription) ->
-      %{subscription | alert_priority_type: String.to_existing_atom(alert_priority_type)}
+      %{subscription | alert_priority_type: ensure_existing_atom(alert_priority_type)}
     end)
   end
   def map_priority(_, _), do: :error
@@ -67,6 +67,13 @@ defmodule AlertProcessor.Subscription.Mapper do
     Enum.map(subscriptions, fn(subscription) ->
       Map.put(subscription, :type, type)
     end)
+  end
+
+  defp ensure_existing_atom(str) when is_binary(str) do
+    String.to_existing_atom(str)
+  end
+  defp ensure_existing_atom(atom) when is_atom(atom) do
+    atom
   end
 
   def map_accessibility(subscriptions, %{"origin" => origin, "accessibility" => accessibility}) do
@@ -505,5 +512,13 @@ defmodule AlertProcessor.Subscription.Mapper do
     else
       _ -> :error
     end
+  end
+
+
+  def raise_on_nil(nil, message) when is_binary(message) do
+    raise message
+  end
+  def raise_on_nil(item, _message) do
+    item
   end
 end

--- a/apps/alert_processor/lib/subscription/subway_mapper.ex
+++ b/apps/alert_processor/lib/subscription/subway_mapper.ex
@@ -32,6 +32,27 @@ defmodule AlertProcessor.Subscription.SubwayMapper do
     {:ok, map_entities(subscriptions, params, route)}
   end
 
+  def subscription_to_informed_entities(%Subscription{} = sub) do
+    route = get_route_by_stops(sub.origin, sub.destination)
+    params = %{
+      "origin" => sub.origin,
+      "destination" => sub.destination,
+      "route" => route.route_id,
+      "direction" => "",
+      "alert_priority_type" => sub.alert_priority_type,
+    }
+
+    [sub]
+    |> map_subscription_direction_id(route)
+    |> map_priority(params)
+    |> map_type(:subway)
+    |> map_entities(params, route)
+    |> case do
+      [{_subscription, informed_entities}] ->
+        informed_entities
+    end
+  end
+
   defp map_entities(subscriptions, params, route) do
     subscriptions
     |> map_route_type(route)

--- a/apps/alert_processor/test/alert_processor/model/route_type_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/route_type_test.exs
@@ -1,0 +1,5 @@
+defmodule AlertProcessor.Model.Subscription.RouteTypeTest do
+  use ExUnit.Case
+  alias AlertProcessor.Model.Subscription.RouteType
+  doctest RouteType
+end

--- a/apps/alert_processor/test/alert_processor/model/subscription/params_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/subscription/params_test.exs
@@ -1,0 +1,52 @@
+defmodule AlertProcessor.Model.Subscription.ParamsTest do
+  use ExUnit.Case
+  alias AlertProcessor.Model.{
+    Subscription,
+    Subscription.Params,
+  }
+
+  describe "create_subscriptions/1" do
+    test "returns error for invalid json" do
+      assert Params.create_subscriptions(%{}) == :error
+    end
+    test "returns a subscription for valid json" do
+      valid_json1 =  %{
+        "alert_priority_type" => "low",
+        "departure_end" => ~T[09:15:00],
+        "departure_start" => ~T[08:45:00],
+        "destination" => nil,
+        "direction" => 1,
+        "origin" => nil,
+        "relevant_days" => ["saturday"],
+        # "return_end" => ~T[17:15:00],
+        "return_end" => nil,
+        # "return_start" => ~T[16:45:00],
+        "return_start" => nil,
+        "route" => "741"
+      }
+      valid_json2 = %{
+        "alert_priority_type" => "low",
+        "departure_end" => ~T[14:00:00],
+        "departure_start" => ~T[12:00:00],
+        "destination" => "Anderson/ Woburn",
+        "direction" => 0,
+        "direction_id" => "0",
+        "origin" => "place-north",
+        "relevant_days" => ["weekday"],
+        # "return_end" => ~T[20:00:00],
+        "return_end" => nil,
+        # "return_start" => ~T[18:00:00],
+        "return_start" => nil,
+        "return_trips" => ["588", "590"],
+        "route" => "CR-Lowell",
+        "route_id" => "CR-Lowell",
+        "trips" => ["123", "125"]
+      }
+
+      assert [%Subscription{relevant_days: [:saturday]}] = Params.create_subscriptions(valid_json1)
+      assert [%Subscription{relevant_days: [:tuesday]}] = Params.create_subscriptions(valid_json2)
+    end
+    test "returns one subscription for return_start and return_end containing json"
+  end
+
+end

--- a/apps/alert_processor/test/alert_processor/subscription/bus_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/bus_mapper_test.exs
@@ -191,4 +191,13 @@ defmodule AlertProcessor.Subscription.BusMapperTest do
       assert subscription2.id != nil
     end
   end
+
+  describe "subscription_to_informed_entities/1" do
+    test "returns the informed entities for valid :bus typed structs" do
+      {:ok, [{subscription, _ie}]} = BusMapper.map_subscription(@one_way_params)
+      entities = BusMapper.subscription_to_informed_entities(subscription)
+      assert length(entities) == 3
+      assert Enum.all?(entities, fn e -> match?(%InformedEntity{}, e) end)
+    end
+  end
 end

--- a/apps/alert_processor/test/alert_processor/subscription/commuter_rail_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/commuter_rail_mapper_test.exs
@@ -795,4 +795,14 @@ defmodule AlertProcessor.Subscription.CommuterRailMapperTest do
       assert updated_subscription.id == subscription.id
     end
   end
+
+  describe "subscription_to_informed_entities/1" do
+    test "returns the informed entities for valid :commuter_rail typed structs" do
+      {:ok, [{subscription, _ie}]} = CommuterRailMapper.map_subscriptions(@one_way_params)
+      entities = CommuterRailMapper.subscription_to_informed_entities(subscription)
+      assert length(entities) == 15
+      assert Enum.all?(entities, fn e -> match?(%InformedEntity{}, e) end)
+    end
+  end
+
 end

--- a/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/ferry_mapper_test.exs
@@ -497,4 +497,13 @@ defmodule AlertProcessor.Subscription.FerryMapperTest do
       assert updated_subscription.id == subscription.id
     end
   end
+
+  describe "subscription_to_informed_entities/1" do
+    test "returns the informed entities for valid :ferry typed structs" do
+      {:ok, [{subscription, _ie}]} = FerryMapper.map_subscriptions(@one_way_params)
+      entities = FerryMapper.subscription_to_informed_entities(subscription)
+      assert length(entities) == 15
+      assert Enum.all?(entities, fn e -> match?(%InformedEntity{}, e) end)
+    end
+  end
 end

--- a/apps/alert_processor/test/alert_processor/subscription/mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/mapper_test.exs
@@ -11,7 +11,9 @@ defmodule AlertProcessor.Subscription.MapperTest do
 
   describe "build_subscription_update_transaction" do
     test "it builds a multi struct to persist subscriptions and informed_entities" do
-      subscription = insert(:subscription, informed_entities: [%InformedEntity{stop: "place-north", facility_type: :bike_storage}])
+      subscription = insert(:subscription, informed_entities: [
+        %InformedEntity{stop: "place-north", facility_type: :bike_storage}
+      ])
       user = insert(:user)
       {:ok, subscription_infos} = BikeStorageMapper.map_subscriptions(@params)
       multi = Mapper.build_subscription_update_transaction(subscription, subscription_infos, user.id)

--- a/apps/alert_processor/test/alert_processor/subscription/subway_mapper_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/subway_mapper_test.exs
@@ -556,4 +556,13 @@ defmodule AlertProcessor.Subscription.SubwayMapperTest do
       assert subscription2.id != nil
     end
   end
+
+  describe "subscription_to_informed_entities/1" do
+    test "returns the informed entities for valid subway typed structs" do
+      {:ok, [{subscription, _ie}]} = SubwayMapper.map_subscriptions(@one_way_params)
+      entities = SubwayMapper.subscription_to_informed_entities(subscription)
+      assert length(entities) == 9
+      assert Enum.all?(entities, fn e -> match?(%InformedEntity{}, e) end)
+    end
+  end
 end

--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -5,15 +5,26 @@ defmodule ConciergeSite.Integration.Matching do
   import ConciergeSite.NotificationFactory
   import AlertProcessor.SubscriptionFilterEngine, only: [determine_recipients: 3]
 
-  @base %{"alert_priority_type" => "medium", "departure_end" => ~T[08:30:00], "departure_start" => ~T[08:00:00],
-          "relevant_days" => ["weekday"], "return_start" => nil, "return_end" => nil}
+  @base %{
+    "alert_priority_type" => "medium",
+    "departure_end" => ~T[08:30:00],
+    "departure_start" => ~T[08:00:00],
+    "relevant_days" => ["weekday"],
+    "return_start" => nil,
+    "return_end" => nil,
+    
+  }
   @alert_active_period [active_period(@base["departure_start"], @base["departure_end"], :tuesday)]
   @alert_weekend_period [active_period(@base["departure_start"], @base["departure_end"], :sunday)]
   @alert_later_period [active_period(~T[09:00:00], ~T[09:30:00], :monday)]
 
   describe "subway subscription" do
-    @subscription subscription(:subway, Map.merge(@base, %{"destination" => "place-brdwy",
-                                                           "origin" => "place-harsq", "roaming" => "false"}))
+    @subscription subscription(:subway, Map.merge(@base, %{
+      "destination" => "place-brdwy",
+      "route_type" => 1,
+      "origin" => "place-harsq",
+      "roaming" => "false"
+    }))
     @subscription_roaming subscription(:subway, Map.merge(@base, %{"destination" => "place-brdwy",
                                                                    "origin" => "place-harsq", "roaming" => "true"}))
 
@@ -31,10 +42,11 @@ defmodule ConciergeSite.Integration.Matching do
     end
 
     test "same route_id and route_type" do
-      subway_entity = :subway
-      |> entity()
-      |> Map.delete("direction_id")
-      |> Map.delete("stop_id")
+      subway_entity = 
+        entity(:subway)
+        |> Map.delete("direction_id")
+        |> Map.delete("stop_id")
+      # assert subway_entity == %{}
       assert_notify alert(informed_entity: [subway_entity]), @subscription
     end
 
@@ -190,6 +202,7 @@ defmodule ConciergeSite.Integration.Matching do
       refute_notify alert(informed_entity: [entity(:commuter_rail, activities: ["NO_MATCH"])]), @subscription
     end
 
+    @tag current: true
     test "similar: different route_type" do
       refute_notify alert(informed_entity: [entity(:commuter_rail, route_type: 1)]), @subscription
     end

--- a/apps/concierge_site/test/support/subscription_factory.ex
+++ b/apps/concierge_site/test/support/subscription_factory.ex
@@ -3,40 +3,63 @@ defmodule ConciergeSite.SubscriptionFactory do
   Standard interface for generating subscriptions
   """
 
-  alias AlertProcessor.Model.User
-  alias AlertProcessor.Subscription.{SubwayMapper, BusMapper, CommuterRailMapper, FerryMapper, AccessibilityMapper,
-                                     BikeStorageMapper, ParkingMapper}
+  alias AlertProcessor.Model.{
+    User,
+    Subscription.RouteType,
+  }
+  alias AlertProcessor.Subscription.{
+    SubwayMapper,
+    BusMapper,
+    CommuterRailMapper,
+    FerryMapper,
+    AccessibilityMapper,
+    BikeStorageMapper,
+    ParkingMapper,
+  }
 
-  def subscription(:subway, params) do
-    SubwayMapper.map_subscriptions(params)
+  def subscription(:subway = name, params) do
+    params
+    |> Map.put("route_type", RouteType.name_to_number(name))    
+    |> SubwayMapper.map_subscriptions
     |> to_subscription
   end
-  def subscription(:bus, params) do
-    BusMapper.map_subscription(params)
+  def subscription(:bus = name, params) do
+    params
+    |> Map.put("route_type", RouteType.name_to_number(name))
+    |> BusMapper.map_subscription
     |> to_subscription
   end
-  def subscription(:commuter_rail, params) do
-    %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
+  def subscription(:commuter_rail = name, params) do
+    %{
+      "trip_type" => "one_way",
+      "return_end" => nil,
+      "return_start" => nil,
+    }
+    |> Map.put("route_type", RouteType.name_to_number(name))    
     |> Map.merge(params)
     |> CommuterRailMapper.map_subscriptions()
     |> to_subscription
   end
-  def subscription(:ferry, params) do
+  def subscription(:ferry = name, params) do
     %{"trip_type" => "one_way", "return_end" => nil, "return_start" => nil}
+    |> Map.put("route_type", RouteType.name_to_number(name))    
     |> Map.merge(params)
     |> FerryMapper.map_subscriptions()
     |> to_subscription
   end
   def subscription(:bike, params) do
-    BikeStorageMapper.map_subscriptions(params)
+    params
+    |> BikeStorageMapper.map_subscriptions
     |> to_subscription
   end
   def subscription(:parking, params) do
-    ParkingMapper.map_subscriptions(params)
+    params
+    |> ParkingMapper.map_subscriptions
     |> to_subscription
   end
   def subscription(:accessibility, params) do
-    AccessibilityMapper.map_subscriptions(params)
+    params
+    |> AccessibilityMapper.map_subscriptions
     |> to_subscription
   end
 


### PR DESCRIPTION
This is an attempt to replace a Subscription's `:informed_entities` field with a call to `Subscription.to_informed_entities/1`.

Issues:

+ Multiple tests are failing. In some test, subscriptions lack `:type` values. In some tests, the params from which a subscription is made do not create a valid `:type`.

+ BikeMapper still needs to be implemented into `to_informed_entities/1`.

+ ParkingMapper still needs to be implemented into `to_informed_entities/1`.

+ `route_type` and `type` of Subscription appear to be the same field and migrating `route_type` may have been unnecessary.

Recommendations:

+ replace stringly keyed `params` interface of Mappers with a highly-tested, well-defined, data-validated struct.

+ separate pure functions from impure functions and increase test coverage of pure functions.
