### PR TITLE
condense green line on trip card

### DIFF
--- a/apps/concierge_site/assets/css/v2/_trip-card.scss
+++ b/apps/concierge_site/assets/css/v2/_trip-card.scss
@@ -1,7 +1,7 @@
 .trip__card {
   display: block;
   line-height: 1.5rem;
-  padding: .75rem;
+  padding: 0.75rem;
   border-color: $steel;
   color: $black !important;
   text-align: left;
@@ -24,23 +24,17 @@
   display: inline-block;
   font-size: 16px;
   font-weight: bold;
-  padding: 0 .5rem;
+  padding: 0 0.5rem;
 }
 
 .trip__card--route-icon {
-  position: relative;
   display: inline-block;
-  width: 20px;
-  height: 20px;
   margin-right: 4px;
   transform: translate(0px, 4px);
-
-  svg {
-    position: absolute;
-  }
 }
 
-.trip__card--type, .trip__card--times {
+.trip__card--type,
+.trip__card--times {
   font-size: 1rem;
   overflow-x: hidden;
   text-overflow: ellipsis;

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -248,9 +248,10 @@ defmodule ConciergeSite.V2.TripControllerTest do
 
       assert html_response(conn, 200) =~ "Success! Your subscription has been created."
 
-      assert html_response(conn, 200) =~ "Green Line C"
-      assert html_response(conn, 200) =~ "Green Line D"
-      assert html_response(conn, 200) =~ "Green Line E"
+      assert html_response(conn, 200) =~ "Green Line"
+      refute html_response(conn, 200) =~ "Green Line D"
+      refute html_response(conn, 200) =~ "Green Line D"
+      refute html_response(conn, 200) =~ "Green Line E"
     end
 
     test "green line single-route", %{conn: conn, user: user} do


### PR DESCRIPTION
[Feature:  New green line branching implementation](https://app.asana.com/0/529741067494252/654748331097264/f)

Change trip card to collapse identical Green line subscriptions, but show multiple icons.

![screen shot 2018-05-02 at 12 02 25 pm](https://user-images.githubusercontent.com/988609/39535232-65cbde52-4e01-11e8-8ac7-c975db6747fb.png)

Note: there are some changes in the controller logic to fix a bug in the previous PR that I only noticed when some of the card tests were not passing.