### PR TITLE
Fix bus trip create bug

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -6,6 +6,8 @@ defmodule ConciergeSite.V2.TripController do
   alias AlertProcessor.ServiceInfoCache
   alias Ecto.Multi
 
+  plug :scrub_params, "trip" when action in [:leg]
+
   action_fallback ConciergeSite.V2.FallbackController
 
   def index(conn, _params, user, _claims) do
@@ -76,7 +78,7 @@ defmodule ConciergeSite.V2.TripController do
   end
 
   def leg(conn, %{"trip" => %{"origin" => origin, "destination" => destination}}, _, _)
-      when origin == destination do
+      when not is_nil(origin) and origin == destination do
     conn
     |> put_flash(:error, "There was an error. Trip origin and destination must be different.")
     |> render("new.html")


### PR DESCRIPTION
Why:

* Currently we can't create bus trips because of the validation that we
recently added to prevent users from creating trips with the same
origins and destinations. More specifically this is because the origin
and destination for a bus trip comes in as two empty strings.
* Asana link: https://app.asana.com/0/529741067494252/640514815408664

This change addresses the need by:

* Adding `:scrub_params` plug to remove empty strings on
V2.TripController's leg action `"trip"` params.
* Editing V2.TripController's leg action to only error and notify user
that origins can't equal destinations if a trip's origin is not nil.