### PR TITLE
fix trip card route name wrapping

### DIFF
--- a/apps/concierge_site/assets/css/v2/_trip-card.scss
+++ b/apps/concierge_site/assets/css/v2/_trip-card.scss
@@ -5,6 +5,7 @@
   border-color: $steel;
   color: $black !important;
   text-align: left;
+  white-space: normal;
 
   &:hover,
   &:active,

--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -1,6 +1,6 @@
 defmodule ConciergeSite.TripCardHelper do
 
-  import Phoenix.HTML.Tag, only: [content_tag: 3]
+  import Phoenix.HTML.Tag, only: [content_tag: 3, content_tag: 2]
   import Phoenix.HTML.Link, only: [link: 2]
   import ConciergeSite.TimeHelper, only: [format_time_string: 2, time_to_string: 1]
   alias AlertProcessor.ServiceInfoCache
@@ -69,20 +69,17 @@ defmodule ConciergeSite.TripCardHelper do
     |> Enum.reject(& &1.return_trip)
     |> collapse_duplicate_green_legs()
     |> Enum.map(fn (subscription) ->
-      [
-        content_tag :span, class: "trip__card--route-icon" do
-          icon(subscription.type, subscription.route)
-        end,
-        content_tag :span, class: "trip__card--route" do
-          route_name(subscription.route)
-        end
-      ]
-    end)
-    |> Enum.intersperse(
-      content_tag :span, class: "trip__card--route-deliminator" do
-        ">"
+      content_tag :div do
+        [
+          content_tag :span, class: "trip__card--route-icon" do
+            icon(subscription.type, subscription.route)
+          end,
+          content_tag :span, class: "trip__card--route" do
+            route_name(subscription.route)
+          end
+        ]
       end
-    )
+    end)
   end
 
   @spec collapse_duplicate_green_legs([Subscription.t]) :: [Subscription.t] 

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -215,7 +215,7 @@ defmodule ConciergeSite.V2.TripControllerTest do
       assert html_response(conn, 200) =~ "Success! Your subscription has been created."
 
       assert html_response(conn, 200) =~
-               "<span class=\"trip__card--route\">Red Line</span>" <>
+               "<span class=\"trip__card--route\">Red Line</span></div>" <>
                  "<div class=\"trip__card--type\">Round-trip, Weekdays</div>" <>
                  "<div class=\"trip__card--times\"> 8:00am -  9:00am /  5:00pm -  6:00pm</div>"
     end


### PR DESCRIPTION
[Modes on trip card should break into second line if overflowing ](https://app.asana.com/0/529741067494252/663095974943503/f)

Each route gets its own line:
![screen shot 2018-05-08 at 2 51 23 pm](https://user-images.githubusercontent.com/988609/39777166-cf0cc0ce-52d0-11e8-84cb-3eff16c769b5.png)

Very Long Route names wrap:
![screen shot 2018-05-08 at 2 53 19 pm](https://user-images.githubusercontent.com/988609/39777174-d4e0b096-52d0-11e8-9a48-f8e6fe73216e.png)
