### PR TITLE
Fix bug: future notification window start time

### DIFF
--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -35,7 +35,6 @@ defmodule AlertProcessor.Supervisor do
     children = [
       supervisor(Registry, [:unique, :mailer_process_registry]),
       supervisor(AlertProcessor.Repo, []),
-      supervisor(ConCache, [[ttl_check: :timer.minutes(10)], [name: :subscription_filter]]),
       worker(ServiceInfoCache, []),
       worker(AlertWorker, []),
       worker(AlertCache, []),

--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -32,7 +32,6 @@ defmodule AlertProcessor.Mixfile do
         :crypto,
         :calendar,
         :comeonin,
-        :con_cache,
         :sweet_xml, # Must come before ex_aws
         :exactor,
         :ex_aws,
@@ -62,7 +61,6 @@ defmodule AlertProcessor.Mixfile do
       {:bamboo_smtp, "~> 1.3.0", only: [:test]},
       {:calendar, "~> 0.17.2"},
       {:comeonin, "~> 3.0"},
-      {:con_cache, "~> 0.12.1"},
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.5.0", only: [:dev]},
       {:ecto, "~> 2.1.0"},

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -13,14 +13,6 @@ defmodule AlertProcessor.AlertParserTest do
     :ok
   end
 
-  setup do
-    :subscription_filter
-    |> ConCache.ets
-    |> :ets.tab2list
-    |> Enum.each(fn({key, _}) -> ConCache.delete(:subscription_filter, key) end)
-    :ok
-  end
-
   test "process_alerts/1" do
     user = insert(:user, phone_number: nil)
     :subscription

--- a/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -147,31 +147,5 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       assert {_, [{:ok, notifications}]} = SubscriptionFilterEngine.schedule_all_notifications([alert])
       assert length(notifications) == 1
     end
-
-    test "test skipping an unchanged alert, then sending when new subscriber is added", %{alert: alert} do
-      user = insert(:user, phone_number: nil)
-
-      :subscription
-      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
-      |> weekday_subscription
-      |> insert
-
-      assert {skipped, [{:ok, notifications}]} = SubscriptionFilterEngine.schedule_all_notifications([alert])
-      assert length(notifications) == 1
-      assert skipped == 0
-
-      assert {skipped, [{:ok, notifications}]} = SubscriptionFilterEngine.schedule_all_notifications([alert])
-      assert length(notifications) == 0
-      assert skipped == 1
-
-      :subscription
-      |> build(route_type: 1, user: user, alert_priority_type: :low, informed_entities: [%InformedEntity{route_type: 1, activities: InformedEntity.default_entity_activities()}])
-      |> weekday_subscription
-      |> insert
-
-      assert {skipped, [{:ok, notifications}]} = SubscriptionFilterEngine.schedule_all_notifications([alert])
-      assert length(notifications) == 1
-      assert skipped == 0
-    end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
+%{
+  "bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "bamboo_smtp": {:hex, :bamboo_smtp, "1.3.0", "1e3f162a352b44cc528827a1a3ab2feb0a34592cd76b49b2570abd33accbece3", [:mix], [{:bamboo, "~> 0.8.0", [hex: :bamboo, optional: false]}, {:gen_smtp, "~> 0.11.0", [hex: :gen_smtp, optional: false]}]},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bodyguard": {:hex, :bodyguard, "1.0.0", "611f636762dadd706f166438cf59d7334ed3dc173cc9db26bacd114d7c051abf", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
@@ -6,7 +7,6 @@
   "calendar": {:hex, :calendar, "0.17.4", "22c5e8d98a4db9494396e5727108dffb820ee0d18fed4b0aa8ab76e4f5bc32f1", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "comeonin": {:hex, :comeonin, "3.2.0", "cb10995a22aed6812667efb3856f548818c85d85394d8132bc116fbd6995c1ef", [:make, :mix], [{:elixir_make, "~> 0.4", [repo: "hexpm", hex: :elixir_make, optional: false]}], "hexpm"},
-  "con_cache": {:hex, :con_cache, "0.12.1", "7553dcd51ee86fd52bd9ea9aa4b33e71bebf0b5fc5ab60e63d2e0bcaa260f937", [:mix], [{:exactor, "~> 2.2.0", [hex: :exactor, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
@@ -60,4 +60,5 @@
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], []},
   "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"},
-  "wallaby": {:hex, :wallaby, "0.19.2", "358bbff251e3555e02566280d1795132da792969dd58ff89963536d013058719", [:mix], [{:httpoison, "~> 0.12", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"}}
+  "wallaby": {:hex, :wallaby, "0.19.2", "358bbff251e3555e02566280d1795132da792969dd58ff89963536d013058719", [:mix], [{:httpoison, "~> 0.12", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
Why:

* Notifications weren't being sent if a subscription was created with a
notification start time at some point in the future and an already
existing alert that should match that subscription.
* Asana link: https://app.asana.com/0/529741067494252/643543461079633

This change addresses the need by:

* Editing `SubscriptionFilterEngine` by removing
`get_and_set_last_subscription_timestampe/2` and
`subscriptions_new_to_alert/4`.
* Removing `:con_cache` deps as it's not being used anymore.