### PR TITLE
Remove excessive API calls

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -4,7 +4,7 @@ defmodule AlertProcessor.AlertParser do
   relevant information to subscription filter engine.
   """
   require Logger
-  alias AlertProcessor.{AlertCache, AlertsClient, ApiClient,
+  alias AlertProcessor.{AlertCache, AlertsClient,
     Helpers.StringHelper, Parser, ServiceInfoCache,
     SubscriptionFilterEngine, Helpers.DateTimeHelper}
   alias AlertProcessor.Model.{Alert, InformedEntity, Notification, SavedAlert}
@@ -196,15 +196,6 @@ defmodule AlertProcessor.AlertParser do
     |> Enum.map(&(&1.route_id))
   end
 
-  defp parse_trip(%{"trip_id" => trip_id}, %{"route_type" => 2}) do
-    with {:ok, schedule} <- ApiClient.schedule_for_trip(trip_id),
-    {:ok, trip_name} <- ServiceInfoCache.get_trip_name(trip_id),
-    parsed_schedule <- parse_schedule(schedule) do
-       %{trip: trip_name, schedule: parsed_schedule}
-    else
-     _ -> %{}
-   end
-  end
   defp parse_trip(%{"trip_id" => trip_id}, %{"route_type" => 4}) do
     case ServiceInfoCache.get_generalized_trip_id(trip_id) do
       {:ok, trip_name} -> %{trip: trip_name}
@@ -216,18 +207,6 @@ defmodule AlertProcessor.AlertParser do
       {:ok, trip_name} -> %{trip: trip_name}
       _ -> %{}
     end
-  end
-
-  defp parse_schedule(schedule) do
-    Enum.map(schedule, &parse_schedule_stop/1)
-  end
-
-  defp parse_schedule_stop(stop) do
-    %{
-      departure_time: stop["attributes"]["departure_time"],
-      stop_id: stop["relationships"]["stop"]["data"]["id"],
-      trip_id: stop["relationships"]["trip"]["data"]["id"]
-    }
   end
 
   defp parse_stop(stop_id) do

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -90,27 +90,6 @@ defmodule AlertProcessor.AlertParserTest do
     end
   end
 
-  test "adds schedule data to trip alerts" do
-    use_cassette "trip_alerts", custom: true, clear_mock: true, match_requests_on: [:query] do
-      AlertParser.process_alerts()
-
-      result =
-        AlertCache.get_alerts()
-        |> Enum.flat_map(& &1.informed_entities)
-        |> Enum.map(& &1.schedule)
-        |> Enum.reject(& is_nil(&1))
-
-      [schedule | _] = List.first(result)
-
-      assert length(result) > 0
-      assert %{
-        departure_time: "2017-10-26T08:52:00-04:00",
-        stop_id: "Newburyport",
-        trip_id: "CR-Saturday-Fall-17-1150",
-      } = schedule
-    end
-  end
-
   test "correctly parses bus stop alert to match bus route subscription" do
     user = insert(:user)
     subscription_details = [


### PR DESCRIPTION
Why:

* Recently, Paul Swartz reported that the alerts concierge API key was
using the MBTA API almost as much as the website. After looking into it
a bit an API usage report for the alerts concierge key shows that 99.3%
(724,193) of the API calls in the last 24 hours were made to the
`/schedules` endpoint. This commit attempts to reduce the amount of API
calls to the `/schedules` endpoint.
* Asana link: https://app.asana.com/0/529741067494252/637596559275142

This change addresses the need by:

* Editing the `AlertParser` to not make calls to the `/schedules`
endpoint for every single alert informed_entity of route_type 2. The
`AlertParser` was hitting the `/schedules` endpoint to add the trip's
"schedule" to commuter rail alerts. This is not necessary because these
schedule values are not being used in any way. Maybe they were used in
the past and once the application stopped relying on those values the
`AlertParser` was not updated?