### PR TITLE
Remove return times for one-way trips

### DIFF
--- a/apps/concierge_site/lib/templates/v2/trip/times.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/times.html.eex
@@ -21,7 +21,7 @@
     <%= ConciergeSite.ScheduleHelper.render(@schedules, "trip_start_time", "trip_end_time") %>
   </div>
 
-  <%= if @round_trip do %>
+  <%= if @round_trip == "true" do %>
     <div class="form-group my-4">
       <span class="form__label">What time do you usually take your return trip?</span>
       <div class="form-group form-inline form__group--inline">


### PR DESCRIPTION
Why:

* If a user creates a one-way trip we shouldn't ask them for the return
times. Also, Trisha reported that the trip card for one-way trips is
displaying return times, which doesn't make sense. This commit fixes
this.
* Asana link: https://app.asana.com/0/529741067494252/633728876475613

This change addresses the need by:

* Editing v2/trip/times.html.eex to render the return times inputs only
for one-way trips.
* Note: I was not able to duplicate one-way trip cards with a return
time after the change above.