### PR TITLE
Fix bug: all clear notifications

### DIFF
--- a/apps/alert_processor/lib/rules_engine/active_period_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/active_period_filter.ex
@@ -16,6 +16,8 @@ defmodule AlertProcessor.ActivePeriodFilter do
     do_filter(subscriptions, alert)
   end
 
+  defp do_filter(_, %Alert{active_period: nil}), do: []
+
   defp do_filter(subscriptions, alert) do
     active_period_timeframe_maps = Alert.timeframe_maps(alert)
 

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -259,22 +259,6 @@ defmodule AlertProcessor.AlertParserTest do
     test "do not remove alert when last_push_notification_timestamp and active_period are set" do
       assert length(AlertParser.remove_ignored([@valid_alert])) == 1
     end
-
-    test "remove alert when active_period is not available"  do
-      assert AlertParser.remove_ignored([Map.delete(@valid_alert, "active_period")]) == []
-    end
-
-    test "remove alert when active_period is nil" do
-      assert AlertParser.remove_ignored([%{@valid_alert | "active_period" => nil}]) == []
-    end
-
-    test "remove alert when active_period is an empty string" do
-      assert AlertParser.remove_ignored([%{@valid_alert | "active_period" => ""}]) == []
-    end
-
-    test "remove alert when active_period is an empty list" do
-      assert AlertParser.remove_ignored([%{@valid_alert | "active_period" => []}]) == []
-    end
   end
 
   describe "parse_translation/1" do
@@ -308,6 +292,25 @@ defmodule AlertProcessor.AlertParserTest do
         ]
       }
       assert AlertParser.parse_translation(translation) == text
+    end
+  end
+
+  describe "parse_alert/1" do
+    test "with alert with no active_period" do
+      some_timestamp = 1524609934
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      refute parsed_alert.active_period
     end
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/active_period_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/active_period_filter_test.exs
@@ -156,4 +156,13 @@ defmodule AlertProcessor.ActivePeriodFilterTest do
         ActivePeriodFilter.filter([weekday_subscription, saturday_subscription, sunday_subscription], alert: alert7)
     end
   end
+
+  describe "with alert with nil 'active_period'" do
+    test "does not match" do
+      alert = %Alert{active_period: nil}
+      subscription = :subscription |> build() |> weekday_subscription()
+
+      assert [] == ActivePeriodFilter.filter([subscription], alert: alert)
+    end
+  end
 end

--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -481,6 +481,13 @@ defmodule ConciergeSite.Integration.Matching do
       [new_notification] = determine_recipients(alert, [@subscription], [notification])
       refute notification == new_notification
     end
+
+    test "matches: notification already sent but it has a closed_timestamp" do
+      alert = alert(informed_entity: [entity(:subway)])
+      notification = notification(:all_clear, alert, [@subscription])
+
+      assert_notify alert, @subscription, [notification]
+    end
   end
 
   describe "estimated duration" do

--- a/apps/concierge_site/test/support/notification_factory.ex
+++ b/apps/concierge_site/test/support/notification_factory.ex
@@ -26,6 +26,16 @@ defmodule ConciergeSite.NotificationFactory do
     }
   end
 
+  def notification(:all_clear, alert, subscriptions) do
+    %Notification{
+      alert_id: alert.id,
+      status: :sent,
+      last_push_notification: alert.last_push_notification,
+      subscriptions: subscriptions,
+      closed_timestamp: Calendar.DateTime.add!(alert.last_push_notification, 1800)
+    }
+  end
+
   defp earlier_push_notification(%Alert{last_push_notification: datetime}) do
     timestamp = DateTime.to_unix(datetime)
 


### PR DESCRIPTION
Why:

* All clear notifications are not being sent out. This commit fixes
this.
* Asana link: https://app.asana.com/0/529741067494252/640392812479507

This change addresses the need by:

* Editing `AlertParser` to not ignore/remove alerts without an
`active_period` because "all clear" notifications do not have
active_periods.
* Editing the `ActivePeriodFilter` to remove alerts without an
active_period. Before this change, the `ActivePeriodFilter` expected all
alerts that go through it to have an `active_period`
* Note: `SentAlertFilter` determines which subscriptions should receive
an "all clear" notification for a given alert.