### PR TITLE
Edit green line branches display names

### DIFF
--- a/apps/concierge_site/lib/views/route_select_helper.ex
+++ b/apps/concierge_site/lib/views/route_select_helper.ex
@@ -58,10 +58,10 @@ defmodule ConciergeSite.RouteSelectHelper do
   defp get_routes(:subway) do
     [{:red, "Red", "Red Line"},
      {:orange, "Orange", "Orange Line"},
-     {:"green-b", "Green-B", "Green Line B Branch"},
-     {:"green-c", "Green-C", "Green Line C Branch"},
-     {:"green-d", "Green-D", "Green Line D Branch"},
-     {:"green-e", "Green-E", "Green Line E Branch"},
+     {:"green-b", "Green-B", "Green Line B"},
+     {:"green-c", "Green-C", "Green Line C"},
+     {:"green-d", "Green-D", "Green Line D"},
+     {:"green-e", "Green-E", "Green Line E"},
      {:blue, "Blue", "Blue Line"},
      {:mattapan, "Mattapan", "Mattapan Trolley"}]
   end

--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -156,10 +156,10 @@ defmodule ConciergeSite.TripCardHelper do
   end
 
   @spec route_name(String.t) :: String.t
-  defp route_name("Green-B"), do: "Green Line B Branch"
-  defp route_name("Green-C"), do: "Green Line C Branch"
-  defp route_name("Green-D"), do: "Green Line D Branch"
-  defp route_name("Green-E"), do: "Green Line E Branch"
+  defp route_name("Green-B"), do: "Green Line B"
+  defp route_name("Green-C"), do: "Green Line C"
+  defp route_name("Green-D"), do: "Green Line D"
+  defp route_name("Green-E"), do: "Green Line E"
   defp route_name(route_id) do
     {:ok, route} = ServiceInfoCache.get_route(route_id)
     case route.long_name do


### PR DESCRIPTION
Why:

* We want green line branches to render as "Green Line B" and not "Green
Line B Branch".
* Asana link: https://app.asana.com/0/529741067494252/650983734352359

This change addresses the need by:

* Edits `RouteSelectHelper` and `TripCardHelper` to render green line
branch names as described above.