### PR TITLE
Fix bug: station feature subscription delays

### DIFF
--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -157,18 +157,14 @@ defmodule AlertProcessor.InformedEntityFilter do
   end
 
   defp stop_related_activities(subscription, informed_entity) do
-    case {subscription.origin, subscription.destination, informed_entity.stop} do
-      {nil, nil, nil} ->
-        ["BOARD", "EXIT"]
-      {origin, destination, stop} when origin == stop and destination == stop ->
-        # When origin equals destination and the informed_entity's stop we have
-        # what we refer to as a "stop subscription". For a stop subscription we
-        # return an empty list. That's because in this case the user doesn't
-        # care about "BOARD" or "EXIT" activities.
+    case {subscription.type, subscription.origin, subscription.destination, informed_entity.stop} do
+      {"accessibility", _, _, _} ->
         []
-      {origin, _, stop} when origin == stop ->
+      {_, nil, nil, nil} ->
+        ["BOARD", "EXIT"]
+      {_, origin, _, stop} when origin == stop ->
         ["BOARD"]
-      {_, destination, stop} when destination == stop ->
+      {_, _, destination, stop} when destination == stop ->
         ["EXIT"]
       _ ->
         ["BOARD", "EXIT"]

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -475,6 +475,52 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
+    test "returns false with activities mismatch (accessibility subscription and BOARD) " do
+      # Accessibility subscription should not match for BOARD activities.
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "some route",
+        origin:  nil,
+        destination: nil,
+        facility_types: [:elevator],
+        type: "accessibility"
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "some route",
+        stop: nil,
+        activities: ["BOARD"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns false with activities mismatch (accessibility subscription and EXIT) " do
+      # Accessibility subscription should not match for BOARD activities.
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "some route",
+        origin: nil,
+        destination: nil,
+        facility_types: [:elevator],
+        type: "accessibility"
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: "some route",
+        stop: nil,
+        activities: ["EXIT"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns true with a 'stop subscription' (activities match)" do
       # A "stop subscription" has these characteristics:
       #   * route_type, direction_id, and route are set to nil
@@ -545,6 +591,7 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         origin: stop,
         destination: stop,
         facility_types: [:bike_storage],
+        type: "accessibility"
       ]
       subscription = build(:subscription, subscription_details)
       informed_entity_details = [


### PR DESCRIPTION
Why:

* Station feature subscriptions (accessibility subscriptions) are
currently triggering notifications for "BOARD" and "EXIT"
alert-activities. This is unwanted behavior.
* Asana link: https://app.asana.com/0/529741067494252/651201986663908

This change addresses the need by:

* Editing `InformedEntityFilter.stop_related_activities/2` to return an
empty list for accessibility type subscriptions. This makes it so that
"accessibility" subscriptions only match for the user defined activities
(station feature) and no other activities.