### PR TITLE
Require stop selection on commute flow

### DIFF
--- a/apps/concierge_site/lib/templates/v2/trip/leg.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/leg.html.eex
@@ -16,12 +16,12 @@ end
         <%= if @saved_mode != "bus" do %>
           <div class="form-group form__section--top">
             <%= label form, :origin, "Where do you get on the #{@route_name}?", class: "form__label" %>
-            <%= ConciergeSite.StopSelectHelper.render(@saved_leg, :trip, :origin) %>
+            <%= ConciergeSite.StopSelectHelper.render(@saved_leg, :trip, :origin, [], [required: true]) %>
           </div>
 
           <div class="form-group form__section">
             <%= label form, :destination, "Where do you exit?", class: "form__label" %>
-            <%= ConciergeSite.StopSelectHelper.render(@saved_leg, :trip, :destination) %>
+            <%= ConciergeSite.StopSelectHelper.render(@saved_leg, :trip, :destination, [], [required: true]) %>
             <%= if @route_name == "Green Line" || @route_name == "Red Line" do %>
               <div class="my-1 font-italic">Only stops on the same branch can be selected</div>
             <% end %>


### PR DESCRIPTION
Why:

* To force users to select an origin and destination before proceeding
to the next step of the subscription creation process (commute flow).
* Asana link: https://app.asana.com/0/529741067494252/649264235595202

This change addresses the need by:

* Edited stop options in `trip/leg/.html.eex` template to be required.

-----------------------------------------------------------------------------------

<img width="721" alt="screen shot 2018-05-10 at 4 50 46 pm" src="https://user-images.githubusercontent.com/1958868/39895036-ce3d7290-5476-11e8-8941-264c107daa94.png">

<img width="1432" alt="screen shot 2018-05-10 at 4 51 06 pm" src="https://user-images.githubusercontent.com/1958868/39895035-ce2b5e84-5476-11e8-85c6-7d7c7aaf481d.png">

