### PR TITLE
Add days validation for commute subscriptions

### DIFF
--- a/apps/concierge_site/assets/js/day-selector.js
+++ b/apps/concierge_site/assets/js/day-selector.js
@@ -37,7 +37,10 @@ DaySelector.prototype.labelsFromInputs = function() {
 DaySelector.prototype.addListeners = function() {
   var that = this;
 
-  for (var day in this.labels) this.labels[day].on("click", renderFn(this, day));
+  for (var day in this.labels) {
+    this.labels[day].on("click", renderFn(this, day));
+    this.labels[day].on("click", disableSubmitButtonIfNoDaySelected(this));
+  }
 
   return this;
 };
@@ -137,6 +140,24 @@ function renderFn(that, day) {
     that.toggleState(day);
     that.htmlFromState();
   };
+}
+
+function disableSubmitButtonIfNoDaySelected(that) {
+  return function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const days = Object.values(that.state);
+    if (!days.some(isTrue)) {
+      $("button[type='submit']").attr("disabled", "disabled");
+    } else {
+      $("button[type='submit']").removeAttr("disabled");
+    }
+  };
+}
+
+function isTrue(element) {
+  return element == true;
 }
 
 function clickLabel($label) {

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -321,6 +321,34 @@ defmodule ConciergeSite.V2.TripControllerTest do
       assert html_response(conn, 200) =~
                "<span class=\"trip__card--route\">Silver Line SL1</span>"
     end
+
+    test "returns error message with no day selected", %{conn: conn, user: user} do
+      trip = %{
+        # Note that ':relevant_days' is missing. This simulates somebody not
+        # selecting a day.
+        bike_storage: "false",
+        destinations: [""],
+        elevator: "false",
+        end_time: "9:00 AM",
+        escalator: "false",
+        legs: ["741 - 1"],
+        modes: ["bus"],
+        origins: [""],
+        parking: "false",
+        return_end_time: "6:00 PM",
+        return_start_time: "5:00 PM",
+        round_trip: "true",
+        start_time: "8:00 AM",
+        alert_time_difference_in_minutes: "120"
+      }
+
+      conn =
+        user
+        |> guardian_login(conn)
+        |> post(v2_trip_path(conn, :create), %{trip: trip})
+
+      assert html_response(conn, 200) =~ "You must select at least one day for your trip."
+    end
   end
 
   test "POST /trip/leg to create new trip leg (orange)", %{conn: conn, user: user} do


### PR DESCRIPTION
Why:

* Currently users are able to create a commute subscription without
selecting any days. This is unwanted behavior.
* Asana link: https://app.asana.com/0/529741067494252/660716586322478

This change addresses the need by:

* Editing TripController's create action to check if a day has been
selected and display an error saying one must be selected if users
don't.
* Editing day-selector.js to add front-end validation that forces users
to select at least one day when creating/editing subscriptions.