### PR TITLE
Adds accessibility trip edit page

### DIFF
--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -151,7 +151,7 @@ defmodule ConciergeSite.Router do
       post "/times", V2.TripController, :times
       get "/type", V2.TripController, :type
     end
-    resources "/accessibility_trips", V2.AccessibilityTripController, only: [:new, :create]
+    resources "/accessibility_trips", V2.AccessibilityTripController, only: [:new, :create, :edit, :update]
   end
 
   if Mix.env == :dev do

--- a/apps/concierge_site/lib/templates/v2/accessibility_trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/accessibility_trip/edit.html.eex
@@ -1,0 +1,42 @@
+<h1 class="heading__title">Edit Subscription</h1>
+<%= flash_error(@conn) %>
+<%= flash_info(@conn) %>
+
+<div class="my-4">
+  <%= ConciergeSite.TripCardHelper.render(@conn, @trip) %>
+  <div class="text-center">
+    <button type="button" class="btn btn-link" data-toggle="modal" data-target="#deleteModal">
+    <i aria-hidden="true" class="fa fa-trash"></i> Delete this subscription
+    </button>
+  </div>
+</div>
+
+<%= form_for @changeset, v2_accessibility_trip_path(@conn, :update, @trip), [as: :trip], fn form -> %>
+  <div class="form-group my-4">
+    <%= label form, :relevant_days, "What days do you take this trip?", class: "form__label" %>
+    <%= ConciergeSite.DaySelectHelper.render(:trip, @trip.relevant_days) %>
+    <%= error_tag form, :relevant_days %>
+  </div>
+
+  <div class="my-5">
+    <%= submit "Update subscription", class: "btn btn-primary btn-login btn-block" %>
+  </div>
+<% end %>
+
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body text-center">
+        <div class="my-2">
+          Are you sure you want to delete this subscription?
+        </div>
+        <div class="my-3">
+          <%= link to: v2_trip_path(@conn, :delete, @trip), method: :delete, class: "btn btn-outline-primary" do %>
+            Yes
+          <% end %>
+          <button type="button" class="btn btn-outline-primary" data-dismiss="modal">No</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -9,7 +9,7 @@ defmodule ConciergeSite.TripCardHelper do
   @spec render(Plug.Conn.t, atom | Trip.t) :: Phoenix.HTML.safe
   def render(conn, %Trip{trip_type: :accessibility, id: id, relevant_days: relevant_days,
                          facility_types: facility_types, subscriptions: subscriptions}) do
-    link to: ConciergeSite.Router.Helpers.v2_trip_path(conn, :edit, id), class: "card trip__card" do
+    link to: ConciergeSite.Router.Helpers.v2_accessibility_trip_path(conn, :edit, id), class: "card trip__card" do
       [
         edit_faux_link(),
         content_tag :span, class: "trip__card--route-icon" do


### PR DESCRIPTION
Why:

* We want users to be able to edit accessibility trips.
* Asana link: https://app.asana.com/0/529741067494252/622739335627366

This change addresses the need by:

* Adding edit and update routes for accessibility trips.
* Editing the TripCardHelper module to use the correct new accessibility
trip edit route mentioned above for accessibility trips. This adds the
correct links to accessibility trips in the trips index page.
* Adding new edit and update actions to the AccessibilityTripController.
* Adding accessibility_trip/edit.html.eex template