### PR TITLE
make day selector accessible

### DIFF
--- a/apps/concierge_site/assets/css/v2/_day_selector.scss
+++ b/apps/concierge_site/assets/css/v2/_day_selector.scss
@@ -76,6 +76,15 @@
   .btn-day {
     min-height: 50px;
 
+    &:focus {
+      background-color: $brand-primary !important;
+      color: $white;
+
+      i {
+        color: $white;
+      }
+    }
+
     &.active {
       background-color: $light-blue;
     }

--- a/apps/concierge_site/assets/js/day-selector.js
+++ b/apps/concierge_site/assets/js/day-selector.js
@@ -40,6 +40,7 @@ DaySelector.prototype.addListeners = function() {
   for (var day in this.labels) {
     this.labels[day].on("click", renderFn(this, day));
     this.labels[day].on("click", disableSubmitButtonIfNoDaySelected(this));
+    this.labels[day].on("keypress", triggerClick());
   }
 
   return this;
@@ -139,6 +140,14 @@ function renderFn(that, day) {
 
     that.toggleState(day);
     that.htmlFromState();
+  };
+}
+
+function triggerClick() {
+  return function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $(e.target).click();
   };
 }
 

--- a/apps/concierge_site/lib/views/day_select_helper.ex
+++ b/apps/concierge_site/lib/views/day_select_helper.ex
@@ -61,12 +61,18 @@ defmodule ConciergeSite.DaySelectHelper do
   end
 
   defp label(input_name, day, selected?) do
-    content_tag :label, class: label_class(selected?) do
+    content_tag :label, class: label_class(selected?), tabindex: "0", role: "button",
+                        aria_label: day_aria_label(day), aria_pressed: aria_pressed?(selected?) do
       [tag(:input, type: "checkbox", autocomplete: "off", value: day,
            name: "#{input_name}[relevant_days][]", checked: selected?),
        check_icon(selected?)]
     end
   end
+
+  defp day_aria_label(day), do: "travel day: #{day}"
+
+  defp aria_pressed?(true), do: "true"
+  defp aria_pressed?(false), do: "false"
 
   defp check_icon(true), do: content_tag(:i, "", class: "fa fa-check")
   defp check_icon(_), do: content_tag(:i, "", class: "fa")
@@ -83,9 +89,13 @@ defmodule ConciergeSite.DaySelectHelper do
   end
 
   defp group_label(name, selected?) do
-    content_tag :label, class: "#{label_class(selected?)} btn-#{name}" do
+    content_tag :label, class: "#{label_class(selected?)} btn-#{name}", tabindex: "0",
+                        role: "button", aria_label: group_aria_label(name), aria_pressed: aria_pressed?(selected?) do
       [tag(:input, type: "checkbox", autocomplete: "off", value: name, checked: selected?),
        String.capitalize(name)]
     end
   end
+
+  defp group_aria_label("weekdays"), do: "travel days: all weekdays"
+  defp group_aria_label("weekend"), do: "travel days: weekend"
 end


### PR DESCRIPTION
[(3) Accessibility of day selector widget](https://app.asana.com/0/529741067494252/661252175051517/f)

Notes:
- add `tabindex` to allow tabbing into `label` tag
- added CSS style to indicate which label was actively tabbed (a little nuanced because the button already has an active/inactive state independent of it being tab-activated
- added JS functionality to enable toggle by keypress
- added `aria` attributes to tab to indicate that it is a toggleable button

Video Demo:
https://drive.google.com/file/d/1PfNxwFn0_5JgL-L7Sa0EV8EnDFUOOJRz/view?usp=sharing