### PR TITLE
Fix bug: station feature alerts

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -55,6 +55,14 @@ defmodule AlertProcessor.NotificationWindowFilter do
     Enum.map(subscription.relevant_days, &Map.get(days, &1))
   end
 
+  defp time_within_notification_window?(%Subscription{type: :accessibility}, _) do
+    # For subscriptions with type of `:accessibility` it doesn't matter what
+    # time of the day it is. The users these subscriptions belong to signed up
+    # to be notified of specific accessibility related alerts, so regardless of
+    # what time of the day it might be, these users should be notified.
+    true
+  end
+
   defp time_within_notification_window?(subscription, now) do
     start_time = notification_window_start_time(subscription)
     end_time = subscription.end_time


### PR DESCRIPTION
Why:

* Station feature alerts (accessibility alerts) weren't triggering
notifications. This is unwanted behavior. The culprit is the
`NotificationWindowFilter`. More specifically, the culprit is the
`time_within_notification_window?/2` function in this module.
* Asana link: https://app.asana.com/0/529741067494252/640514815408666

This change addresses the need by:

* Editing `NotificationWindowFilter.time_within_notification_window?/2`
to always return true for accessibility-type subscriptions. This is
because users that sign up for accessibility subscriptions want to be
notified of matching alerts regardless of the current time. In other
words, these type of subscriptions don't have a notification window.