### PR TITLE
Avoids crashes with invalid alerts feed

### DIFF
--- a/apps/alert_processor/test/alert_processor/api/alerts_client_test.exs
+++ b/apps/alert_processor/test/alert_processor/api/alerts_client_test.exs
@@ -2,6 +2,7 @@ defmodule AlertProcessor.AlertsClientTest do
   use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
+  import ExUnit.CaptureLog
   alias AlertProcessor.{AlertsClient}
 
   test "get_alerts/0 returns list of alerts if successful" do
@@ -13,6 +14,17 @@ defmodule AlertProcessor.AlertsClientTest do
   test "get_alerts/0 can use the v2 format as well" do
     use_cassette "get_alerts_enhanced_json_v2", custom: true, clear_mock: true, match_requests_on: [:query] do
       assert {:ok, [%{"id" => "114302", "effect" => "NO_SERVICE"} | _t], 1510944995} = AlertsClient.get_alerts()
+    end
+  end
+
+  test "get_alerts/0 does not blow up and logs errors with invalid JSON body" do
+    # Simulates S3 outage
+    use_cassette "get_invalid_alerts_enhanced_json", custom: true, clear_mock: true, match_requests_on: [:query] do
+      fun = fn ->
+        assert {:ok, [], nil} = AlertsClient.get_alerts()
+      end
+      message = ~s(Error getting alerts enhanced JSON: reason={:invalid, "<")
+      assert capture_log(fun) =~ message
     end
   end
 end

--- a/apps/alert_processor/test/fixture/custom_cassettes/get_invalid_alerts_enhanced_json.json
+++ b/apps/alert_processor/test/fixture/custom_cassettes/get_invalid_alerts_enhanced_json.json
@@ -1,0 +1,14 @@
+[
+  {
+    "request": {
+      "url": "http://s3.amazonaws.com/mbta-realtime-test/alerts_enhanced.json"
+    },
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": "text/html"
+      },
+      "body": "<h1>Custom Response</h1>"
+    }
+  }
+]


### PR DESCRIPTION
Why:

* We noticed on production that when S3 goes down we crash. This is
because `AlertsClient` blows up when it can't get the
alerts_enhanced.json file. The crash report is on the asana ticket if
you're curious on what that looks like.
* Asana link: https://app.asana.com/0/529741067494252/675457984535411

This change addresses the need by:

* Editing `AlertsClient` to not blow up and log an error if the
`alerts_enhanced.json` URL returns HTML instead of the expected JSON
file.