### PR TITLE
Fix intermittent NotificationWorkerTest failure

### DIFF
--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -22,6 +22,10 @@ config :alert_processor, database_url: {:system, "DATABASE_URL_TEST"}
 
 config :alert_processor, :notification_window_filter, AlertProcessor.NotificationWindowFilterMock
 
+config :alert_processor,
+  pool_size: 0,
+  overflow: 0
+
 config :exvcr, [
   vcr_cassette_library_dir: "test/fixture/vcr_cassettes",
   custom_cassette_library_dir: "test/fixture/custom_cassettes",

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
@@ -61,12 +61,10 @@ defmodule AlertProcessor.NotificationWorkerTest do
     user = insert :user
     notification = Map.put(notification, :user, user)
 
-    SendingQueue.start_link()
-    {:ok, pid} = NotificationWorker.start_link([name: :notification_worker_test_1])
+    {:ok, pid} = start_supervised(NotificationWorker)
     :erlang.trace(pid, true, [:receive])
 
     SendingQueue.enqueue(notification)
-    :timer.sleep(101)
 
     assert_receive {:trace, ^pid, :receive, {:sent_notification_email, _}}
     assert_number_of_notifications_persisted_for_user(1, user)
@@ -85,8 +83,7 @@ defmodule AlertProcessor.NotificationWorkerTest do
 
     RateLimiter.check_rate_limit(user.id)
 
-    SendingQueue.start_link()
-    {:ok, pid} = NotificationWorker.start_link([name: :notification_worker_test_2])
+    {:ok, pid} = start_supervised(NotificationWorker)
     :erlang.trace(pid, true, [:receive])
 
     a = fn ->
@@ -104,12 +101,10 @@ defmodule AlertProcessor.NotificationWorkerTest do
     notification = Map.put(notification, :user, user)
     notification = Map.put(notification, :service_effect, nil)
 
-    SendingQueue.start_link()
-    {:ok, pid} = NotificationWorker.start_link([name: :notification_worker_test_3])
+    {:ok, pid} = start_supervised(NotificationWorker)
     :erlang.trace(pid, true, [:receive])
 
     SendingQueue.enqueue(notification)
-    :timer.sleep(101)
 
     refute_receive {:trace, ^pid, :receive, {:sent_notification_email, _}}
     assert_number_of_notifications_persisted_for_user(0, user)


### PR DESCRIPTION
Why:

* There is a test in `NotificationWorkerTest` that fails intermittently
and is causing us to manually rebuild on CI. The root of the problem is
a race condition between the two `NotificationWorker` processes started
in `AlertProcessor.Supervisor`'s `init/1` and the `NotificationWorker`
started in the test. These three processes are constantly attempting to
pop off of the `SendingQueue`. In the test we attempt to assert that a
specific `NotificationWorker` process, out of the three that are running
at that point, gets the notification enqueued in the test and processes
it. When this doesn't happen, the test fails.
* Asana link: https://app.asana.com/0/529741067494252/569662205566961

This change addresses the need by:

* Editing the apps/alert_processor/config/test.exs to start 0
NotificationWorker processes in test env. These are not needed when in
test env. This gets rid of the race condition because we no longer have
these two processes trying to process `SendingQueue` elements.
* Editing `NotificationWorkerTest` tests to not start the `SendingQueue`
because it's already started by `AlertProcessor.Supervisor`.
* Editing `NotificatioWorkerTest` to use `start_supervised/1` to start
the `NotificationWorker` process required for each of the tests in that
file. `start_supervised/1` starts a child process under the test
supervisor. This child process, `NotificationWorker` in this scenario,
is guaranteed to exit before the next test starts.
* Editing `NotificationWorkerTest` by removing the `:timer.sleep/1`
calls that are not needed.