### PR TITLE
red line enforce same shape

### DIFF
--- a/apps/concierge_site/lib/views/stop_select_helper.ex
+++ b/apps/concierge_site/lib/views/stop_select_helper.ex
@@ -1,6 +1,6 @@
 defmodule ConciergeSite.StopSelectHelper do
 
-  @type stop_row :: [id: String.t, name: String.t, modes: MapSet.t, accessible: boolean]
+  @type stop_row :: [id: String.t, name: String.t, modes: MapSet.t, accessible: boolean, shapes: MapSet.t]
 
   alias AlertProcessor.ServiceInfoCache
   import Phoenix.HTML.Tag, only: [content_tag: 3]
@@ -21,9 +21,9 @@ defmodule ConciergeSite.StopSelectHelper do
   end
 
   @spec render_option(stop_row, [String.t]) :: Phoenix.HTML.safe
-  defp render_option([id: id, name: name, modes: modes, accessible: _accessible], selected) do
+  defp render_option([id: id, name: name, modes: modes, accessible: _accessible, shapes: shapes], selected) do
     selected = if Enum.member?(selected, id), do: [selected: "selected"], else: []
-    attributes = [value: id, data: option_data(modes)] ++ selected
+    attributes = [value: id, data: option_data(modes) ++ option_data(shapes)] ++ selected
     content_tag :option, attributes do
       name
     end
@@ -46,20 +46,42 @@ defmodule ConciergeSite.StopSelectHelper do
     |> Enum.uniq_by(& &1)
   end
   defp get_stops_by_route(route_id) do
-    {:ok, stops_with_icons} = ServiceInfoCache.get_stops_with_icons()
-    route_stops = route_id
-    |> get_stop_list()
-    |> Enum.sort_by(fn({name, _, _, _}) -> name end)
+    with {:ok, stops_with_icons} = ServiceInfoCache.get_stops_with_icons(),
+         {:ok, subway_lines} = ServiceInfoCache.get_subway_info do
+      red_line_shapes = get_redline_shapes(route_id, subway_lines)
+      route_stops = route_id
+      |> get_stop_list(subway_lines)
+      |> Enum.sort_by(fn({name, _, _, _}) -> name end)
 
-    for {name, id, _, _} <- route_stops do
-      stops_with_icons[id]
-      |> Keyword.put(:name, name)
-      |> Keyword.put(:id, id)
+      for {name, id, _, _} <- route_stops do
+        stops_with_icons[id]
+        |> Keyword.put(:name, name)
+        |> Keyword.put(:id, id)
+        |> add_redline_shapes(route_id, id, red_line_shapes)
+      end
     end
   end
 
-  @spec get_stop_list(String.t) :: [tuple]
-  defp get_stop_list("Green") do
+  defp add_redline_shapes(stop, "Red", stop_id, shapes), do: stop ++ [shapes: MapSet.new(shapes[stop_id])]
+  defp add_redline_shapes(stop, _, _, _), do: stop ++ [shapes: MapSet.new()]
+
+  defp get_redline_shapes("Red", subway_lines) do
+    [shape_1, shape_2] = subway_lines
+    |> Enum.filter(fn(%{stop_list: [{_, first_stop_id, _, _} | _], route_id: route_id}) ->
+      route_id == "Red" && (first_stop_id == "place-asmnl" || first_stop_id == "place-brntn")
+    end)
+    |> Enum.map(fn(%{stop_list: [{_, first_stop_id, _, _} | _] = stops}) ->
+      shape = if first_stop_id == "place-asmnl", do: [:red_1], else: [:red_2]
+      Enum.reduce(stops, %{}, fn ({_, stop_id, _, _}, acc) -> Map.put(acc, stop_id, shape) end)
+    end)
+    Map.merge(shape_1, shape_2, fn(_key, shape1, shape2) ->
+      shape1 ++ shape2
+    end)
+  end
+  defp get_redline_shapes(_, _), do: %{}
+
+  @spec get_stop_list(String.t, list) :: [tuple]
+  defp get_stop_list("Green", _) do
     with {:ok, %{stop_list: b_stops}} = ServiceInfoCache.get_route("Green-B"),
          {:ok, %{stop_list: c_stops}} = ServiceInfoCache.get_route("Green-C"),
          {:ok, %{stop_list: d_stops}} = ServiceInfoCache.get_route("Green-D"),
@@ -67,16 +89,14 @@ defmodule ConciergeSite.StopSelectHelper do
       Enum.uniq_by(b_stops ++ c_stops ++ d_stops ++ e_stops, & &1)
     end
   end
-  defp get_stop_list("Red") do
-    with {:ok, subway_lines} = ServiceInfoCache.get_subway_info do
-      subway_lines
-      |> Enum.flat_map(fn(%{stop_list: stops, route_id: route_id}) -> 
-        if route_id == "Red", do: stops, else: []
-      end)
-      |> Enum.uniq_by(& &1)
-    end
+  defp get_stop_list("Red", subway_lines) do
+    subway_lines
+    |> Enum.flat_map(fn(%{stop_list: stops, route_id: route_id}) -> 
+      if route_id == "Red", do: stops, else: []
+    end)
+    |> Enum.uniq_by(& &1)
   end
-  defp get_stop_list(route_id), do: with {:ok, %{stop_list: stops}} = ServiceInfoCache.get_route(route_id), do: stops
+  defp get_stop_list(route_id, _), do: with {:ok, %{stop_list: stops}} = ServiceInfoCache.get_route(route_id), do: stops
 
   @spec attributes(atom, atom, String.t, keyword) :: keyword(String.t)
   defp attributes(input_name, field, route_id, attrs) do

--- a/apps/concierge_site/test/web/views/stop_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/stop_select_helper_test.exs
@@ -8,10 +8,10 @@ defmodule ConciergeSite.StopSelectHelperTest do
 
     assert html =~ "<select class=\"form-control\" data-route=\"Red\" data-type=\"stop\" id=\"foo_bar\" name=\"foo[bar]\">"
     assert html =~ "Select a stop"
-    assert html =~ "<option data-bus=\"true\" data-mattapan=\"true\" data-red=\"true\" value=\"place-asmnl\">Ashmont</option>"
-    assert html =~ "<option data-green-b=\"true\" data-green-c=\"true\" data-green-d=\"true\" data-green-e=\"true\" data-red=\"true\" value=\"place-pktrm\">Park Street</option>"
-    assert html =~ "<option data-orange=\"true\" data-red=\"true\" value=\"place-dwnxg\">Downtown Crossing</option>"
-    assert html =~ "<option data-bus=\"true\" data-cr=\"true\" data-red=\"true\" value=\"place-brntn\">Braintree</option>"
+    assert html =~ "<option data-bus=\"true\" data-mattapan=\"true\" data-red=\"true\" data-red-1=\"true\" value=\"place-asmnl\">Ashmont</option>"
+    assert html =~ "<option data-green-b=\"true\" data-green-c=\"true\" data-green-d=\"true\" data-green-e=\"true\" data-red=\"true\" data-red-1=\"true\" data-red-2=\"true\" value=\"place-pktrm\">Park Street</option>"
+    assert html =~ "<option data-orange=\"true\" data-red=\"true\" data-red-1=\"true\" data-red-2=\"true\" value=\"place-dwnxg\">Downtown Crossing</option>"
+    assert html =~ "<option data-bus=\"true\" data-cr=\"true\" data-red=\"true\" data-red-2=\"true\" value=\"place-brntn\">Braintree</option>"
   end
 
   test "render/3 Commuter Rail" do


### PR DESCRIPTION
[Feature:  Red line branching](https://app.asana.com/0/529741067494252/656261816860039/f)

When `ServiceInfoCache.get_subway_info` is called, it returns the maps that are identical for the `Red Line`, except that they have different stop lists.  The first one is all of one shape, the second one is all of another shape, and the third is just that part of both shapes that is common among them (the trunk). When I process this data, I ignore the trunk and just use the two other maps to generate a Map keyed by `stop_id` that contains the names of the relevant shapes.

`shapes` is then added to the data that is rendered for each HTML select option.  Later the JS uses this data to enforce that 2 stops must have at least one shape in common.