### PR TITLE
Parse direction_id within informed_entity trip

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -196,17 +196,23 @@ defmodule AlertProcessor.AlertParser do
     |> Enum.map(&(&1.route_id))
   end
 
-  defp parse_trip(%{"trip_id" => trip_id}, %{"route_type" => 4}) do
-    case ServiceInfoCache.get_generalized_trip_id(trip_id) do
-      {:ok, trip_name} -> %{trip: trip_name}
-      _ -> %{}
+  defp parse_trip(trip, informed_entity) do
+    trip_name = get_trip_name(trip, informed_entity)
+    case {trip_name, trip} do
+      {{:ok, trip_name}, %{"direction_id" => direction_id}} ->
+        %{trip: trip_name, direction_id: direction_id}
+      {_, %{"direction_id" => direction_id}} ->
+        %{direction_id: direction_id}
+      _ ->
+        %{}
     end
   end
-  defp parse_trip(%{"trip_id" => trip_id}, _ie) do
-    case ServiceInfoCache.get_trip_name(trip_id) do
-      {:ok, trip_name} -> %{trip: trip_name}
-      _ -> %{}
-    end
+
+  defp get_trip_name(%{"trip_id" => trip_id}, %{"route_type" => 4}) do
+    ServiceInfoCache.get_generalized_trip_id(trip_id)
+  end
+  defp get_trip_name(%{"trip_id" => trip_id}, _informed_enttiy) do
+    ServiceInfoCache.get_trip_name(trip_id)
   end
 
   defp parse_stop(stop_id) do

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -286,5 +286,52 @@ defmodule AlertProcessor.AlertParserTest do
       parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
       refute parsed_alert.active_period
     end
+
+    test "with direction_id for informed_entity" do
+      informed_entity = %{
+        "direction_id" => 0
+      }
+      some_timestamp = 1524609934
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [informed_entity],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      [informed_entity] = parsed_alert.informed_entities
+      assert informed_entity.direction_id == 0
+    end
+
+    test "with direction_id for informed_entity when within 'trip'" do
+      # Some alert's informed_entities include the direction_id within a
+      # 'trip'.
+      informed_entity = %{
+        "trip" => %{
+          "trip_id" => "some-trip-id",
+          "direction_id" => 0
+        }
+      }
+      some_timestamp = 1524609934
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [informed_entity],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      [informed_entity] = parsed_alert.informed_entities
+      assert informed_entity.direction_id == 0
+    end
   end
 end


### PR DESCRIPTION
Why:

* Chris Hayes reported that he received an irrelevant alert. Details in
the asana ticket (link below). The problem was that some alerts include
the direction_id within the trip object within informed entities.
* Asana link: https://app.asana.com/0/529741067494252/666384956315455

This change addresses the need by:

* Editing `AlertParser.parse_trip/2` to attempt to parse the
`direction_id` when provided within an informed-entity's trip.