### PR TITLE
V2 InformedEntityFilter

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -82,7 +82,7 @@ defmodule AlertProcessor.Model.Subscription do
   end
 
   @permitted_fields ~w(alert_priority_type user_id trip_id relevant_days start_time
-    end_time type rank route return_trip)a
+    end_time type rank route return_trip route_type)a
   @required_fields ~w(alert_priority_type user_id start_time end_time)a
   @update_permitted_fields ~w(alert_priority_type relevant_days start_time end_time)a
   @valid_days ~w(weekday monday tuesday wednesday thursday friday saturday sunday)a

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -39,34 +39,22 @@ defmodule AlertProcessor.AlertParserTest do
   test "process_alerts/1 sends to correct users via filter chain" do
     user1 = insert(:user, phone_number: nil)
     :subscription
-    |> build(user: user1, alert_priority_type: :low, informed_entities: [
-        %InformedEntity{route_type: 2, route: "CR-Needham", activities: InformedEntity.default_entity_activities()},
-        %InformedEntity{route_type: 2, route: "CR-Needham", direction_id: 1, activities: InformedEntity.default_entity_activities()}
-      ])
+    |> build(route_type: 2, route: "CR-Needham", direction_id: 1, user: user1, alert_priority_type: :low)
     |> weekday_subscription
     |> PaperTrail.insert
     user2 = insert(:user, phone_number: nil)
     :subscription
-    |> build(user: user2, alert_priority_type: :high, informed_entities: [
-        %InformedEntity{route_type: 2, route: "CR-Needham", activities: InformedEntity.default_entity_activities()},
-        %InformedEntity{route_type: 2, route: "CR-Needham", direction_id: 1, activities: InformedEntity.default_entity_activities()}
-      ])
+    |> build(route_type: 2, route: "CR-Needham", direction_id: 1, user: user2, alert_priority_type: :high)
     |> weekday_subscription
     |> PaperTrail.insert
     user3 = insert(:user, phone_number: nil)
     :subscription
-    |> build(user: user3, alert_priority_type: :low, informed_entities: [
-        %InformedEntity{route_type: 2, route: "CR-Lowell", activities: InformedEntity.default_entity_activities()},
-        %InformedEntity{route_type: 2, route: "CR-Lowell", direction_id: 1, activities: InformedEntity.default_entity_activities()}
-      ])
+    |> build(route_type: 2, route: "CR-Lowell", direction_id: 1, user: user3, alert_priority_type: :low)
     |> weekday_subscription
     |> PaperTrail.insert
     user4 = insert(:user, phone_number: nil)
     :subscription
-    |> build(user: user4, alert_priority_type: :low, informed_entities: [
-        %InformedEntity{route_type: 2, route: "CR-Needham", activities: InformedEntity.default_entity_activities()},
-        %InformedEntity{route_type: 2, route: "CR-Needham", direction_id: 1, activities: InformedEntity.default_entity_activities()}
-      ])
+    |> build(route_type: 2, route: "CR-Needham", direction_id: 1, user: user4, alert_priority_type: :low)
     |> weekday_subscription
     |> PaperTrail.insert
     insert(:notification, alert_id: "114166", last_push_notification: ~N[2017-06-19 20:02:14], user: user4, email: user4.email, phone_number: user4.phone_number, status: "sent", send_after: ~N[2017-04-25 10:00:00])
@@ -81,8 +69,15 @@ defmodule AlertProcessor.AlertParserTest do
 
   test "process_alerts/1 parses alerts and replaces facility id with type" do
     user1 = insert(:user, phone_number: nil)
+    subscription_details = [
+      route: "Red",
+      origin: "place-davis",
+      destination: "place-davis",
+      facility_types: ~w(escalator)a,
+      user: user1
+    ]
     :subscription
-    |> build(user: user1, alert_priority_type: :low, informed_entities: [%InformedEntity{stop: "place-davis", facility_type: :escalator, activities: ["USING_ESCALATOR"]}])
+    |> build(subscription_details)
     |> weekday_subscription
     |> PaperTrail.insert
 
@@ -105,22 +100,6 @@ defmodule AlertProcessor.AlertParserTest do
       for entity <- facility_entities do
         refute is_nil(entity.route)
       end
-    end
-  end
-
-  test "correctly parses and matches trips" do
-    user = insert(:user)
-
-    subscription_factory()
-    |> Map.put(:informed_entities, [%InformedEntity{trip: "775", route: "CR-Fairmount", route_type: 2, activities: InformedEntity.default_entity_activities()}])
-    |> Map.merge(%{type: :commuter_rail, user: user, relevant_days: [:weekday], start_time: ~T[00:00:00], end_time: ~T[23:59:59]})
-    |> insert()
-
-    use_cassette "trip_alerts", custom: true, clear_mock: true, match_requests_on: [:query] do
-      {_, result} = AlertParser.process_alerts()
-      [notification] = Enum.reduce(result, [], fn({:ok, x}, acc) -> acc ++ x end)
-      assert notification.header == "Fairmount Line Train 775 (5:00 pm from South Station) cancelled today due to congestion"
-      assert notification.email == user.email
     end
   end
 
@@ -147,11 +126,15 @@ defmodule AlertProcessor.AlertParserTest do
 
   test "correctly parses bus stop alert to match bus route subscription" do
     user = insert(:user)
-
-    subscription_factory()
+    subscription_details = [
+      route_type: 3,
+      route: "66",
+      user: user
+    ]
+    :subscription
+    |> build(subscription_details)
     |> bus_subscription()
     |> weekday_subscription()
-    |> Map.put(:informed_entities, bus_subscription_entities("66", :inbound))
     |> Map.put(:user, user)
     |> insert()
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -28,20 +28,20 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       user2 = insert(:user, phone_number: nil, email: email_no_match)
 
       s1 = :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
       s2 = :subscription
-      |> build(user: user, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 4, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 4, user: user, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 4, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
 
       s3 = :subscription
-      |> build(user: user2, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 3, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 3, user: user2, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 3, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
       s4 = :subscription
-      |> build(user: user2, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 2, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 2, user: user2, alert_priority_type: :high, informed_entities: [%InformedEntity{route_type: 2, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> sunday_subscription
       |> insert
@@ -87,14 +87,14 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
 
       user_morning = insert(:user, phone_number: nil, email: "redline|weekdays|low|morning@test.com")
       subscription_morning = :subscription
-      |> build(user: user_morning, alert_priority_type: :low, start_time: ~T[08:00:00], end_time: ~T[10:00:00],
+      |> build(route_type: 1, route: "Red", user: user_morning, alert_priority_type: :low, start_time: ~T[08:00:00], end_time: ~T[10:00:00],
                informed_entities: informed_entities)
       |> weekday_subscription()
       |> insert
 
       user_evening = insert(:user, phone_number: nil, email: "redline|weekdays|low|evening@test.com")
       evening_subscription = :subscription
-      |> build(user: user_evening, alert_priority_type: :low, start_time: ~T[16:00:00], end_time: ~T[17:00:00],
+      |> build(route_type: 1, route: "Red", user: user_evening, alert_priority_type: :low, start_time: ~T[16:00:00], end_time: ~T[17:00:00],
                informed_entities: informed_entities)
       |> weekday_subscription()
       |> insert
@@ -118,11 +118,11 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       user = insert(:user, phone_number: nil)
 
       s1 = :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
       s2 = :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
 
@@ -140,7 +140,7 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       user = insert(:user, phone_number: nil)
 
       :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
 
@@ -152,7 +152,7 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       user = insert(:user, phone_number: nil)
 
       :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
 
@@ -165,7 +165,7 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       assert skipped == 1
 
       :subscription
-      |> build(user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
+      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
       |> weekday_subscription
       |> insert
 

--- a/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
+++ b/apps/alert_processor/test/alert_processor/subscription/admin/diagnostic_test.exs
@@ -45,7 +45,8 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
       inserted_at: date,
       relevant_days: [:sunday],
       alert_priority_type: :medium,
-      type: :bus
+      type: :bus,
+      route_type: 3
     )
     create_changeset = Subscription.create_changeset(%Subscription{}, sub_params)
     inserted_sub = PaperTrail.insert!(create_changeset)
@@ -440,7 +441,8 @@ defmodule AlertProcessor.Subscription.DiagnosticTest do
         user: user,
         relevant_days: [:sunday],
         alert_priority_type: :high,
-        type: :ferry
+        type: :ferry,
+        route: "some route" # doesn't match the alert route
       )
       create_changeset = Subscription.create_changeset(%Subscription{}, sub_params)
       PaperTrail.insert!(create_changeset)

--- a/apps/concierge_site/test/web/controllers/accessibility_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/accessibility_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.AccessibilitySubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Model.Subscription, Model.InformedEntity, Repo}
+  alias AlertProcessor.{Model.Subscription, Model.InformedEntity, Repo}
 
   describe "authorized" do
     setup :login_user
@@ -108,8 +108,6 @@ defmodule ConciergeSite.AccessibilitySubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/accessibility/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, accessibility_subscription_entities())
@@ -128,7 +126,6 @@ defmodule ConciergeSite.AccessibilitySubscriptionControllerTest do
       use_cassette "accessibility_update", clear_mock: true  do
         conn = patch(conn, "/subscriptions/accessibility/#{subscription.id}", params)
         assert html_response(conn, 302) =~ "my-subscriptions"
-        assert :error = HoldingQueue.pop()
       end
     end
 

--- a/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bike_storage_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.BikeStorageSubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Model.Subscription, Model.InformedEntity, Repo}
+  alias AlertProcessor.{Model.Subscription, Model.InformedEntity, Repo}
 
   describe "authorized" do
     setup :login_user
@@ -94,8 +94,6 @@ defmodule ConciergeSite.BikeStorageSubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/bike_storage/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, bike_storage_subscription_entities())
@@ -112,7 +110,6 @@ defmodule ConciergeSite.BikeStorageSubscriptionControllerTest do
       use_cassette "bike_storage_update", clear_mock: true  do
         conn = patch(conn, "/subscriptions/bike_storage/#{subscription.id}", params)
         assert html_response(conn, 302) =~ "my-subscriptions"
-        assert :error = HoldingQueue.pop()
       end
     end
 

--- a/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/bus_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.BusSubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Model, Repo}
+  alias AlertProcessor.{Model, Repo}
   alias Model.{InformedEntity, Subscription}
 
   @password "password1"
@@ -220,8 +220,6 @@ defmodule ConciergeSite.BusSubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/bus/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> bus_subscription()
@@ -246,7 +244,6 @@ defmodule ConciergeSite.BusSubscriptionControllerTest do
       |> patch("/subscriptions/bus/#{subscription.id}", params)
 
       assert html_response(conn, 302) =~ "my-subscriptions"
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /subscriptions/bus/:id invalid timeframe", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/commuter_rail_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.CommuterRailSubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Repo}
+  alias AlertProcessor.Repo
   alias AlertProcessor.Model.{InformedEntity, Subscription}
 
   describe "authorized" do
@@ -139,8 +139,6 @@ defmodule ConciergeSite.CommuterRailSubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/commuter_rail/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, commuter_rail_subscription_entities())
@@ -156,7 +154,6 @@ defmodule ConciergeSite.CommuterRailSubscriptionControllerTest do
       conn = patch(conn, "/subscriptions/commuter_rail/#{subscription.id}", params)
 
       assert html_response(conn, 302) =~ "my-subscriptions"
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /subscriptions/commuter_rail/:id displays error if trip not selected", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/controllers/ferry_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/ferry_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.FerrySubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Repo}
+  alias AlertProcessor.Repo
   alias AlertProcessor.Model.{InformedEntity, Subscription}
 
   describe "authorized" do
@@ -143,8 +143,6 @@ defmodule ConciergeSite.FerrySubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/ferry/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, ferry_subscription_entities())
@@ -161,7 +159,6 @@ defmodule ConciergeSite.FerrySubscriptionControllerTest do
       conn = patch(conn, "/subscriptions/ferry/#{subscription.id}", params)
 
       assert html_response(conn, 302) =~ "my-subscriptions"
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /subscriptions/ferry/:id displays error if trip not selected", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/my_account_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule ConciergeSite.MyAccountControllerTest do
   use ConciergeSite.ConnCase
-  alias AlertProcessor.{HoldingQueue, Model, Repo}
+  alias AlertProcessor.{Model, Repo}
   alias Model.User
 
   describe "authorized" do
@@ -15,8 +15,6 @@ defmodule ConciergeSite.MyAccountControllerTest do
     end
 
     test "PATCH /my-account/ with valid params", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       params = %{"user" => %{
         "dnd_toggle" => "true",
         "do_not_disturb_start" => "16:30:00",
@@ -35,7 +33,6 @@ defmodule ConciergeSite.MyAccountControllerTest do
       assert updated_user.phone_number == "5551234567"
       assert updated_user.do_not_disturb_end == ~T[18:30:00.000000]
       assert updated_user.do_not_disturb_start == ~T[16:30:00.000000]
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /my-account/ with invalid params", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/parking_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.ParkingSubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Model.Subscription, Model.InformedEntity, Repo}
+  alias AlertProcessor.{Model.Subscription, Model.InformedEntity, Repo}
 
   describe "authorized" do
     setup :login_user
@@ -94,8 +94,6 @@ defmodule ConciergeSite.ParkingSubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/parking/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> Map.put(:informed_entities, parking_subscription_entities())
@@ -112,7 +110,6 @@ defmodule ConciergeSite.ParkingSubscriptionControllerTest do
       use_cassette "parking_update", clear_mock: true  do
         conn = patch(conn, "/subscriptions/parking/#{subscription.id}", params)
         assert html_response(conn, 302) =~ "my-subscriptions"
-        assert :error = HoldingQueue.pop()
       end
     end
 

--- a/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subscription_controller_test.exs
@@ -3,7 +3,7 @@ defmodule ConciergeSite.SubscriptionControllerTest do
 
   import AlertProcessor.Factory
   import Ecto.Query
-  alias AlertProcessor.{HoldingQueue, Model, Repo}
+  alias AlertProcessor.{Model, Repo}
   alias Model.{InformedEntity, Subscription}
 
   describe "authorized" do
@@ -130,8 +130,6 @@ defmodule ConciergeSite.SubscriptionControllerTest do
     test "DELETE /subscriptions/:id with a user who owns the subscription", %{conn: conn} do
       user = insert(:user)
       {:ok, subscription} = insert_bus_subscription_for_user(user)
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
 
       conn = user
       |> guardian_login(conn)
@@ -143,7 +141,6 @@ defmodule ConciergeSite.SubscriptionControllerTest do
       assert html_response(conn, 302) =~ "/my-subscriptions"
       assert subscription_count == 0
       assert informed_entity_count == 0
-      assert :error = HoldingQueue.pop()
     end
 
     test "DELETE /subscriptions/:id with a user who does not own the subscription", %{conn: conn} do

--- a/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/subway_subscription_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.SubwaySubscriptionControllerTest do
   use ConciergeSite.ConnCase
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
-  alias AlertProcessor.{HoldingQueue, Model, Repo}
+  alias AlertProcessor.{Model, Repo}
   alias Model.{InformedEntity, Subscription}
 
   describe "authorized" do
@@ -141,8 +141,6 @@ defmodule ConciergeSite.SubwaySubscriptionControllerTest do
     end
 
     test "PATCH /subscriptions/subway/:id", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       subscription =
         subscription_factory()
         |> subway_subscription()
@@ -163,7 +161,6 @@ defmodule ConciergeSite.SubwaySubscriptionControllerTest do
       |> patch("/subscriptions/subway/#{subscription.id}", params)
 
       assert html_response(conn, 302) =~ "my-subscriptions"
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /subscriptions/subway/:id invalid timeframe", %{conn: conn, user: user} do

--- a/apps/concierge_site/test/web/controllers/vacation_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/vacation_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule ConciergeSite.VacationControllerTest do
   use ConciergeSite.ConnCase
   import AlertProcessor.Factory
-  alias AlertProcessor.{HoldingQueue, Model, Repo}
+  alias AlertProcessor.{Model, Repo}
   alias Model.User
 
 
@@ -15,8 +15,6 @@ defmodule ConciergeSite.VacationControllerTest do
     end
 
     test "PATCH /my-account/vacation with a valid submission", %{conn: conn, user: user} do
-      notification = build(:notification, user_id: user.id, send_after: DateTime.from_unix!(4_078_579_247))
-      :ok = HoldingQueue.list_enqueue([notification])
       params = %{"user" => %{
         "vacation_start" => "09/01/2017",
         "vacation_end" => "09/01/2035"
@@ -29,7 +27,6 @@ defmodule ConciergeSite.VacationControllerTest do
       assert html_response(conn, 302) =~ subscription_path(conn, :index)
       assert :eq = NaiveDateTime.compare(updated_user.vacation_start, ~N[2017-09-01 00:00:00])
       assert :eq = NaiveDateTime.compare(updated_user.vacation_end, ~N[2035-09-01 00:00:00])
-      assert :error = HoldingQueue.pop()
     end
 
     test "PATCH /my-account/vacation with vacation_end in past", %{conn: conn, user: user} do


### PR DESCRIPTION
Why:

* In what we're calling v2, the `InformedEntityFilter` module should not
rely on a subscription's informed_entities, because in v2 subscriptions
do not have informed_entities. This commit updates the
`InformedEntityFilter` module accordingly.
* Asana link: https://app.asana.com/0/529741067494252/598093528009268

This change addresses the need by:

* Editing `InformedEntityFilter` as described above.
* Fixing all the tests that broke after the changes mentioned above.
This is needed because all these tests were previously relying on
a subscription's informed_entities to work, but the subscription's in the
test were not set up as needed per the updates to the
`InformedEntityFilter` module.