### PR TITLE
Add ExActor to Mix deps

### DIFF
--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -34,6 +34,7 @@ defmodule AlertProcessor.Mixfile do
         :comeonin,
         :con_cache,
         :sweet_xml, # Must come before ex_aws
+        :exactor,
         :ex_aws,
         :ex_rated,
         :hackney,
@@ -66,6 +67,7 @@ defmodule AlertProcessor.Mixfile do
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.5.0", only: [:dev]},
       {:ecto, "~> 2.1.0"},
+      {:exactor, "~> 2.2.0"},
       {:excoveralls, "~> 0.5", only: [:dev, :test]},
       {:ex_aws, git: "https://github.com/bfauble/ex_aws", ref: "f64f2cb026171dc6def03102ccae31906797deb0"},
       {:ex_machina, "~> 2.0", only: :test},


### PR DESCRIPTION
`exactor` is a transitive dependency of `con_cache`, but `con_cache` doesn't specify it in its list of applications. As such, distillery thinks that exactor is unused and does not include its code in the release. As a workaround, list exactor as a direct dependency.

I was getting this error when compiling the release:

```
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :exactor

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.
```