### PR TITLE
show route long or short name on commuter trip card

### DIFF
--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -73,7 +73,7 @@ defmodule ConciergeSite.TripCardHelper do
           icon(subscription.type, subscription.route)
         end,
         content_tag :span, class: "trip__card--route" do
-          subscription.route
+          route_name(subscription.route)
         end
       ]
     end)
@@ -159,7 +159,10 @@ defmodule ConciergeSite.TripCardHelper do
   defp route_name("Green"), do: "Green Line"
   defp route_name(route_id) do
     {:ok, route} = ServiceInfoCache.get_route(route_id)
-    route.long_name
+    case route.long_name do
+      "" -> route.short_name
+      _ -> route.long_name
+    end
   end
 
   @spec edit_faux_link() :: Phoenix.HTML.safe

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -179,7 +179,7 @@ defmodule ConciergeSite.V2.TripControllerTest do
       assert html_response(conn, 200) =~ "Success! If at any time you need to edit the features, "
       <> "stations, or lines you&#39;ve subscribed to, you can click in the box below."
 
-      assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">Red</span>"
+      assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">Red Line</span>"
       <> "<div class=\"trip__card--type\">Round-trip, Weekdays</div>"
       <> "<div class=\"trip__card--times\"> 8:00am -  9:00am /  5:00pm -  6:00pm</div>"
     end
@@ -210,7 +210,7 @@ defmodule ConciergeSite.V2.TripControllerTest do
 
       conn = get(conn, v2_trip_path(conn, :index))
 
-      assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">741</span>"
+      assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">Silver Line SL1</span>"
     end
   end
 

--- a/apps/concierge_site/test/web/views/trip_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_card_helper_test.exs
@@ -20,20 +20,22 @@ defmodule ConciergeSite.TripCardHelperTest do
         add_subscription_for_trip(trip, %{type: :subway, route: "Mattapan", origin: "place-asmnl", destination: "place-matt",
                                           direction_id: 0, rank: 5}),
         add_subscription_for_trip(trip, %{type: :bus, route: "57A", direction_id: 0, rank: 6}),
+        add_subscription_for_trip(trip, %{type: :bus, route: "741", direction_id: 0, rank: 6}),
         add_subscription_for_trip(trip, %{type: :cr, route: "CR-Haverhill", origin: "Melrose Highlands",
                                           destination: "place-north", direction_id: 1, rank: 7}),
         add_subscription_for_trip(trip, %{type: :ferry, route: "Boat-F4", origin: "Boat-Long",
                                           destination: "Boat-Charlestown", direction_id: 0, rank: 8})]}
 
       html = Phoenix.HTML.safe_to_string(TripCardHelper.render(conn, trip_with_subscriptions))
-      assert html =~ "Red"
-      assert html =~ "Orange"
-      assert html =~ "Green"
-      assert html =~ "Blue"
-      assert html =~ "Mattapan"
+      assert html =~ "Red Line"
+      assert html =~ "Orange Line"
+      assert html =~ "Green Line"
+      assert html =~ "Blue Line"
+      assert html =~ "Mattapan Trolley"
       assert html =~ "57A"
-      assert html =~ "CR-Haverhill"
-      assert html =~ "Boat-F4"
+      assert html =~ "Silver Line SL1"
+      assert html =~ "Haverhill Line"
+      assert html =~ "Charlestown Ferry"
       assert html =~ "One-way"
       refute html =~ "Round-trip"
       assert html =~ "Mondays"


### PR DESCRIPTION
[Bug:  CT, SL (bus) & commuter rail/ferry names rendering incorrectly](https://app.asana.com/0/529741067494252/633728876475615/f)

![screen shot 2018-04-24 at 5 28 54 pm](https://user-images.githubusercontent.com/988609/39215655-a52bb9ee-47e6-11e8-8a17-91341185210e.png)
