### PR TITLE
Add weekdays/weekend to DaySelectHelper

### DIFF
--- a/apps/concierge_site/lib/views/day_select_helper.ex
+++ b/apps/concierge_site/lib/views/day_select_helper.ex
@@ -1,15 +1,25 @@
 defmodule ConciergeSite.DaySelectHelper do
   import Phoenix.HTML.Tag, only: [content_tag: 3, tag: 2]
 
-  @days ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+  @weekdays ["monday", "tuesday", "wednesday", "thursday", "friday"]
+  @weekend ["saturday", "sunday"]
+  @days @weekdays ++ @weekend
   @short_days ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
   @spec render(atom) :: Phoenix.HTML.safe
   def render(input_name, checked \\ []) do
-    checked_set = checked |> ensure_days_as_string() |> MapSet.new()
+    checked_set = prepare_checked_set(checked)
     content_tag :div, class: "day-selector", data: [selector: "date"] do
       [title(), day(input_name, checked_set), group(checked_set)]
     end
+  end
+
+  defp prepare_checked_set(checked) do
+    checked
+    |> ensure_days_as_string()
+    |> MapSet.new()
+    |> if_needed_add_weekday()
+    |> if_needed_add_weekend()
   end
 
   defp ensure_days_as_string([]), do: []
@@ -19,6 +29,22 @@ defmodule ConciergeSite.DaySelectHelper do
   defp ensure_day_as_string(day) when is_atom(day), do: Atom.to_string(day)
 
   defp ensure_day_as_string(day) when is_binary(day), do: day
+
+  defp if_needed_add_weekday(checked) do
+    if MapSet.subset?(MapSet.new(@weekdays), checked) do
+      MapSet.put(checked, "weekdays")
+    else
+      checked
+    end
+  end
+
+  defp if_needed_add_weekend(checked) do
+    if MapSet.subset?(MapSet.new(@weekend), checked) do
+      MapSet.put(checked, "weekend")
+    else
+      checked
+    end
+  end
 
   defp title do
     content_tag :div, class: "title-part" do

--- a/apps/concierge_site/test/web/views/day_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/day_select_helper_test.exs
@@ -14,14 +14,53 @@ defmodule ConciergeSite.DaySelectHelperTest do
     assert html =~ "<input autocomplete=\"off\" type=\"checkbox\" value=\"weekdays\">"
   end
 
-  test "render/2" do
-    html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, ["monday"]))
+  describe "render/2" do
+    test "with monday as string" do
+      html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, ["monday"]))
 
-    assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"monday\">"
-    assert html =~ "<input autocomplete=\"off\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"tuesday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"monday\">"
+      assert html =~ "<input autocomplete=\"off\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"tuesday\">"
+    end
 
-    html_2 = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, [:monday]))
+    test "with monday as atom" do
+      html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, [:monday]))
 
-    assert html == html_2
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"monday\">"
+      assert html =~ "<input autocomplete=\"off\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"tuesday\">"
+    end
+
+    test "weekdays" do
+      weekdays = ~w(monday tuesday wednesday thursday friday)a
+      html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, weekdays))
+
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"monday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"tuesday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"thursday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"friday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" type=\"checkbox\" value=\"weekdays\">"
+    end
+
+    test "weekend" do
+      weekdays = ~w(saturday sunday)a
+      html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, weekdays))
+
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"saturday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"sunday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" type=\"checkbox\" value=\"weekend\">"
+    end
+
+    test "weekdays and weekend" do
+      weekdays = ~w(monday tuesday wednesday thursday friday saturday sunday)a
+      html = Phoenix.HTML.safe_to_string(DaySelectHelper.render(:foo, weekdays))
+
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"monday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"tuesday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"thursday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"friday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"saturday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" name=\"foo[relevant_days][]\" type=\"checkbox\" value=\"sunday\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" type=\"checkbox\" value=\"weekdays\">"
+      assert html =~ "<input autocomplete=\"off\" checked=\"checked\" type=\"checkbox\" value=\"weekend\">"
+    end
   end
 end


### PR DESCRIPTION
Why:

* The `DaySelectHelper` module doesn't currently include the 'weekdays'
and 'weekend' input as checked when needed. This commit fixes this.
* Asana link: https://app.asana.com/0/529741067494252/599283856113908