### PR TITLE
AlertParser supports valid TranslatedString type

### DIFF
--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -301,4 +301,38 @@ defmodule AlertProcessor.AlertParserTest do
       assert AlertParser.remove_ignored([%{@valid_alert | "active_period" => []}]) == []
     end
   end
+
+  describe "parse_translation/1" do
+    test "parses list of translations" do
+      # Note that a list of translations is not correct per the GTFS-realtime
+      # spec but the feed we're working with does not currently follow the
+      # GTFS-realtime spec. For details take a look here:
+      # https://developers.google.com/transit/gtfs-realtime/reference/#message_translatedstring
+      text = "some text"
+      translation = [
+        %{
+          "translation" => %{
+            "text" => text,
+            "language" => "en"
+          }
+        }
+      ]
+      assert AlertParser.parse_translation(translation) == text
+    end
+
+    test "parses a translation map" do
+      # Parses a `TranslatedString` type per:
+      # https://developers.google.com/transit/gtfs-realtime/reference/#message_translatedstring
+      text = "some text"
+      translation = %{
+        "translation" => [
+          %{
+            "text" => text,
+            "language" => "en"
+          }
+        ]
+      }
+      assert AlertParser.parse_translation(translation) == text
+    end
+  end
 end


### PR DESCRIPTION
Why:

* The feed we're currently working with doesn't correctly format
`TranslatedString` types. In the near future they will. So we want to be
ready for this when the feed starts formatting this data per the
GTFS-realtime specification. This commit extends
`AlertParser.parse_translation/1` for it to be able to parse valid
`TranslatedString` types as well as the incorrect format the feed has
currently generates. For examples of the correct and incorrect format
take a look at the comments in the Asana ticket below.
* Asana link: https://app.asana.com/0/529741067494252/605854572861571