### PR TITLE
adjust vertical position of help text link

### DIFF
--- a/apps/concierge_site/assets/css/v2/_help_text.scss
+++ b/apps/concierge_site/assets/css/v2/_help_text.scss
@@ -1,5 +1,6 @@
 .helptext__link {
   display: none;
+  transform: translate(0px, 3px);
 }
 
 .helptext__link--icon {


### PR DESCRIPTION
[Helper icons lowered to be aligned with text](https://app.asana.com/0/529741067494252/663095974943493/f)

Before:
![before-1](https://user-images.githubusercontent.com/988609/39933400-e1c78efa-5510-11e8-88cc-f5a90789d06d.png)

After:
![screen shot 2018-05-11 at 11 43 16 am](https://user-images.githubusercontent.com/988609/39933419-ef3982d2-5510-11e8-8d42-67eda706b359.png)
