### PR TITLE
store facility_types on accessibility subscription

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/accessibility_trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/accessibility_trip_controller.ex
@@ -169,6 +169,7 @@ defmodule ConciergeSite.V2.AccessibilityTripController do
       start_time: trip.start_time,
       end_time: trip.end_time,
       type: :accessibility,
+      facility_types: trip.facility_types,
       return_trip: false
     }
   end


### PR DESCRIPTION
[Creation of accessibility trips does not include `facility_types` in the subscription table](https://app.asana.com/0/529741067494252/627669471617649/f)

