### PR TITLE
Don't load cache in prod

### DIFF
--- a/apps/alert_processor/lib/service_info/service_info_cache.ex
+++ b/apps/alert_processor/lib/service_info/service_info_cache.ex
@@ -239,17 +239,21 @@ defmodule AlertProcessor.ServiceInfoCache do
   end
 
   defp load_initial_service_info do
-    Logger.info("Loading initial service info from cached file")
-    case CacheFile.load_service_info() do
-      {:ok, state} when is_map(state) ->
-        Logger.info("Loading initial service info from cached file")
-        state
-      _ ->
-        Logger.info("Loading initial service info from APIs")
-        state = fetch_and_cache_service_info()
-        Logger.info("Loaded initial service info from APIs")
-        CacheFile.save_service_info(state)
-        state
+    if CacheFile.should_use_file? do
+      Logger.info("Loading initial service info from cached file")
+      case CacheFile.load_service_info() do
+        {:ok, state} when is_map(state) ->
+          Logger.info("Loading initial service info from cached file")
+          state
+        _ ->
+          Logger.info("Loading initial service info from APIs")
+          state = fetch_and_cache_service_info()
+          Logger.info("Loaded initial service info from APIs")
+          CacheFile.save_service_info(state)
+          state
+      end
+    else
+      fetch_and_cache_service_info()
     end
   end
 


### PR DESCRIPTION
This was preventing the master branch of the app from starting up in `MIX_ENV=prod` for me. The function call `CacheFile.load_service_info()` definitely crashes in prod mode, but given that `CacheFile.should_use_file?` returns false for `prod` I'm led to believe it's not supposed to be called in prod mode. However, `should_use_file?` was not used anywhere, which may have been an oversight.