### PR TITLE
fix time selection on Android

### DIFF
--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -30,11 +30,11 @@
           <span class="form__label">My first trip is usually at this time:</span>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :start_time, "Departing around", class: "form__label--inline" %>
-            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.start_time, :second), data: [type: "time"] %>
+            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: Time.truncate(@trip.start_time, :second), data: [type: "time"] %>
           </div>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :end_time, "Arriving around", class: "form__label--inline" %>
-            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.end_time, :second), data: [type: "time"] %>
+            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: Time.truncate(@trip.end_time, :second), data: [type: "time"] %>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@schedules, "trip_start_time", "trip_end_time") %>
         </div>
@@ -44,11 +44,11 @@
           <span class="form__label">My return trip is usually at this time:</span>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :return_start_time, "Departing around", class: "form__label--inline" %>
-            <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.return_start_time, :second), data: [type: "time"] %>
+            <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: Time.truncate(@trip.return_start_time, :second), data: [type: "time"] %>
           </div>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :return_end_time, "Arriving around", class: "form__label--inline" %>
-            <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", required: true, value: Time.truncate(@trip.return_end_time, :second), data: [type: "time"] %>
+            <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: Time.truncate(@trip.return_end_time, :second), data: [type: "time"] %>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
         </div>

--- a/apps/concierge_site/lib/templates/v2/trip/times.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/times.html.eex
@@ -32,11 +32,11 @@ end
           <span class="form__label"><%= first_trip_label %></span>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :start_time, "Departing around", class: "form__label--inline" %>
-            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", required: true, value: "8:00 AM", data: [type: "time"]  %>
+            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "8:00 AM", data: [type: "time"]  %>
           </div>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :end_time, "Arriving around", class: "form__label--inline" %>
-            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", required: true, value: "9:00 AM", data: [type: "time"] %>
+            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "9:00 AM", data: [type: "time"] %>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@schedules, "trip_start_time", "trip_end_time") %>
         </div>
@@ -46,11 +46,11 @@ end
             <span class="form__label">What time do you usually take your return trip?</span>
             <div class="form-group form-inline form__group--inline">
               <%= label form, :return_start_time, "Departing around", class: "form__label--inline" %>
-              <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", required: true, value: "5:00 PM", data: [type: "time"] %>
+              <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "5:00 PM", data: [type: "time"] %>
             </div>
             <div class="form-group form-inline form__group--inline">
               <%= label form, :return_end_time, "Arriving around", class: "form__label--inline" %>
-              <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", required: true, value: "6:00 PM", data: [type: "time"] %>
+              <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "6:00 PM", data: [type: "time"] %>
             </div>
             <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
           </div>


### PR DESCRIPTION
NO TICKET?

There was an issue reported that on Android devices, a native time-input selector was popping up (which is good) but it included seconds and milliseconds (which is bad!).

This turned out to be a known issue with the flatpickr component with a known workaround: setting a `step` value on the origin input element.

Note: the time pickers look a bit different in different versions of Android, the pictures uploaded are for the latest version. The fix should apply to all versions.

Before:
<img width="249" alt="bad-android-input" src="https://user-images.githubusercontent.com/988609/39827484-0b0efeec-5386-11e8-89e3-1cca176ddae2.png">

---

After:
![screen shot 2018-05-09 at 12 35 03 pm](https://user-images.githubusercontent.com/988609/39827518-2a03cb02-5386-11e8-98db-d3b8c5c8598f.png)

![screen shot 2018-05-09 at 12 35 14 pm](https://user-images.githubusercontent.com/988609/39827533-32d4aeea-5386-11e8-817a-abb6fd10d6df.png)
