### PR TITLE
Adds alert update notification window

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -30,7 +30,11 @@ defmodule AlertProcessor.NotificationWindowFilter do
     end)
   end
 
-  @doc false
+  @doc """
+  Returns true if the given datetime is within the subscription's notification
+  window. Returns false if it's not.
+
+  """
   @spec within_notification_window?(Subscription.t, DateTime.t) :: boolean
   def within_notification_window?(subscription, now) do
     start_time = subscription.start_time

--- a/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
@@ -2,29 +2,25 @@ defmodule AlertProcessor.SentAlertFilter do
   @moduledoc """
   Filter users to receive alert based on having previously received alert
   """
-  alias AlertProcessor.Model.{Alert, Subscription}
+  alias AlertProcessor.NotificationWindowFilter
+  alias AlertProcessor.Model.{Alert, Subscription, Notification}
 
   @doc """
   Takes a single alert, a list of subscriptions, and a list of notifications. Returns the list of subscriptions
   that have not already recieved a notification for the alert, or that have already recieved a notification
   but with an older last_push_notification
   """
-  @spec filter([Subscription.t], Keyword.t) :: {[Subscription.t], [Subscription.t]}
-  def filter(subscriptions, alert: alert, notifications: notifications) do
-    do_filter(subscriptions, alert, notifications)
+  @spec filter([Subscription.t], Alert.t, [Notification.t], DateTime.t) :: {[Subscription.t], [Subscription.t]}
+  def filter(subscriptions, alert, notifications, now \\ Calendar.DateTime.now!("America/New_York")) do
+    do_filter(subscriptions, alert, notifications, now)
   end
 
-  defp do_filter(subscriptions, %Alert{id: alert_id, last_push_notification: lpn}, notifications) do
+  defp do_filter(subscriptions, %Alert{id: alert_id, last_push_notification: lpn}, notifications, now) do
     sent_matching_notifications =
       Enum.filter(notifications, fn (n) -> alert_id == n.alert_id && n.status == :sent end)
 
-    resend_subscription_id_set = sent_matching_notifications
-    |> Enum.filter(fn (n) -> new?(lpn, n.last_push_notification) end)
-    |> Enum.flat_map(fn (n) -> n.subscriptions end)
-    |> MapSet.new(fn (n) -> n.id end)
-
     subscriptions_to_auto_resend =
-      Enum.filter(subscriptions, fn (s) -> MapSet.member?(resend_subscription_id_set, s.id) end)
+      subscriptions_to_auto_resend(subscriptions, sent_matching_notifications, lpn, now)
 
     subscription_ids = MapSet.new(subscriptions, fn (s) -> s.id end)
 
@@ -43,7 +39,43 @@ defmodule AlertProcessor.SentAlertFilter do
     {subscriptions_to_test, subscriptions_to_auto_resend}
   end
 
-  defp new?(lpn, notification_lpn) do
-    DateTime.compare(lpn, notification_lpn) == :gt
+  defp subscriptions_to_auto_resend(subscriptions, notifications, last_push_notification, now) do
+    subscription_ids_to_notify =
+      notifications
+      |> subscriptions_to_notify_of_update(last_push_notification, now)
+      |> MapSet.new(fn(subscription) -> subscription.id end)
+
+    Enum.filter(subscriptions, fn(subscription) ->
+      MapSet.member?(subscription_ids_to_notify, subscription.id)
+    end)
+  end
+
+  defp subscriptions_to_notify_of_update(notifications, last_push_notification, now) do
+    Enum.reduce(notifications, [], fn(notification, subscriptions_to_notify) ->
+      case DateTime.compare(notification.last_push_notification, last_push_notification) do
+        :lt ->
+          notification.subscriptions
+          |> notification_window_filter(now)
+          |> Enum.concat(subscriptions_to_notify)
+        _ ->
+          subscriptions_to_notify
+      end
+    end)
+  end
+
+  defp notification_window_filter(subscriptions, now) do
+    Enum.filter(subscriptions, fn(subscription) ->
+      # We extend the subscription's end time because we only want to send
+      # notifications for updates that occur between the subscription's start
+      # time and it's end time plus one hour.
+      modified_subscription = extend_subscription_end_time(subscription)
+      NotificationWindowFilter.within_notification_window?(modified_subscription, now)
+    end)
+  end
+
+  defp extend_subscription_end_time(subscription) do
+    Map.update!(subscription, :end_time, fn(end_time) ->
+      Time.add(end_time, :timer.hours(1), :millisecond)
+    end)
   end
 end

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -37,11 +37,11 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
   @doc """
   determine_recipients/3 receives an alert and applies relevant filters to exclude users who should not be notified
   """
-  @spec determine_recipients(Alert.t, [Subscription.t], [Notification.t]) :: [Subscription.t]
-  def determine_recipients(alert, subscriptions, notifications) do
-    {subscriptions_to_test, subscriptions_to_auto_resend} = SentAlertFilter.filter(subscriptions,
-                                                                                   alert: alert,
-                                                                                   notifications: notifications)
+  @spec determine_recipients(Alert.t, [Subscription.t], [Notification.t], DateTime.t) :: [Subscription.t]
+  def determine_recipients(alert, subscriptions, notifications, now \\ Calendar.DateTime.now!("America/New_York")) do
+    {subscriptions_to_test, subscriptions_to_auto_resend} =
+      SentAlertFilter.filter(subscriptions, alert, notifications, now)
+
     subscriptions_to_test
     |> @notification_window_filter.filter()
     |> InformedEntityFilter.filter(alert: alert)

--- a/apps/concierge_site/test/integration/matching_test.exs
+++ b/apps/concierge_site/test/integration/matching_test.exs
@@ -3,7 +3,7 @@ defmodule ConciergeSite.Integration.Matching do
   import ConciergeSite.SubscriptionFactory
   import ConciergeSite.AlertFactory, only: [active_period: 3, severity_by_priority: 1]
   import ConciergeSite.NotificationFactory
-  import AlertProcessor.SubscriptionFilterEngine, only: [determine_recipients: 3]
+  import AlertProcessor.SubscriptionFilterEngine, only: [determine_recipients: 3, determine_recipients: 4]
   import AlertProcessor.Factory
 
   @base %{"alert_priority_type" => "medium", "departure_end" => ~T[08:30:00], "departure_start" => ~T[08:00:00],
@@ -443,9 +443,9 @@ defmodule ConciergeSite.Integration.Matching do
     test "matches: notification already sent but last push time changed" do
       alert = alert(informed_entity: [entity(:subway)])
       notification = notification(:earlier, alert, [@subscription])
+      monday_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
 
-      [new_notification] = determine_recipients(alert, [@subscription], [notification])
-      refute notification == new_notification
+      assert [_subscription] = determine_recipients(alert, [@subscription], [notification], monday_at_8am)
     end
 
     test "does not match: notification already sent but it has a closed_timestamp" do


### PR DESCRIPTION
Why:

* Current logic allows updates (including all-clears) on the same alert
to be sent at any time after the original alert to users who have
received the original one. We want to implement a time limit on when
customers will receive updates (to respect their notification window) by
imposing a 1 hour post-notification time window during which they can
receive updates to the same alert.  After this, they will no longer
receive updates.
* Asana link: https://app.asana.com/0/529741067494252/656261816861043

This change addresses the need by:

* Adding brief function documentation for
`NotificationWindowFilter.withing_notification_window?/2`. This function
is now used from the `SentAlertFilter` module.
* Editing `SentAlertFilter` for it to only return subscriptions for
updated alerts when within the notification window. The notification
window for "updates" is any time from the subscriptions start time to
it's end time plus one hour.
* Editing `MatchingTest` because the changes above broke one of the
tests. To fix the failure we edited
`SubscriptionFilterEngine.determine_recipients/3` to accept the current
datetime and edited the test to pass a current datetime within the
subscription's notification window.