### PR TITLE
Add reminders functionality

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -79,6 +79,7 @@ defmodule AlertProcessor.AlertParser do
     |> Map.put(:timeframe, parse_translation(alert_data["timeframe_text"]))
     |> Map.put(:recurrence, parse_translation(alert_data["recurrence_text"]))
     |> Map.put(:closed_timestamp, parse_datetime_or_nil(alert_data["closed_timestamp"]))
+    |> Map.put(:reminder_times, parse_reminder_times(alert_data["reminder_times"]))
   end
 
   def parse_alert(alert, _, _) do
@@ -278,4 +279,9 @@ defmodule AlertProcessor.AlertParser do
       _ -> nil
     end
   end
+
+  defp parse_reminder_times(reminder_times) when is_list(reminder_times) do
+    Enum.map(reminder_times, & parse_datetime(&1))
+  end
+  defp parse_reminder_times(_), do: []
 end

--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -6,7 +6,8 @@ defmodule AlertProcessor.Model.Alert do
 
   defstruct [:active_period, :effect_name, :id, :header, :informed_entities,
              :severity, :last_push_notification, :service_effect, :description, :url,
-             :timeframe, :recurrence, :duration_certainty, :created_at, :closed_timestamp]
+             :timeframe, :recurrence, :duration_certainty, :created_at, :closed_timestamp,
+             :reminder_times]
 
   @type informed_entity :: [
     %{
@@ -34,7 +35,8 @@ defmodule AlertProcessor.Model.Alert do
     recurrence: String.t,
     duration_certainty: {:estimated, pos_integer} | :known,
     created_at: DateTime.t,
-    closed_timestamp: DateTime.t | nil
+    closed_timestamp: DateTime.t | nil,
+    reminder_times: [DateTime.t] | nil
   }
 
   @route_types %{

--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -99,7 +99,7 @@ defmodule AlertProcessor.Model.Notification do
       where: n.status == "sent",
       preload: [:subscriptions],
       distinct: [:alert_id, :user_id],
-      order_by: [desc: n.last_push_notification],
+      order_by: [desc: [n.last_push_notification, n.inserted_at]],
       select: n
     )
   end

--- a/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
@@ -9,18 +9,27 @@ defmodule AlertProcessor.SentAlertFilter do
   Takes a single alert, a list of subscriptions, and a list of notifications. Returns the list of subscriptions
   that have not already recieved a notification for the alert, or that have already recieved a notification
   but with an older last_push_notification
+
+  The notifications passed in as the third argument are expected to be unique
+  per user, relevant to the alert in the second argument, and the latest one
+  inserted to the DB (according to it's `inserted_at` value).  This is to make
+  sure we can correctly match for updates (where the `last_push_notification`
+  changes) and reminders.
   """
   @spec filter([Subscription.t], Alert.t, [Notification.t], DateTime.t) :: {[Subscription.t], [Subscription.t]}
   def filter(subscriptions, alert, notifications, now \\ Calendar.DateTime.now!("America/New_York")) do
     do_filter(subscriptions, alert, notifications, now)
   end
 
-  defp do_filter(subscriptions, %Alert{id: alert_id, last_push_notification: lpn}, notifications, now) do
+  defp do_filter(subscriptions, alert, notifications, now) do
+    alert_id = alert.id
+    lpn = alert.last_push_notification
+
     sent_matching_notifications =
       Enum.filter(notifications, fn (n) -> alert_id == n.alert_id && n.status == :sent end)
 
     subscriptions_to_auto_resend =
-      subscriptions_to_auto_resend(subscriptions, sent_matching_notifications, lpn, now)
+      subscriptions_to_auto_resend(subscriptions, alert, sent_matching_notifications, lpn, now)
 
     subscription_ids = MapSet.new(subscriptions, fn (s) -> s.id end)
 
@@ -39,18 +48,25 @@ defmodule AlertProcessor.SentAlertFilter do
     {subscriptions_to_test, subscriptions_to_auto_resend}
   end
 
-  defp subscriptions_to_auto_resend(subscriptions, notifications, last_push_notification, now) do
+  defp subscriptions_to_auto_resend(subscriptions, alert, notifications, last_push_notification, now) do
+    subscription_ids_to_update =
+      subscription_ids_to_update(notifications, last_push_notification, now)
+    subscription_ids_to_remind =
+      subscription_ids_to_remind(notifications, alert, now)
     subscription_ids_to_notify =
-      notifications
-      |> subscriptions_to_notify_of_update(last_push_notification, now)
-      |> MapSet.new(fn(subscription) -> subscription.id end)
-
+      MapSet.union(subscription_ids_to_update, subscription_ids_to_remind)
     Enum.filter(subscriptions, fn(subscription) ->
       MapSet.member?(subscription_ids_to_notify, subscription.id)
     end)
   end
 
-  defp subscriptions_to_notify_of_update(notifications, last_push_notification, now) do
+  defp subscription_ids_to_update(notifications, last_push_notification, now) do
+    notifications
+    |> subscriptions_to_send_update(last_push_notification, now)
+    |> MapSet.new(fn(subscription) -> subscription.id end)
+  end
+
+  defp subscriptions_to_send_update(notifications, last_push_notification, now) do
     Enum.reduce(notifications, [], fn(notification, subscriptions_to_notify) ->
       case DateTime.compare(notification.last_push_notification, last_push_notification) do
         :lt ->
@@ -61,6 +77,49 @@ defmodule AlertProcessor.SentAlertFilter do
           subscriptions_to_notify
       end
     end)
+  end
+
+  defp subscription_ids_to_remind(_, %Alert{reminder_times: nil}, _) do
+    MapSet.new()
+  end
+
+  defp subscription_ids_to_remind(_, %Alert{reminder_times: []}, _) do
+    MapSet.new()
+  end
+
+  defp subscription_ids_to_remind(notifications, alert, now) do
+    notifications
+    |> subscriptions_to_send_reminder(alert, now)
+    |> MapSet.new(fn(subscription) -> subscription.id end)
+  end
+
+  defp subscriptions_to_send_reminder(notifications, alert, now) do
+    Enum.reduce(notifications, [], fn(notification, subscriptions_to_notify) ->
+      if reminder_due?(notification, alert, now) do
+        notification.subscriptions
+        |> Enum.filter(& NotificationWindowFilter.within_notification_window?(&1, now))
+        |> Enum.concat(subscriptions_to_notify)
+      else
+        subscriptions_to_notify
+      end
+    end)
+  end
+
+  defp reminder_due?(notification, alert, now) do
+    inserted_at = notification.inserted_at
+    Enum.any?(alert.reminder_times, fn reminder_time ->
+      reminder_time_earlier_than_now?(reminder_time, now)
+      && reminder_time_later_than_inserted_at?(reminder_time, inserted_at)
+    end)
+  end
+
+  defp reminder_time_earlier_than_now?(reminder_time, now) do
+    DateTime.compare(reminder_time, now) == :lt
+  end
+
+  defp reminder_time_later_than_inserted_at?(reminder_time, inserted_at) do
+    inserted_at = DateTime.from_naive!(inserted_at, "Etc/UTC")
+    DateTime.compare(reminder_time, inserted_at) == :gt
   end
 
   defp notification_window_filter(subscriptions, now) do

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -369,5 +369,42 @@ defmodule AlertProcessor.AlertParserTest do
         } = schedule
       end
     end
+
+    test "with reminder_times" do
+      some_timestamp = 1524609934
+      reminder_times = [1515166200, 1515408300]
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp,
+        "reminder_times" => reminder_times
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      expected_reminder_times = Enum.map(reminder_times, & DateTime.from_unix!(&1))
+      assert parsed_alert.reminder_times == expected_reminder_times
+    end
+
+    test "without reminder_times" do
+      some_timestamp = 1524609934
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp,
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      assert parsed_alert.reminder_times == []
+    end
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
@@ -239,5 +239,230 @@ defmodule AlertProcessor.SentAlertFilterTest do
         SentAlertFilter.filter(subscriptions, updated_alert, notifications, @monday_at_8am)
       assert returned_sub.id == sub2.id
     end
+
+    test "if reminder due" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_9_at_7_45am = DateTime.from_naive!(~N[2018-04-09 07:45:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert {[], [returned_subscription]} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_9_at_7_45am)
+      assert returned_subscription.id == subscription.id
+    end
+
+    test "if a second reminder is due" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      tuesday_april_10_at_1pm = DateTime.from_naive!(~N[2018-04-10 13:00:00], "Etc/UTC")
+      monday_april_16_at_7_01am = DateTime.from_naive!(~N[2018-04-16 07:01:00], "Etc/UTC")
+      tuesday_april_17_at_1pm = DateTime.from_naive!(~N[2018-04-17 13:00:00], "Etc/UTC")
+      monday_april_23_at_7_01am = DateTime.from_naive!(~N[2018-04-23 07:01:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [tuesday_april_10_at_1pm, tuesday_april_17_at_1pm]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_16_at_7_01am),
+      }
+
+      assert {[], [returned_subscription]} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_23_at_7_01am)
+      assert returned_subscription.id == subscription.id
+    end
+
+    test "if reminder not due yet" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_16_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert {[], []} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_9_at_7_30am)
+    end
+
+    test "if reminder not due yet and multiple reminder times" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      monday_april_23_at_7_30am = DateTime.from_naive!(~N[2018-04-23 07:30:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am, monday_april_23_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_9_at_7_30am),
+      }
+
+      assert {[], []} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_16_at_7_30am)
+    end
+
+    test "with two reminders that were already sent" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      monday_april_23_at_7_30am = DateTime.from_naive!(~N[2018-04-23 07:30:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am, monday_april_16_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_16_at_7_30am),
+      }
+
+      # Note that the third argument is expected to include the latest known
+      # sent notification for a user/alert combination.
+      assert {[], []} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_23_at_7_30am)
+    end
+
+    test "reminders are sent within notification window only" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      friday_april_6_at_1pm = DateTime.from_naive!(~N[2018-04-06 13:00:00], "Etc/UTC")
+      friday_april_6_at_2pm = DateTime.from_naive!(~N[2018-04-06 14:00:00], "Etc/UTC")
+      monday_april_9_at_6am = DateTime.from_naive!(~N[2018-04-09 06:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      :subscription |> insert(user: user) |> Repo.preload(:user)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [friday_april_6_at_1pm]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert {[], []} =
+        SentAlertFilter.filter([subscription], alert, [notification], friday_april_6_at_2pm)
+      assert {[], []} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_9_at_6am)
+      assert {[], [returned_subscription]} =
+        SentAlertFilter.filter([subscription], alert, [notification], monday_april_9_at_7_30am)
+      assert returned_subscription.id == subscription.id
+    end
   end
 end


### PR DESCRIPTION
Why:

* PIOs can include reminder times in an alert, typically used for
recurring alerts. These are times that the same alert should be resent
to users. Before this commit there was no support for reminder times.
* Asana link: https://app.asana.com/0/529741067494252/656261816861041

This change addresses the need by:

* Editing `Alert` and `AlertParser` it to support `reminder_times`
* Editing `Notification.most_recent_for_subscriptions_and_alerts/2` for
it to return most recent notifications by `inserted_at`. Before, it was
only returning the most recent notifications by
`last_push_notification`. This is necessary to be able to determine,
based on the latest sent notification for a given alert, if we should
send a reminder. Note that each sent notification creates a new
notification record in the notifications table. So, an initial
notification, an update, first reminder, and second reminder, would be
represented as four separate rows in the notifications table.
* Editing `SentAlertFilter` to also return subscriptions that should be
sent a reminder.