### PR TITLE
Fix bug: route-only subscriptions infer stops

### DIFF
--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -109,7 +109,7 @@ defmodule AlertProcessor.InformedEntityFilter do
     {subscription, informed_entity, updated_match_report}
   end
 
-  defp stop_match?({%{type: "accessibility", origin: nil} = subscription, informed_entity, match_report}) do
+  defp stop_match?({%{type: :accessibility, origin: nil} = subscription, informed_entity, match_report}) do
     stop_match? = route_stop_match?(subscription.route, informed_entity.stop)
     updated_match_report = Map.put(match_report, :stop_match?, stop_match?)
     {subscription, informed_entity, updated_match_report}
@@ -127,8 +127,8 @@ defmodule AlertProcessor.InformedEntityFilter do
   defp route_stop_match?(route, stop) do
     case ServiceInfoCache.get_route(route) do
       {:ok, %{stop_list: stop_list}} ->
-        Enum.any?(stop_list, fn {route_stop, _, _, _} ->
-          route_stop == stop
+        Enum.any?(stop_list, fn {_, route_stop_id, _, _} ->
+          route_stop_id == stop
         end)
       _ -> false
     end
@@ -158,7 +158,7 @@ defmodule AlertProcessor.InformedEntityFilter do
 
   defp stop_related_activities(subscription, informed_entity) do
     case {subscription.type, subscription.origin, subscription.destination, informed_entity.stop} do
-      {"accessibility", _, _, _} ->
+      {:accessibility, _, _, _} ->
         []
       {_, nil, nil, nil} ->
         ["BOARD", "EXIT"]

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -484,7 +484,7 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         origin:  nil,
         destination: nil,
         facility_types: [:elevator],
-        type: "accessibility"
+        type: :accessibility
       ]
       subscription = build(:subscription, subscription_details)
       informed_entity_details = [
@@ -507,7 +507,7 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         origin: nil,
         destination: nil,
         facility_types: [:elevator],
-        type: "accessibility"
+        type: :accessibility
       ]
       subscription = build(:subscription, subscription_details)
       informed_entity_details = [
@@ -591,7 +591,7 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         origin: stop,
         destination: stop,
         facility_types: [:bike_storage],
-        type: "accessibility"
+        type: :accessibility
       ]
       subscription = build(:subscription, subscription_details)
       informed_entity_details = [
@@ -692,14 +692,14 @@ defmodule AlertProcessor.InformedEntityFilterTest do
         origin:  nil,
         destination: nil,
         facility_types: [:elevator],
-        type: "accessibility"
+        type: :accessibility
       ]
       subscription = build(:subscription, subscription_details)
       informed_entity_details = [
         route_type: 1,
         direction_id: nil,
         route: nil,
-        stop: "Harvard",
+        stop: "place-harsq",
         activities: ["USING_WHEELCHAIR"]
       ]
       informed_entity = build(:informed_entity, informed_entity_details)


### PR DESCRIPTION
Why:

* For route-only subscriptions to trigger notifications for alerts with
no route specified. This commit fixes this by making sure that stop
inferring, based on a route, uses stop id's and not the stop display
names. Also, it edits `InformedEntityFilter` to expect subscription
types to come back as atoms and not strings from the DB.
* Asana link: https://app.asana.com/0/529741067494252/646017407575848