### PR TITLE
Adds support for in-between stop matching

### DIFF
--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -119,7 +119,10 @@ defmodule AlertProcessor.InformedEntityFilter do
     origin = subscription.origin
     destination = subscription.destination
     stop = informed_entity.stop
-    stop_match? = origin == stop || destination == stop
+    stop_match? =
+      origin == stop
+      || destination == stop
+      || in_between_stop_match?(subscription, informed_entity)
     updated_match_report = Map.put(match_report, :stop_match?, stop_match?)
     {subscription, informed_entity, updated_match_report}
   end
@@ -130,8 +133,61 @@ defmodule AlertProcessor.InformedEntityFilter do
         Enum.any?(stop_list, fn {_, route_stop_id, _, _} ->
           route_stop_id == stop
         end)
-      _ -> false
+      _ ->
+        false
     end
+  end
+
+  defp in_between_stop_match?(%{type: "accessibility"}, _), do: false
+
+  defp in_between_stop_match?(_, %{activities: nil}), do: false
+
+  defp in_between_stop_match?(subscription, %{activities: activities, stop: stop}) do
+    if "RIDE" in activities do
+      stop in stops_in_between(subscription)
+    else
+      false
+    end
+  end
+
+  defp stops_in_between(%{route: route, origin: origin, destination: destination}) do
+    case ServiceInfoCache.get_route(route) do
+      {:ok, %{stop_list: stop_list}} ->
+        stops_in_between_from_stop_list(stop_list, origin, destination)
+      _ ->
+        []
+    end
+  end
+
+  defp stops_in_between_from_stop_list([], _, _), do: []
+
+  defp stops_in_between_from_stop_list(stop_list, origin, destination) do
+    with {:ok, slice_range} <- slice_range(stop_list, origin, destination) do
+      stop_list
+      |> Enum.slice(slice_range)
+      |> Enum.map(fn {_, route_stop_id, _, _} -> route_stop_id end)
+    else
+      _ -> []
+    end
+  end
+
+  defp slice_range(stop_list, origin, destination) do
+    origin_index = stop_list_index(stop_list, origin)
+    destination_index = stop_list_index(stop_list, destination)
+    case {origin_index, destination_index} do
+      {origin, destination} when is_nil(origin) or is_nil(destination)->
+        :error
+      {origin, destination} when origin < destination ->
+        {:ok, origin_index..destination_index}
+      _ ->
+        {:ok, destination_index..origin_index}
+    end
+  end
+
+  defp stop_list_index(stop_list, stop) do
+    Enum.find_index(stop_list, fn {_, route_stop_id, _, _} ->
+      route_stop_id == stop
+    end)
   end
 
   defp activities_match?({subscription, informed_entity, match_report}) do
@@ -161,13 +217,13 @@ defmodule AlertProcessor.InformedEntityFilter do
       {:accessibility, _, _, _} ->
         []
       {_, nil, nil, nil} ->
-        ["BOARD", "EXIT"]
+        ["BOARD", "EXIT", "RIDE"]
       {_, origin, _, stop} when origin == stop ->
-        ["BOARD"]
+        ["BOARD", "RIDE"]
       {_, _, destination, stop} when destination == stop ->
-        ["EXIT"]
+        ["EXIT", "RIDE"]
       _ ->
-        ["BOARD", "EXIT"]
+        ["BOARD", "EXIT", "RIDE"]
     end
   end
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -176,6 +176,74 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
+    test "returns true with stop match (with stop in between origin and destination)" do
+      # As you can see here:
+      # https://cdn.mbta.com/sites/default/files/maps/2018-04-map-rapid-transit-key-bus-v31a.pdf,
+      # "Davis" (place-davis) is in between "Alewife" (place-alfcl) and "Porter" (place-portr).
+      subscription_details_1 = [
+        route_type: 1,
+        direction_id: 0,
+        route: "Red",
+        origin: "place-alfcl",
+        destination: "place-portr",
+        facility_types: [],
+      ]
+      subscription_1 = build(:subscription, subscription_details_1)
+      informed_entity_details_1 = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: "place-davis",
+        activities: ["RIDE"]
+      ]
+      informed_entity_1 = build(:informed_entity, informed_entity_details_1)
+      assert InformedEntityFilter.subscription_match?(subscription_1, informed_entity_1)
+
+      # The scenario below is the return trip for the scenario above (opposite origin/destination).
+      subscription_details_2 = [
+        route_type: 1,
+        direction_id: 1,
+        route: "Red",
+        origin: "place-portr",
+        destination: "place-alfcl",
+        facility_types: [],
+      ]
+      subscription_2 = build(:subscription, subscription_details_2)
+      informed_entity_details_2 = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: "place-davis",
+        activities: ["RIDE"]
+      ]
+      informed_entity_2 = build(:informed_entity, informed_entity_details_2)
+      assert InformedEntityFilter.subscription_match?(subscription_2, informed_entity_2)
+    end
+
+    test "returns false with stop match (with stop in between origin and destination but wrong activity)" do
+      # As you can see here:
+      # https://cdn.mbta.com/sites/default/files/maps/2018-04-map-rapid-transit-key-bus-v31a.pdf,
+      # "Davis" (place-davis) is in between "Alewife" (place-alfcl) and "Porter" (place-portr).
+      subscription_details = [
+        route_type: 1,
+        direction_id: 0,
+        route: "Red",
+        origin: "Alewife",
+        destination: "Porter",
+        facility_types: [],
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: "Davis",
+        activities: ["BOARD"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns false with stop mismatch" do
       subscription_details = [
         route_type: 1,
@@ -241,6 +309,31 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
+    test "returns false with stop mismatch (with stop not in between origin and destination)" do
+      # As you can see here:
+      # https://cdn.mbta.com/sites/default/files/maps/2018-04-map-rapid-transit-key-bus-v31a.pdf,
+      # "Harvard" (place-harsq) is not in between "Alewife" (place-alfcl) and
+      # "Porter" (place-portr).
+      subscription_details = [
+        route_type: 1,
+        direction_id: 0,
+        route: "Red",
+        origin: "place-alfcl",
+        destination: "place-portr",
+        facility_types: [],
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: "place-harsq",
+        activities: ["RIDE"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns true with activities match (BOARD)" do
       # An "activities BOARD match" happens when the alert's informed_entity
       # activities includes "BOARD" and it's stop equals the subscription's
@@ -286,6 +379,32 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         route: nil,
         stop: nil,
         activities: ["BOARD"]
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns true with activities match (RIDE)" do
+      # An "activities RIDE match" happens when the alert's informed_entity
+      # activities includes "RIDE" and it's stop equals the subscription's
+      # origin or destination value. It can also happen if the
+      # informed_entity's stop is nil.
+      stop = "some stop"
+      subscription_details = [
+        route_type: 1,
+        direction_id: 0,
+        route: "some route",
+        origin: stop,
+        destination: "some destination",
+        facility_types: [],
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: stop,
+        activities: ["RIDE"]
       ]
       informed_entity = build(:informed_entity, informed_entity_details)
       assert InformedEntityFilter.subscription_match?(subscription, informed_entity)


### PR DESCRIPTION
Why:

* We want users to receive notifications for alerts that come in for
"RIDE" activities on stops in between a subscription's origin and
destination.
* Asana link: https://app.asana.com/0/529741067494252/649264235596202

This change addresses the need by:

* Editing `InformedEntityFilter.stop_match?` to return true for stops in
between a subscription's origin and destination if the alert include
"RIDE" in it's activities.