### PR TITLE
Fix inaccurate matching test

### DIFF
--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -112,10 +112,10 @@ defmodule ConciergeSite.Integration.Matching do
         "route_type" => 1,
         "direction_id" => 1,
         "route" => "Red",
-        "stop" => "place-cntsq",
+        "stop_id" => "place-cntsq",
         "activities" => ["BOARD"]
       }
-      assert_notify alert(informed_entity: [informed_entity_details]), @subscription_roaming
+      refute_notify alert(informed_entity: [informed_entity_details]), @subscription_roaming
     end
   end
 


### PR DESCRIPTION
Why:

* For clarity, this commit fixes a test that currently implies the
application supports matching for stops in between a subscription's
origin and destination.
* Asana link: n/a