### PR TITLE
remove responsive treatment of sub-menu

### DIFF
--- a/apps/concierge_site/assets/css/v2/_header.scss
+++ b/apps/concierge_site/assets/css/v2/_header.scss
@@ -45,32 +45,12 @@
   line-height: 2.5rem;
   border-bottom: 1px solid $pale-grey;
 
-  .container {
-    @include media-breakpoint-up(md) {
-      text-align: right;
+  .container {    
+    text-align: right;
 
-      a {
-        display: inline-block;
-        margin-left: 2rem;
-      }
-    }
-
-    @include media-breakpoint-down(sm) {
-      display: flex;
-
-      a {
-        flex-grow: 1;
-        flex-basis: 0;
-        text-align: center;
-
-        &:first-child {
-          text-align: left;
-        }
-
-        &:last-child {
-          text-align: right;
-        }
-      }
+    a {
+      display: inline-block;
+      margin-left: 2rem;
     }
   }
 }


### PR DESCRIPTION
[Secondary header on mobile, keep consistent spacing between links](https://app.asana.com/0/529741067494252/662654800362194/f)

Instead of having a different treatment of the sub-nav on mobile, it now works the same as desktop.

![screen shot 2018-05-15 at 4 29 13 pm](https://user-images.githubusercontent.com/988609/40081894-59a22742-585d-11e8-9e3e-d31806ca17c1.png)
