### PR TITLE
Match against stops in schedule for CR alerts

### DIFF
--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -333,5 +333,26 @@ defmodule AlertProcessor.AlertParserTest do
       [informed_entity] = parsed_alert.informed_entities
       assert informed_entity.direction_id == 0
     end
+
+    test "adds schedule data to trip alerts" do
+      use_cassette "trip_alerts", custom: true, clear_mock: true, match_requests_on: [:query] do
+        AlertParser.process_alerts()
+
+        result =
+          AlertCache.get_alerts()
+          |> Enum.flat_map(& &1.informed_entities)
+          |> Enum.map(& &1.schedule)
+          |> Enum.reject(& is_nil(&1))
+
+        [schedule | _] = List.first(result)
+
+        assert length(result) > 0
+        assert %{
+          departure_time: "2017-10-26T08:52:00-04:00",
+          stop_id: "Newburyport",
+          trip_id: "CR-Saturday-Fall-17-1150",
+        } = schedule
+      end
+    end
   end
 end


### PR DESCRIPTION
Why:

* Chris Hayes reported a bug in which he received an irrelevant alert
for a commuter rail subscription. The alert's informed entity didn't
include a stop id and it's trip didn't have a scheduled stop at the
subscription's origin. He has subscriptions from `Grafton -> Back Bay`
and `Worcester -> Back Bay` but the alert was for trip 591 which doesn't
stop at Grafton or Worcester. This notification was sent because
currently we don't consider the scheduled stops for a given trip when
figuring out if there should be a "stop match". So, because the alert
didn't include a stop and everything else matched, the notification was
sent.
* Asana link: https://app.asana.com/0/529741067494252/668866288927880

This change addresses the need by:

* Editing `InformedEntityFilter.stop_match?/1` to try to match against
the stops in a schedule when no stop is provided in the alert's informed
entity.
* Editing `AlertParser` to fetch the trip's schedule and add it to the
alert's informed entity. This is necessary for the changes made to
`InformedEntityFilter` to work. Note that we only do this from an
alert's informed_entity if it doesn't include a stop_id. This is because
if the stop_id is provided, we don't need the schedule to infer the
affected stops from in `InformedEntityFilter`.