### PR TITLE
Trips are not created with same origin/destination

### DIFF
--- a/apps/concierge_site/assets/js/select-stop.js
+++ b/apps/concierge_site/assets/js/select-stop.js
@@ -11,7 +11,8 @@ export default function($) {
   };
 
   $("select[data-type='stop']").each(function() {
-     $(this).select2(options);
+    $(this).select2(options);
+    addSameStopValidationIfTripLegForm($(this));
   });
 };
 
@@ -29,3 +30,23 @@ function formatStop(stop) {
   const ferry = $el.data("ferry") ? getIcon("ferry")(className) : "";
   return $(`<span>${stop.text}${accessible}${ferry}${cr}${bus}${mattapan}${blue}${green}${orange}${red}</span>`);
 };
+
+function addSameStopValidationIfTripLegForm(selectStopComponent) {
+  if (isTripLegForm()) {
+    selectStopComponent.on("select2:select", disableSubmitButtonIfSameStops);
+  }
+}
+
+function isTripLegForm() {
+  return $("#tripleg-form").length > 0
+}
+
+function disableSubmitButtonIfSameStops() {
+  const origin = $("#select2-trip_origin-container").attr("title")
+  const destination = $("#select2-trip_destination-container").attr("title")
+  if (origin == destination) {
+    $("button[type='submit']").attr("disabled", "disabled");
+  } else {
+    $("button[type='submit']").removeAttr("disabled");
+  }
+}

--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -75,6 +75,13 @@ defmodule ConciergeSite.V2.TripController do
     end
   end
 
+  def leg(conn, %{"trip" => %{"origin" => origin, "destination" => destination}}, _, _)
+      when origin == destination do
+    conn
+    |> put_flash(:error, "There was an error. Trip origin and destination must be different.")
+    |> render("new.html")
+  end
+
   def leg(conn, %{"trip" => trip}, _user, _claims) do
     case trip do
       %{"route" => route, "saved_leg" => saved_leg, "origin" => origin,

--- a/apps/concierge_site/lib/templates/v2/trip/leg.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/leg.html.eex
@@ -1,7 +1,7 @@
 <%= render ConciergeSite.V2.LayoutView, "_steps.html", step: "two" %>
 <h1 class="heading__title">Personalize Subscription</h1>
 
-<%= form_for @conn, v2_trip_trip_path(@conn, :leg), [as: :trip, method: :post], fn form -> %>
+<%= form_for @conn, v2_trip_trip_path(@conn, :leg), [as: :trip, method: :post, id: "tripleg-form"], fn form -> %>
   <%= if @saved_mode != "bus" do %>
     <div class="form-group my-4">
       <%= label form, :origin, "Where do you get on the #{@route_name}?", class: "form__label" %>

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -233,6 +233,25 @@ defmodule ConciergeSite.V2.TripControllerTest do
     assert html_response(conn, 200) =~ "Do you make a connection to another route or line?"
   end
 
+  test "leg/3 with same origin and destination", %{conn: conn, user: user} do
+    stop = "some-stop"
+
+    trip = %{
+      destination: stop,
+      new_leg: "true",
+      origin: stop,
+      round_trip: "true",
+      route: "Green~~Green Line~~subway",
+      saved_leg: "Red",
+      saved_mode: "subway"
+    }
+    conn = user
+    |> guardian_login(conn)
+    |> post(v2_trip_trip_path(conn, :leg), %{trip: trip})
+
+    assert html_response(conn, 200) =~ "Trip origin and destination must be different."
+  end
+
   test "POST /trip/leg to create new trip leg with existing trip legs", %{conn: conn, user: user} do
     trip = %{
       destination: "place-pktrm",


### PR DESCRIPTION
Why:

* It doesn't make sense to allow users to create trips with the same
origin and destination.
* Asana link: https://app.asana.com/0/529741067494252/604923501801002

This change addresses the need by:

* Editing V2.TripController#leg action to render an error if origin is
the same as the destination.
* Editing js/select-stop.js to disable the submit button if origin and
destination are the same.