### PR TITLE
Change home page to create account page

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/page_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/page_controller.ex
@@ -1,10 +1,6 @@
 defmodule ConciergeSite.V2.PageController do
   use ConciergeSite.Web, :controller
 
-  def index(conn, _params) do
-    render conn, "index.html"
-  end
-
   def trip_type(conn, _params) do
     render conn, "trip_type.html"
   end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -61,11 +61,11 @@ defmodule ConciergeSite.Router do
   scope "/", ConciergeSite, as: :v2 do
     pipe_through [:redirect_prod_http, :browser, :v2_layout]
 
-    get "/", V2.PageController, :index
+    get "/", V2.AccountController, :new
     get "/trip_type", V2.PageController, :trip_type
     get "/deleted", V2.PageController, :account_deleted
     resources "/login", V2.SessionController, only: [:new, :create, :delete], singleton: true
-    resources "/account", V2.AccountController, only: [:new, :create]
+    resources "/account", V2.AccountController, only: [:create]
     resources "/password_resets",V2.PasswordResetController, only: [:new, :create, :edit, :update]
   end
 

--- a/apps/concierge_site/lib/templates/v2/page/index.html.eex
+++ b/apps/concierge_site/lib/templates/v2/page/index.html.eex
@@ -1,9 +1,0 @@
-<h1 class="heading__hero my-4 text-center">Welcome to T-Alerts!</h1>
-
-<p class="my-4 text-center">T-Alerts are personalized text or email notifications about service disruptions and changes.</p>
-
-<p class="my-4 text-center">Want to learn more? <a href="https://www.mbta.com/about-t-alerts-beta">Read out FAQ <i aria-hidden="true" class="fa fa-arrow-right "></i></a></p>
-
-<p class="my-4 text-center"><a class="btn btn-primary btn btn-lg" href="<%= v2_account_path(@conn, :new) %>">Sign up to T-Alerts</a></p>
-
-<p class="my-4 text-center">Already have an account? <a href="<%= v2_session_path(@conn, :new) %>">Sign in <i aria-hidden="true" class="fa fa-arrow-right "></i></a></p>

--- a/apps/concierge_site/test/feature/v2/create_subscription_test.exs
+++ b/apps/concierge_site/test/feature/v2/create_subscription_test.exs
@@ -15,7 +15,7 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
 
   test "new account", %{session: session} do
     session
-    |> visit("/account/new")
+    |> visit("/")
     |> fill_in(text_field("user_email"), with: "test@test.com")
     |> fill_in(text_field("user_password"), with: @password)
     |> click(button("Create my account"))
@@ -29,12 +29,6 @@ defmodule ConciergeSite.V2.CreateSubscriptionTest do
     |> assert_has(css("#main", text: "Customize my settings"))
     |> click(button("Next"))
     |> assert_has(css("#main", text: "What kind of alerts would you like to setup?"))
-  end
-
-  test "home page", %{session: session} do
-    session
-    |> visit("/")
-    |> assert_has(css("#main", text: "Welcome to T-Alerts!"))
   end
 
   test "new session", %{session: session, user: user} do

--- a/apps/concierge_site/test/web/controllers/v2/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/account_controller_test.exs
@@ -3,7 +3,7 @@ defmodule ConciergeSite.V2.AccountControllerTest do
   import AlertProcessor.Factory
   alias AlertProcessor.{Model.User, Repo}
 
-  test "GET /account/new", %{conn: conn} do
+  test "new/4", %{conn: conn} do
     conn = get(conn, v2_account_path(conn, :new))
     assert html_response(conn, 200) =~ "Create account"
   end

--- a/apps/concierge_site/test/web/controllers/v2/page_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/page_controller_test.exs
@@ -1,11 +1,6 @@
 defmodule ConciergeSite.V2.PageControllerTest do
   use ConciergeSite.ConnCase
 
-  test "GET /", %{conn: conn} do
-    conn = get(conn, v2_page_path(conn, :index))
-    assert html_response(conn, 200) =~ "Welcome to T-Alerts!"
-  end
-
   test "GET /trip_type", %{conn: conn} do
     conn = get(conn, v2_page_path(conn, :trip_type))
 


### PR DESCRIPTION
Why:

* We want users to see the 'create account' page when they visit the
home page `/`.
* Asana link: https://app.asana.com/0/516686971504018/625819020231198/f

This change addresses the need by:

* Edits the "/" route to point to the new account controller#action
(V2.AccountController#new).
* Deletes V2.PageController#index and v2/page/index.html.eex as it's not
being used anymore.