### PR TITLE
Add password reset / forgot password functionality

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/password_reset_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/password_reset_controller.ex
@@ -1,0 +1,74 @@
+defmodule ConciergeSite.V2.PasswordResetController do
+  use ConciergeSite.Web, :controller
+  alias AlertProcessor.Model.User
+  alias ConciergeSite.Dissemination.{Email, Mailer}
+  alias ConciergeSite.SignInHelper
+
+  action_fallback ConciergeSite.V2.FallbackController
+
+  def new(conn, _params) do
+    render(conn, "new.html")
+  end
+
+  def create(conn, %{"password_reset" => %{"email" => email}}) do
+    case User.for_email(email) do
+      nil ->
+        conn
+        |> put_flash(:error, "Could not find that email address.")
+        |> render("new.html")
+      user ->
+        reset_token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", email)
+        user |> Email.password_reset_email(reset_token) |> Mailer.deliver_later()
+        conn
+        |> put_flash(:info, "We've sent you a password reset email. Check your inbox!")
+        |> redirect(to: v2_session_path(conn, :new))
+    end
+  end
+
+  def edit(conn, %{"id" => reset_token}) do
+    render(conn, "edit.html", reset_token: reset_token)
+  end
+
+  def update(conn, %{"id" => reset_token, "password_reset" => password_reset_params}) do
+    two_hours = 7_200
+    with {:ok, email} <- verify_token(reset_token, max_age: two_hours),
+         user when not is_nil(user) <- User.for_email(email),
+         {:ok, :password_confirmation} <- check_password_confirmation(password_reset_params),
+         {:ok, _} <- User.update_password(user, password_reset_params, user) do
+      conn
+      |> put_flash(:info, "Your password has been updated.")
+      |> SignInHelper.sign_in(user, redirect: :v2_default)
+    else
+      {:error, :password_confirmation} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_flash(:error, "Password confirmation must match.")
+        |> render("edit.html", reset_token: reset_token)
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_flash(:error, password_reset_errors(changeset))
+        |> render("edit.html", reset_token: reset_token, changeset: changeset)
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  defp verify_token(reset_token, max_age: max_age) do
+    Phoenix.Token.verify(ConciergeSite.Endpoint, "password_reset", reset_token, max_age: max_age)
+  end
+
+  defp check_password_confirmation(params) do
+    if params["password"] == params["password_confirmation"] do
+      {:ok, :password_confirmation}
+    else
+      {:error, :password_confirmation}
+    end
+  end
+
+  defp password_reset_errors(changeset) do
+    changeset.errors
+    |> Enum.map(fn ({_, {error, _}}) -> error end)
+    |> Enum.join(",")
+  end
+end

--- a/apps/concierge_site/lib/dissemination/email.ex
+++ b/apps/concierge_site/lib/dissemination/email.ex
@@ -11,6 +11,27 @@ defmodule ConciergeSite.Dissemination.Email do
 
   EEx.function_from_file(
     :def,
+    :password_reset_html_email,
+    Path.join(@template_dir, "password_reset.html.eex"),
+    [:reset_token, :manage_subscriptions_url, :feedback_url])
+  EEx.function_from_file(
+    :def,
+    :password_reset_text_email,
+    Path.join(~w(#{System.cwd!} lib mail_templates password_reset.txt.eex)),
+    [:reset_token, :manage_subscriptions_url, :feedback_url])
+
+  def password_reset_email(user, reset_token) do
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    feedback_url = MailHelper.feedback_url()
+    base_email()
+    |> to(user.email)
+    |> subject("Reset Your MBTA Alerts Password")
+    |> html_body(password_reset_html_email(reset_token, manage_subscriptions_url, feedback_url))
+    |> text_body(password_reset_text_email(reset_token, manage_subscriptions_url, feedback_url))
+  end
+
+  EEx.function_from_file(
+    :def,
     :confirmation_html_email,
     Path.join(@template_dir, "confirmation.html.eex"),
     [:manage_subscriptions_url, :feedback_url])

--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -145,4 +145,8 @@ defmodule ConciergeSite.Helpers.MailHelper do
       url -> url
     end
   end
+
+  def reset_password_url(reset_token) do
+    Helpers.v2_password_reset_url(ConciergeSite.Endpoint, :edit, reset_token)
+  end
 end

--- a/apps/concierge_site/lib/mail_templates/password_reset.html.eex
+++ b/apps/concierge_site/lib/mail_templates/password_reset.html.eex
@@ -17,14 +17,14 @@
         Please click the link below and follow the instructions on the page to reset your password:
       </p>
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">
-        <a href="<%= ConciergeSite.Helpers.MailHelper.reset_password_url(password_reset_id) %>">Reset My Password</a>
+        <a href="<%= ConciergeSite.Helpers.MailHelper.reset_password_url(reset_token) %>">Reset My Password</a>
       </p>
       <p style="margin: 0; padding: 0; margin-bottom: 16px;">
         Please note that this link will expire after one hour.
       </p>
     </div>
     <center>
-      <%= ConciergeSite.Helpers.MailHelper.html_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
+      <%= ConciergeSite.Helpers.MailHelper.html_footer(manage_subscriptions_url, feedback_url) %>
     </center>
   </body>
 </html>

--- a/apps/concierge_site/lib/mail_templates/password_reset.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/password_reset.txt.eex
@@ -4,9 +4,9 @@ You recently requested a password reset for your MBTA Alerts account.
 
 Please click the link below and follow the instructions on the page to reset your password:
 
-<%= ConciergeSite.Helpers.MailHelper.reset_password_url(password_reset_id) %>
+<%= ConciergeSite.Helpers.MailHelper.reset_password_url(reset_token) %>
 
 
 Please note that this link will expire after one hour.
 
-<%= ConciergeSite.Helpers.MailHelper.text_footer(unsubscribe_url, manage_subscriptions_url, feedback_url) %>
+<%= ConciergeSite.Helpers.MailHelper.text_footer(manage_subscriptions_url, feedback_url) %>

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -66,6 +66,7 @@ defmodule ConciergeSite.Router do
     get "/deleted", V2.PageController, :account_deleted
     resources "/login", V2.SessionController, only: [:new, :create, :delete], singleton: true
     resources "/account", V2.AccountController, only: [:new, :create]
+    resources "/password_resets",V2.PasswordResetController, only: [:new, :create, :edit, :update]
   end
 
   scope "/", ConciergeSite, as: :v2 do

--- a/apps/concierge_site/lib/templates/v2/password_reset/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/password_reset/edit.html.eex
@@ -1,0 +1,23 @@
+<h1 class="heading__title my-4">Reset Password</h1>
+<div class="form-header">
+  <%= flash_error(@conn) %>
+  <p>Enter and confirm your new password below.</p>
+</div>
+
+<%= form_for @conn, v2_password_reset_path(@conn, :update, @reset_token), [method: "PATCH", as: :password_reset], fn f -> %>
+  <div class="form-group my-4">
+    <%= label f, :password, "Password", class: "form__label" %>
+    <%= error_tag f, :password %>
+    <%= password_input f, :password, placeholder: "Enter your password", class: "form-control", pattern: password_regex_string(), required: true %>
+    <span></span>
+  </div>
+  <div class="form-group my-4">
+    <%= label f, :password_confirmation, "Password Confirmation", class: "form__label" %>
+    <%= error_tag f, :password_confirmation %>
+    <%= password_input f, :password_confirmation, placeholder: "Re-enter your password", class: "form-control", pattern: password_regex_string(), required: true %>
+    <span></span>
+  </div>
+  <div class="form-footer">
+    <%= submit "Reset Password", class: "btn btn-primary btn-wide" %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/templates/v2/password_reset/new.html.eex
+++ b/apps/concierge_site/lib/templates/v2/password_reset/new.html.eex
@@ -1,0 +1,21 @@
+<h1 class="heading__title my-4">Forgot password?</h1>
+<div class="form-header">
+  <%= flash_error(@conn) %>
+  <h2>Reset your password</h2>
+  <p>
+  Enter the email address you use to sign into your T-Alerts account. We’ll
+  send you instructions on how to reset your password.
+  </p>
+</div>
+
+<%= form_for @conn, v2_password_reset_path(@conn, :create), [as: :password_reset], fn f -> %>
+  <div class="form-group my-4">
+    <%= label f, :email, "Email Address", class: "form-label" %>
+    <%= error_tag f, :email %>
+    <%= email_input f, :email, placeholder: "your@email.com", class: "form-control", required: true %>
+    <span></span>
+  </div>
+  <div class="form-footer">
+    <%= submit "Send reset link", class: "btn btn-primary btn-wide" %>
+  </div>
+<% end %>

--- a/apps/concierge_site/lib/templates/v2/session/new.html.eex
+++ b/apps/concierge_site/lib/templates/v2/session/new.html.eex
@@ -14,7 +14,13 @@
     <%= label f, :password, "Password", class: "form__label" %>
     <%= error_tag f, :password %>
     <%= password_input f, :password, placeholder: "Enter your password", class: "form-control form__input", pattern: password_regex_string(), required: true %>
+
+    <div class="text-right">
+      <%= link "Forgot password?", to: v2_password_reset_path(@conn, :new) %>
+    </div>
   </div>
+
+
   <div class="my-5">
     <%= submit "Go to my account", class: "btn btn-primary btn btn-block" %>
   </div>

--- a/apps/concierge_site/lib/views/v2/password_reset_view.ex
+++ b/apps/concierge_site/lib/views/v2/password_reset_view.ex
@@ -1,0 +1,4 @@
+defmodule ConciergeSite.V2.PasswordResetView do
+  use ConciergeSite.Web, :view
+  import ConciergeSite.PasswordHelper, only: [password_regex_string: 0]
+end

--- a/apps/concierge_site/test/lib/dissemination/email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/email_test.exs
@@ -2,6 +2,18 @@ defmodule ConciergeSite.Dissemination.EmailTest do
   use ConciergeSite.ConnCase
   alias ConciergeSite.Dissemination.Email
 
+  test "password reset email" do
+    user = insert(:user)
+    reset_token = "some reset token"
+
+    email = Email.password_reset_email(user, reset_token)
+
+    assert email.to == user.email
+    assert email.subject == "Reset Your MBTA Alerts Password"
+    assert email.html_body =~ "Please click the link below and follow the instructions on the page to reset your password"
+    assert email.html_body =~ "mbtafeedback.com"
+  end
+
   test "confirmation email" do
     user = insert(:user)
 

--- a/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
+++ b/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
@@ -151,4 +151,13 @@ defmodule ConcerigeSite.Helpers.MailHelperTest do
       assert MailHelper.feedback_url() == "http://mbtafeedback.com/"
     end
   end
+
+  describe "reset_password_url" do
+    test "generates url with password reset id" do
+      reset_token = "some-reset-token"
+      url = MailHelper.reset_password_url(reset_token)
+      assert url =~ "http"
+      assert url =~ "password_resets/#{reset_token}/edit"
+    end
+  end
 end

--- a/apps/concierge_site/test/web/controllers/v2/password_reset_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/password_reset_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule ConciergeSite.V2.PasswordResetControllerTest do
+  use ConciergeSite.ConnCase
+  use Bamboo.Test
+
+  test "new/2", %{conn: conn} do
+    conn = get(conn, v2_password_reset_path(conn, :new))
+    assert html_response(conn, 200) =~ "Reset your password"
+  end
+
+  describe "create/2" do
+    test "existing user can request email to reset password", %{conn: conn}  do
+      user = insert(:user)
+      params = %{"password_reset" => %{"email" => user.email}}
+      conn = post(conn, v2_password_reset_path(conn, :create), params)
+      assert html_response(conn, 302) =~ "/"
+      assert get_flash(conn)["info"] == "We've sent you a password reset email. Check your inbox!"
+      assert_delivered_with(to: [{nil, user.email}])
+    end
+
+    test "non-existent user can't request email to reset password", %{conn: conn} do
+      email = "non-existing-user@domain.com"
+      params = %{"password_reset" => %{"email" => email}}
+      conn = post(conn, v2_password_reset_path(conn, :create), params)
+      assert html_response(conn, 200) =~ "Could not find that email address."
+    end
+  end
+
+  test "edit/2", %{conn: conn} do
+    conn = get(conn, v2_password_reset_path(conn, :edit, "some-reset-token"))
+    assert html_response(conn, 200) =~ "Reset Password"
+  end
+
+  describe "update/2" do
+    test "with valid reset token and password", %{conn: conn} do
+      user = insert(:user)
+      reset_token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", user.email)
+      valid_password = "password1!"
+      params = %{
+        "password_reset" => %{
+          "password" => valid_password,
+          "password_confirmation" => valid_password
+        }
+      }
+      conn = patch(conn, v2_password_reset_path(conn, :update, reset_token), params)
+      assert get_flash(conn)["info"] == "Your password has been updated."
+    end
+
+    test "with invalid reset token", %{conn: conn} do
+      reset_token = "some-invalid-token"
+      valid_password = "password1!"
+      params = %{
+        "password_reset" => %{
+          "password" => valid_password,
+          "password_confirmation" => valid_password
+        }
+      }
+      conn = patch(conn, v2_password_reset_path(conn, :update, reset_token), params)
+      assert html_response(conn, 404) =~ "cannot be found"
+    end
+
+    test "with invalid password", %{conn: conn} do
+      user = insert(:user)
+      reset_token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", user.email)
+      invalid_password = "invalid"
+      params = %{
+        "password_reset" => %{
+          "password" => invalid_password,
+          "password_confirmation" => invalid_password
+        }
+      }
+      conn = patch(conn, v2_password_reset_path(conn, :update, reset_token), params)
+      assert html_response(conn, 422) =~ "Password must contain one number or special character"
+    end
+
+    test "with invalid password confirmation", %{conn: conn} do
+      user = insert(:user)
+      reset_token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", user.email)
+      params = %{
+        "password_reset" => %{
+          "password" => "password1!",
+          "password_confirmation" => "secret1!"
+        }
+      }
+      conn = patch(conn, v2_password_reset_path(conn, :update, reset_token), params)
+      assert html_response(conn, 422) =~ "Password confirmation must match."
+    end
+  end
+end


### PR DESCRIPTION
Why:

* For users to be able to reset their password if they forget it.
* Asana link: https://app.asana.com/0/529741067494252/629437387840208

This change addresses the need by:

* Adding a `forgot password?` link to the sign in page. When clicked,
users will be taken to a page where they can type their email to receive
a link to reset their password. When users click on the link they get
sent to their email, they'll get a form where the they can enter a
password and password confirmation to reset their password. Once they do
this they'll be automatically signed in and their password will be
updated.