### PR TITLE
Gets rid of AlertWorker errors in test env

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_worker.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_worker.ex
@@ -30,6 +30,10 @@ defmodule AlertProcessor.AlertWorker do
     {:noreply, nil}
   end
 
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
   defp schedule_work do
     Process.send_after(self(), :work, filter_interval())
   end


### PR DESCRIPTION
Why:

* This commit fixes this by adding a `handle_info/2` catch-all.
* Asana link: https://app.asana.com/0/529741067494252/657960216353632

--------------------------------------------------------------------------------

The errors in question:

![screen shot 2018-05-02 at 3 08 18 pm](https://user-images.githubusercontent.com/1958868/39544071-f7373008-4e1a-11e8-97eb-4519e37ec04b.png)
