### PR TITLE
Adds newsletter option to signup flow

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -10,7 +10,8 @@ defmodule AlertProcessor.Model.User do
     vacation_start: DateTime.t | nil,
     vacation_end: DateTime.t | nil,
     do_not_disturb_start: Time.t | nil,
-    do_not_disturb_end: Time.t | nil
+    do_not_disturb_end: Time.t | nil,
+    digest_opt_in: boolean
   }
 
   @type id :: String.t
@@ -33,6 +34,7 @@ defmodule AlertProcessor.Model.User do
     field :do_not_disturb_start, :time
     field :do_not_disturb_end, :time
     field :encrypted_password, :string
+    field :digest_opt_in, :boolean, default: true
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true
     field :sms_toggle, :boolean, virtual: true
@@ -152,7 +154,7 @@ defmodule AlertProcessor.Model.User do
   """
   def update_account_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, ~w(phone_number do_not_disturb_start do_not_disturb_end))
+    |> cast(params, ~w(phone_number do_not_disturb_start do_not_disturb_end digest_opt_in))
     |> validate_format(:phone_number, ~r/^[0-9]{10}$/, message: "Phone number is not in a valid format.")
   end
 

--- a/apps/concierge_site/lib/controllers/v2/account_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/account_controller.ex
@@ -27,7 +27,7 @@ defmodule ConciergeSite.V2.AccountController do
   end
 
   def options_create(conn, %{"user" => user_params}, user, {:ok, claims}) do
-    params = options_params(user_params)
+    params = Map.merge(user_params, options_params(user_params))
 
     case User.update_account(user, params, Map.get(claims, "imp", user.id)) do
       {:ok, user} ->

--- a/apps/concierge_site/lib/templates/v2/account/options_new.html.eex
+++ b/apps/concierge_site/lib/templates/v2/account/options_new.html.eex
@@ -21,6 +21,12 @@
     </div>
   </div>
 
+  <div class="form-group my-4">
+    <%= checkbox form, :digest_opt_in, class: "form__input--inline" %>
+    <%= label form, :digest_opt_in, "Yes, I want to receive a weekly email about planned service changes", class: "form__label" %>
+    <i title="Even if you receive text alerts, this will be sent to the email address you signed up with" class="fa fa-question-circle"></i>
+  </div>
+
   <div class="my-5">
     <%= submit "Next", class: "btn btn-primary btn-login btn-block" %>
     <br>

--- a/apps/concierge_site/test/web/controllers/v2/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/account_controller_test.exs
@@ -48,7 +48,8 @@ defmodule ConciergeSite.V2.AccountControllerTest do
 
     user_params = %{
       sms_toggle: "true",
-      phone_number: "5555555555"
+      phone_number: "5555555555",
+      digest_opt_in: false
     }
 
     conn = user
@@ -59,6 +60,7 @@ defmodule ConciergeSite.V2.AccountControllerTest do
 
     assert html_response(conn, 302) =~ "/v2/trip_type"
     assert updated_user.phone_number == "5555555555"
+    assert updated_user.digest_opt_in == false
   end
 
   test "POST /v2/account/options with email", %{conn: conn} do


### PR DESCRIPTION
Why:

* For users to decide if they want to receive a weekly newsletter/digest
in the signup flow.
* Asana link: https://app.asana.com/0/529741067494252/621606075206021

This change addresses the need by:

* Editing the User model to allow for `digest_opt_in` updates and adding
`digest_opt_in` to the schema and Uset.t type definition.
* Editing the UserController#options_create action for the user's
`digest_opt_in` selection to be taken into account.
* Adding the `digest_opt_in` checkbox to the account/option_new.html.eex
template.