### PR TITLE
Add error routes for debugging issue on staging

### DIFF
--- a/apps/concierge_site/lib/controllers/error_controller.ex
+++ b/apps/concierge_site/lib/controllers/error_controller.ex
@@ -1,0 +1,16 @@
+defmodule ConciergeSite.ErrorController do
+  @moduledoc """
+  Simple controller to attempt to debug why certain errors are not being logged
+  and/or pushed to Splunk when in production.
+  """
+
+  use ConciergeSite.Web, :controller
+
+  def five_hundred(conn, _params) do
+    send_resp(conn, 500, "")
+  end
+
+  def raise(_conn, _params) do
+    raise "Boom!"
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -50,6 +50,8 @@ defmodule ConciergeSite.Router do
   scope "/", ConciergeSite do
     # no pipe
     get "/_health", HealthController, :index
+    get "/_five_hundred", ErrorController, :five_hundred
+    get "/_raise", ErrorController, :raise
   end
 
   scope "/", ConciergeSite do


### PR DESCRIPTION
Why:

* We've noticed that there are some errors missing from the logs on
Splunk. We want an easy way to trigger 500s and exceptions on staging.
* Asana link: https://app.asana.com/0/529741067494252/662476273928411

This change addresses the need by:

* Adding `/_five_hundred` and `/_raise` routes