### PR TITLE
Stops MailerInterface unexpected message error

### DIFF
--- a/apps/concierge_site/lib/dissemination/mailer_interface.ex
+++ b/apps/concierge_site/lib/dissemination/mailer_interface.ex
@@ -25,4 +25,8 @@ defmodule ConciergeSite.Dissemination.MailerInterface do
     Logger.info(fn -> "Notification Email result: #{inspect(response)}, alert_id: #{notification.alert_id}, user_id: #{notification.user.id}," end)
     {:reply, response, nil}
   end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
 end


### PR DESCRIPTION
Why:

* MailerInterface error:
```
[error] ConciergeSite.Dissemination.MailerInterface #PID<0.677.0>
received unexpected message in handle_info/2: {:DOWN,
:normal}
```

`MailerInterface` spawns processes that are linked to and monitored.
These processes are spawned through
`ConciergeSite.Dissemination.DeliverLaterStrategy.deliver_later/3`. The
DOWN messages from these processes are being handled by the default
`GenServer.handle_info/2` which is logging the "received unexpected
message in handle_info/2 ... " message as we see above.
* Asana link: https://app.asana.com/0/529741067494252/641802003247121

This change addresses the need by:

* Adding a `handle_info/2` catch-all to `MailerInterface`