### PR TITLE
Fix bug: accessibility subscription without stops

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -197,7 +197,7 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
-    test "returns false with stop mismatch (bus subscription and BOARD activity)" do
+   test "returns false with stop mismatch (bus subscription and BOARD activity)" do
       # Bus subscriptions don't have an origin and destination
       subscription_details = [
         route_type: 3,
@@ -632,6 +632,31 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       ]
       informed_entity = build(:informed_entity, informed_entity_details)
       refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns true for accessibility subscription route-stop match" do
+      # With an "accessibility" type subscription with no origin or destination
+      # we want to infer the stops from the route. In the scenario below the
+      # "Harvard" stop is on the "Red" line so we have a match.
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "Red",
+        origin:  nil,
+        destination: nil,
+        facility_types: [:elevator],
+        type: "accessibility"
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: 1,
+        direction_id: nil,
+        route: nil,
+        stop: "Harvard",
+        activities: ["USING_WHEELCHAIR"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
   end
 end


### PR DESCRIPTION
Why:

* Notifications are not being sent for accessibility subscriptions
(station feature subscriptions) with no stops (origin and destination)
and only a route.
* Asana link: https://app.asana.com/0/529741067494252/646017407575848

This change addresses the need by:

* Editing `InformedEntityFilter.stop_match?/3` to infer the stops for a
given subscription's route when a subscription is of type
"accessibility" and it's origin and destination is nil.