### PR TITLE
Fix green line bug

### DIFF
--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -86,6 +86,14 @@ defmodule AlertProcessor.InformedEntityFilter do
     {subscription, informed_entity, updated_match_report}
   end
 
+  defp route_match?({%{route: "Green"} = subscription, informed_entity, match_report}) do
+    # The "Green" route is a special case. Subscriptions's for "Green" routes
+    # should match on all the Green branches.
+    route_match? = informed_entity.route in ["Green-B", "Green-C", "Green-D", "Green-E"]
+    updated_match_report = Map.put(match_report, :route_match?, route_match?)
+    {subscription, informed_entity, updated_match_report}
+  end
+
   defp route_match?({subscription, informed_entity, match_report}) do
     route_match? = subscription.route == informed_entity.route
     updated_match_report = Map.put(match_report, :route_match?, route_match?)

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -111,6 +111,27 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
+    test "returns true with 'Green-E' route match" do
+      subscription_details = [
+        route_type: 1,
+        direction_id: 0,
+        route: "Green",
+        origin: "some origin",
+        destination: "some destination",
+        facility_types: [],
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "Green-E",
+        stop: nil,
+        activities: nil
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns false with route mismatch" do
       subscription_details = [
         route_type: 1,


### PR DESCRIPTION
Why:

* The green line is a special case because it has "branching". This was
not taken into account when the `InformedEntityFilter` was recently
updated. This causes green line alerts to not trigger notifications.
* Asana link: https://app.asana.com/0/529741067494252/642541074624087

This change addresses the need by:

* Editing `InformedEntityFilter` to match 'Green'-route subscriptions
with all the green line branches.