### PR TITLE
Bump elixir version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir v1.5.2-otp-20
+elixir 1.6.4
 nodejs 8.7.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ functionality remain low and that MBTA can manage and improve the system.
 ### Requirements
 
 * PostgreSQL ~10.0
-* Elixir 1.5.2 (you can use [asdf](https://github.com/asdf-vm/asdf) with
+* Elixir 1.6.x (you can use [asdf](https://github.com/asdf-vm/asdf) with
   [asdf-elixir](https://github.com/asdf-vm/asdf-elixir) to manage Elixir
   versions)
 * Node.js 8.7.0 (you can use [asdf](https://github.com/asdf-vm/asdf) with

--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -8,7 +8,7 @@ defmodule AlertProcessor.Mixfile do
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.4",
+     elixir: "~> 1.6",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,

--- a/apps/concierge_site/mix.exs
+++ b/apps/concierge_site/mix.exs
@@ -8,7 +8,7 @@ defmodule ConciergeSite.Mixfile do
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.4",
+     elixir: "~> 1.6",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext, :yecc, :leex, :erlang, :elixir, :xref, :app],
      preferred_cli_env: [coveralls: :test, "coveralls.json": :test],


### PR DESCRIPTION
Why:

* For the project's mix files to be consistent with the rest of the
project, the elixir version on semaphore, and what devs are running
locally.
* Asana link: https://app.asana.com/0/529741067494252/579604200353159

This commit addresses the need by:

* Bumping version in mix files and .tool-versions. Note that I'm not
using asdf but since the .tool-versions is in the repo I updated it for
it to be consistent with the rest of the project.