### PR TITLE
Fix failing tests because of API changes

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
@@ -81,8 +81,8 @@ defmodule AlertProcessor.TextReplacementTest do
       }
 
       expected = %{
-        header: "Newburyport Train 180 (22:17 pm from Chelsea - Bellingham Sq) has departed Newburyport 20-40 minutes late and will operate at a reduced speed due to a mechanical issue.",
-        description: "Affected trips: Newburyport Train 180 (22:17 pm from Chelsea - Bellingham Sq)"
+        header: "Newburyport Train 180 (22:17 pm from Chelsea) has departed Newburyport 20-40 minutes late and will operate at a reduced speed due to a mechanical issue.",
+        description: "Affected trips: Newburyport Train 180 (22:17 pm from Chelsea)"
       }
 
       assert TextReplacement.replace_text(alert, [sub]) == Map.merge(alert, expected)

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -22,7 +22,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
       %Route{route_id: "Orange", long_name: "Orange Line", route_type: 1, direction_names: ["Southbound", "Northbound"], stop_list: [{_, _, _, _}| _]},
       %Route{route_id: "Red", long_name: "Red Line", route_type: 1, direction_names: ["Southbound", "Northbound"], stop_list: [{"Ashmont", "place-asmnl", _, _}| _]},
       %Route{route_id: "Red", long_name: "Red Line", route_type: 1, direction_names: ["Southbound", "Northbound"], stop_list: [{"Braintree", "place-brntn", _, _}| _]},
-      %Route{route_id: "Red", long_name: "Red Line", route_type: 1, direction_names: ["Southbound", "Northbound"], stop_list: [{"JFK/Umass", "place-jfk", _, _}| _]}
+      %Route{route_id: "Red", long_name: "Red Line", route_type: 1, direction_names: ["Southbound", "Northbound"], stop_list: [{"JFK/UMass", "place-jfk", _, _}| _]}
     ] = Enum.sort_by(route_info, &(&1.route_id))
   end
 
@@ -96,7 +96,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     assert {:ok, "Braintree"} == ServiceInfoCache.get_headsign(pid, "place-davis", "place-brntn", 0)
     assert {:ok, "Alewife"} == ServiceInfoCache.get_headsign(pid, "place-asmnl", "place-davis", 1)
     assert {:ok, "Alewife"} == ServiceInfoCache.get_headsign(pid, "place-brntn", "place-davis", 1)
-    assert {:ok, "Ashmont, Braintree, or JFK/Umass"} == ServiceInfoCache.get_headsign(pid, "place-davis", "place-pktrm", 0)
+    assert {:ok, "Ashmont, Braintree, or JFK/UMass"} == ServiceInfoCache.get_headsign(pid, "place-davis", "place-pktrm", 0)
     assert {:ok, "Alewife"} == ServiceInfoCache.get_headsign(pid, "place-pktrm", "place-davis", 1)
     assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-north", "place-clmnl", 0)
     assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-clmnl", "place-north", 1)


### PR DESCRIPTION
Why:

* Minor changes to the MBTA API broke three of our tests.
* Asana link: https://app.asana.com/0/529741067494252/676310675339946