### PR TITLE
Add silver line stops to accessibility flow

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -179,7 +179,8 @@ defmodule AlertProcessor.AlertParser do
   defp set_route_for_amenity(%{facility_id: fid, stop: stop} = entity) when not is_nil(fid) do
     with {:ok, subway_infos} <- ServiceInfoCache.get_subway_info(),
       {:ok, cr_infos} <- ServiceInfoCache.get_commuter_rail_info(),
-      routes <- get_routes_for_stop(stop, subway_infos ++ cr_infos) do
+      {:ok, bus_infos} <- ServiceInfoCache.get_bus_info(),
+      routes <- get_routes_for_stop(stop, subway_infos ++ cr_infos ++ bus_infos) do
         Enum.map(routes, & Map.put(entity, :route, &1))
     else
       _ -> [entity]

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -218,6 +218,16 @@ defmodule AlertProcessor.AlertParserTest do
     end
   end
 
+  test "parse informed_entities for bus alert if facility_id is included" do
+    # This test ensures `AlertParser.set_route_for_amenity/1` supports bus
+    # alerts when a facility_id is included.
+    use_cassette "bus_alert_with_facility_id", custom: true, clear_mock: true, match_requests_on: [:query] do
+      {:ok, [alert], feed_timestamp} = AlertProcessor.AlertsClient.get_alerts()
+      result = AlertParser.parse_alert(alert, %{}, feed_timestamp)
+      assert length(result.informed_entities) > 0
+    end
+  end
+
   describe "remove_ignored/1" do
     @valid_alert %{"active_period" => [%{"start" => 1507661322}], "last_push_notification_timestamp" => 1507661322}
 

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -40,15 +40,31 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     ] = Enum.sort_by(route_info, &(&1.route_id))
   end
 
-  test "get_bus_info/0 returns bus headsign lists", %{pid: pid} do
-    {:ok, [route | _]} = ServiceInfoCache.get_bus_info(pid)
+  describe "get_bus_info/0" do
+    test "returns bus headsign lists", %{pid: pid} do
+      {:ok, [route | _]} = ServiceInfoCache.get_bus_info(pid)
 
-    assert route == %AlertProcessor.Model.Route{
-                      direction_names: ["Outbound", "Inbound"],
-                      headsigns: %{0 => ["Logan Airport", "Silver Line Way"],
-                                   1 => ["South Station"]},
-                      long_name: "Silver Line SL1", order: 0,
-                      route_id: "741", route_type: 3, short_name: "SL1", stop_list: []}
+      assert route == %AlertProcessor.Model.Route{
+        direction_names: ["Outbound", "Inbound"],
+        headsigns: %{0 => ["Logan Airport", "Silver Line Way"],
+          1 => ["South Station"]},
+        long_name: "Silver Line SL1", order: 0,
+        route_id: "741", route_type: 3, short_name: "SL1", stop_list: [
+          {"World Trade Center", "place-wtcst", {42.34863, -71.04246}, 1},
+          {"Courthouse", "place-crtst", {42.35245, -71.04685}, 1},
+          {"South Station", "place-sstat", {42.352271, -71.055242}, 1}
+        ]}
+    end
+
+    test "includes populated stop_list for Silver Line routes", %{pid: pid} do
+      {:ok, routes} = ServiceInfoCache.get_bus_info(pid)
+      silver_line_route_ids = ~w(741 742 743 749 751)
+
+      for silver_line_route_id <- silver_line_route_ids do
+        route = Enum.find(routes, & &1.route_id == silver_line_route_id)
+        assert length(route.stop_list) > 0
+      end
+    end
   end
 
   test "get_commuter_rail_info/0 returns commuter rail info", %{pid: pid} do

--- a/apps/alert_processor/test/fixture/custom_cassettes/bus_alert_with_facility_id.json
+++ b/apps/alert_processor/test/fixture/custom_cassettes/bus_alert_with_facility_id.json
@@ -1,0 +1,18 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://s3.amazonaws.com/mbta-realtime-test/alerts_enhanced.json"
+    },
+    "response": {
+      "body": "{ \"header\": { \"gtfs_realtime_version\": \"1.0\", \"incrementality\": 0, \"timestamp\": 1527776758 }, \"entity\": [ { \"id\": \"117908\", \"alert\": { \"effect\": \"OTHER_EFFECT\", \"effect_detail\": \"ELEVATOR_CLOSURE\", \"cause\": \"UNKNOWN_CAUSE\", \"cause_detail\": \"UNKNOWN_CAUSE\", \"header_text\": { \"translation\": [ { \"text\": \"Courthouse Elevator 937 (South Station platform to lobby) unavailable\", \"language\": \"en\" } ] }, \"description_text\": { \"translation\": [ { \"text\": \"If exiting, exit the Silver Line at South Station and transfer to outbound service back to Courthouse. If boarding, board outbound service to World Trade Center and switch to inbound service.\", \"language\": \"en\" } ] }, \"service_effect_text\": { \"translation\": [ { \"text\": \"elevator unavailable\", \"language\": \"en\" } ] }, \"short_header_text\": { \"translation\": [ { \"text\": \"Courthouse Elevator 937 (South Station platform to lobby) unavailable\", \"language\": \"en\" } ] }, \"severity\": 3, \"created_timestamp\": 1527776753, \"last_modified_timestamp\": 1527776753, \"last_push_notification_timestamp\": 1527776753, \"alert_lifecycle\": \"NEW\", \"duration_certainty\": \"ESTIMATED\", \"active_period\": [ { \"start\": 1527776750, \"end\": 1527783958 } ], \"informed_entity\": [ { \"stop_id\": \"74616\", \"facility_id\": \"937\", \"activities\": [ \"USING_WHEELCHAIR\" ] } ] } } ] }",
+      "headers": {},
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/apps/concierge_site/lib/views/stop_select_helper.ex
+++ b/apps/concierge_site/lib/views/stop_select_helper.ex
@@ -42,6 +42,7 @@ defmodule ConciergeSite.StopSelectHelper do
     |> get_routes()
     |> Kernel.++(get_routes(:cr))
     |> Kernel.++(get_routes(:ferry))
+    |> Kernel.++(get_routes(:bus_silver_line))
     |> Enum.flat_map(& get_stops_by_route(&1))
     |> Enum.uniq_by(& &1)
   end
@@ -107,6 +108,7 @@ defmodule ConciergeSite.StopSelectHelper do
 
   @spec get_routes(atom) :: [String.t]
   defp get_routes(:subway), do: ["Red", "Orange", "Green", "Blue", "Mattapan"]
+  defp get_routes(:bus_silver_line), do: ~w(741 742 743 749 751)
   defp get_routes(:cr) do
     with {:ok, routes} <- ServiceInfoCache.get_commuter_rail_info() do
       for route <- routes, do: route.route_id


### PR DESCRIPTION
Why:

* Some of the Silver Line stops (bus) offer accessibility features which
accessibility flow users might like to be notified about.
* Asana link: https://app.asana.com/0/529741067494252/656261816861039

This change addresses the need by:

* Editing `ServiceInfoCache` to load stops (with elevator or escalator)
for silver line bus routes.
* Editing `AlertParser.set_route_for_amenity/1` to support bus stops.
Without this bus alerts that include a facility_id will not work. This
can affect accessibility alerts for bus stops.
* Editing `StopSelectHelper.get_stops_by_route("*")`, which is used in
the accessibility flow, to get stops for the silver line bus routes.