### PR TITLE
log entire notification when sending SMS

### DIFF
--- a/apps/alert_processor/lib/dissemination/dispatcher.ex
+++ b/apps/alert_processor/lib/dissemination/dispatcher.ex
@@ -22,12 +22,17 @@ defmodule AlertProcessor.Dispatcher do
     email = @mailer.send_notification_email(notification)
     {:ok, email}
   end
-  def send_notification(%Notification{phone_number: phone_number} = notification) when not is_nil(phone_number) do
+  def send_notification(%Notification{phone_number: phone_number,
+                                      header: header,
+                                      closed_timestamp: closed_timestamp,
+                                      alert_id: alert_id,
+                                      user: user
+                                     } = notification) when not is_nil(phone_number) do
     result =
       notification
       |> NotificationSmser.notification_sms()
       |> AwsClient.request()
-    Logger.info(fn -> "SMS notification: notification=#{inspect(notification)} result=#{inspect(result)}" end)
+    Logger.info(fn -> "SMS notification: header=#{header} user_id=#{user.id} alert_id=#{alert_id} closed_timestamp=#{closed_timestamp} result=#{inspect(result)}" end)
     result
   end
   def send_notification(_) do


### PR DESCRIPTION
[Record content of text message in delivery logs](https://app.asana.com/0/529741067494252/678047159897559/f)

```
[info] SMS notification:
header=Orange Line experiencing delays of up to 10 minutes due to construction RYAN TEST 10 
user_id=a2a75243-598b-4567-9876-8116974fe3b9
alert_id=117813
closed_timestamp=
result={:ok, %{body: %{message_id: "123", request_id: "345"}}}
```
