### PR TITLE
Fix bus alert bug

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -6,7 +6,7 @@ defmodule ConciergeSite.V2.TripController do
   alias AlertProcessor.ServiceInfoCache
   alias Ecto.Multi
 
-  plug :scrub_params, "trip" when action in [:leg]
+  plug :scrub_params, "trip" when action in [:create, :leg]
 
   action_fallback ConciergeSite.V2.FallbackController
 


### PR DESCRIPTION
Why:

* A bug was reported in which a bus alert didn't trigger a notification.
This seems to be because bus trip subscriptions in the DB end up with
empty strings for origins and destinations. This commit fixes this by
making sure bus-trip subscriptions are created with origin and
destination of nil. This allows the `stop_match?` function in the
`InformedEntityFilter` to correctly match on an alert with nil stop for
a given bus subscription. For more details refer to the asana ticket
below.
* Asana link: https://app.asana.com/0/529741067494252/639718241588664

This change addresses the need by:

* "Scrubbing params" for V2.TripController's create action.