### PR TITLE
Fix bug: can't create red line subscriptions

### DIFF
--- a/apps/concierge_site/lib/controllers/v2/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/v2/trip_controller.ex
@@ -318,7 +318,8 @@ defmodule ConciergeSite.V2.TripController do
     ])
     |> Enum.flat_map(fn {type, route_in, origin, destination, rank} ->
       {route_id, direction} = determine_route(route_in)
-      {:ok, route} = ServiceInfoCache.get_route(route_id)
+      route_filter = %{route_id: route_id, stop_ids: [origin, destination]}
+      {:ok, route} = ServiceInfoCache.get_route(route_filter)
 
       %Subscription{
         alert_priority_type: "low",


### PR DESCRIPTION
Why:

* Red line subscriptions from Alewife to Braintree cannot be created. It
generates an internal server error. This is because the
`determine_direction_id/4` function in `TripController` is not  working
for red line subscriptions. It doesn't work for some red line
subscriptions because there are three different routes in
`ServiceInfoCache` with a 'Red' route_id, each with a different
'stop_list'. Each of these different routes represents a different
shape/branch of the red line.
* Asana link: https://app.asana.com/0/529741067494252/651911808670165

This change addresses the need by:

* Editing `ServiceInfoCache.get_route/2` to allow us to give it a map
with a route_id string and stop_ids list. This way we can iterate
through the different red line shapes and make sure we return the one
that includes the stops given in the stop_ids list.
* Editing `TripController` to use the new function clause reference
above.