### PR TITLE
Adds NotificationWindowFilter

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -7,7 +7,9 @@ use Mix.Config
 
 # General application configuration
 config :alert_processor,
-  ecto_repos: [AlertProcessor.Repo]
+  ecto_repos: [AlertProcessor.Repo],
+  notification_window_filter: AlertProcessor.NotificationWindowFilter
+
 
 config :paper_trail, repo: AlertProcessor.Repo, item_type: Ecto.UUID, originator_type: Ecto.UUID
 

--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -23,6 +23,8 @@ config :alert_processor, :mailer, AlertProcessor.MailerMock
 
 config :alert_processor, database_url: {:system, "DATABASE_URL_TEST"}
 
+config :alert_processor, :notification_window_filter, AlertProcessor.NotificationWindowFilterMock
+
 config :exvcr, [
   vcr_cassette_library_dir: "test/fixture/vcr_cassettes",
   custom_cassette_library_dir: "test/fixture/custom_cassettes",

--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -1,0 +1,72 @@
+defmodule AlertProcessor.NotificationWindowFilter do
+  @moduledoc """
+  Filters subscriptions by their notification window. If the current day and
+  time is within the subscription's notification window, then the subscription
+  is filtered through.
+
+  A subscription's notificaiton window has a start time and an end time:
+
+  * A subscription's notification window start time is equal to the
+  subscription's `start_time` minus the `alert_time_difference_in_minutes`
+  (column in the trips table).
+
+  * A subscription's notification window end time is equal to the
+  subscription's `end_time`.
+
+  """
+
+  alias AlertProcessor.Model.Subscription
+
+  @doc """
+  Accepts a list of subscriptions and returns a filtered list of subscriptions
+  that could be notified on a given day and time per their notification window.
+
+  *Important Note:* Subscriptions are expected to have their trip preloaded.
+
+  """
+  @spec filter([Subscription.t], DateTime.t) :: [Subscription.t]
+  def filter(subscriptions, now \\ Calendar.DateTime.now!("America/New_York")) do
+    Enum.filter(subscriptions, fn(subscription) ->
+      within_notification_window?(subscription, now)
+    end)
+  end
+
+  @doc false
+  @spec within_notification_window?(Subscription.t, DateTime.t) :: boolean
+  def within_notification_window?(subscription, now) do
+    day_of_week(now) in relevant_days(subscription)
+    && time_within_notification_window?(subscription, now)
+  end
+
+  defp day_of_week(now) do
+    now |> DateTime.to_date() |> Date.day_of_week()
+  end
+
+  defp relevant_days(subscription) do
+    days = %{
+      monday: 1,
+      tuesday: 2,
+      wednesday: 3,
+      thursday: 4,
+      friday: 5,
+      saturday: 6,
+      sunday: 7
+    }
+    Enum.map(subscription.relevant_days, &Map.get(days, &1))
+  end
+
+  defp time_within_notification_window?(subscription, now) do
+    start_time = notification_window_start_time(subscription)
+    end_time = subscription.end_time
+    time_now = DateTime.to_time(now)
+    start_time_ok? = Time.compare(time_now, start_time) in [:gt, :eq]
+    end_time_ok? = Time.compare(time_now, end_time) in [:lt, :eq]
+    start_time_ok? && end_time_ok?
+  end
+
+  defp notification_window_start_time(subscription) do
+    difference_in_minutes = subscription.trip.alert_time_difference_in_minutes
+    difference_in_seconds = difference_in_minutes * 60
+    Time.add(subscription.start_time, -difference_in_seconds)
+  end
+end

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_window_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_window_filter_test.exs
@@ -1,0 +1,93 @@
+defmodule AlertProcessor.NotificationWindowFilterTest do
+  use ExUnit.Case
+  alias AlertProcessor.NotificationWindowFilter
+  import AlertProcessor.Factory
+
+  describe "filter/2" do
+    test "within notification window" do
+      trip_details = [
+        alert_time_difference_in_minutes: 60
+      ]
+      trip = build(:trip, trip_details)
+      subscription_details = [
+        relevant_days: ~w(monday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+      subscription = build(:subscription, subscription_details)
+      monday_at_7am = DateTime.from_naive!(~N[2018-04-02 07:00:00], "Etc/UTC")
+      result = NotificationWindowFilter.filter([subscription], monday_at_7am)
+      assert result == [subscription]
+    end
+
+    test "outside notification window (day mismatch: sunday)" do
+      trip_details = [
+        alert_time_difference_in_minutes: 60
+      ]
+      trip = build(:trip, trip_details)
+      subscription_details = [
+        relevant_days: ~w(monday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+      subscription = build(:subscription, subscription_details)
+      sunday_at_7am = DateTime.from_naive!(~N[2018-04-01 07:00:00], "Etc/UTC")
+      result = NotificationWindowFilter.filter([subscription], sunday_at_7am)
+      assert result == []
+    end
+
+    test "outside notification window (day mismatch: thursday)" do
+      trip_details = [
+        alert_time_difference_in_minutes: 60
+      ]
+      trip = build(:trip, trip_details)
+      subscription_details = [
+        # Thursday is missing from `relevant_days`
+        relevant_days: ~w(monday tuesday wednesday friday saturday sunday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+      subscription = build(:subscription, subscription_details)
+      thursday_at_7am = DateTime.from_naive!(~N[2018-04-05 07:00:00], "Etc/UTC")
+      result = NotificationWindowFilter.filter([subscription], thursday_at_7am)
+      assert result == []
+    end
+
+    test "outside notification window (day match but time before window)" do
+      trip_details = [
+        alert_time_difference_in_minutes: 60
+      ]
+      trip = build(:trip, trip_details)
+      subscription_details = [
+        relevant_days: ~w(monday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+      subscription = build(:subscription, subscription_details)
+      monday_at_6am = DateTime.from_naive!(~N[2018-04-02 06:00:00], "Etc/UTC")
+      result = NotificationWindowFilter.filter([subscription], monday_at_6am)
+      assert result == []
+    end
+
+    test "outside notification window (day match but time after window)" do
+      trip_details = [
+        alert_time_difference_in_minutes: 60
+      ]
+      trip = build(:trip, trip_details)
+      subscription_details = [
+        relevant_days: ~w(monday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+      subscription = build(:subscription, subscription_details)
+      monday_at_10am = DateTime.from_naive!(~N[2018-04-02 10:00:00], "Etc/UTC")
+      result = NotificationWindowFilter.filter([subscription], monday_at_10am)
+      assert result == []
+    end
+  end
+end

--- a/apps/alert_processor/test/support/mocks/notificaton_window_filter_mock.ex
+++ b/apps/alert_processor/test/support/mocks/notificaton_window_filter_mock.ex
@@ -1,0 +1,5 @@
+defmodule AlertProcessor.NotificationWindowFilterMock do
+  @moduledoc false
+
+  def filter(subscriptions), do: subscriptions
+end


### PR DESCRIPTION
Why:

* We want users to not receive notifications outside of their
selected notification window.
* Asana link: https://app.asana.com/0/529741067494252/604442924210533

This change addresses the need by:

* Adding a `NotificationWindowFilter` module.
* Adding a `NotificationWindowFilterMock` module.
* Editing `SubscriptionFilterEngine` to use the new
`NotificationWindowFilter` when in dev or prod environments and the
`NotificationWindowFilterMock` when in test environment.