### PR TITLE
fix flow of tabbing through time inputs

### DIFF
--- a/apps/concierge_site/assets/css/vendor/flatpickr/light.scss
+++ b/apps/concierge_site/assets/css/vendor/flatpickr/light.scss
@@ -1,4 +1,10 @@
+.flatpickr-calendar-container {
+  position: relative;
+}
+
 .flatpickr-calendar {
+  top: 45px !important;
+  left: 0px !important;
   background: transparent;
   opacity: 0;
   display: none;

--- a/apps/concierge_site/assets/js/custom-time-select.js
+++ b/apps/concierge_site/assets/js/custom-time-select.js
@@ -59,6 +59,6 @@ export default pubsub => {
   pubsub.subscribe("time-change", shiftEndTime);
 
   [...document.querySelectorAll("input[data-type='time']")].forEach(input => {
-    flatpickr(input, config);
+    flatpickr(input, Object.assign({}, config, {appendTo: input.parentNode}));
   });
 };

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -29,9 +29,13 @@ first_trip_padding_class = if @trip.roundtrip == "true", do: "", else: "form__se
           <span class="form__label"><%= time_label %></span>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :start_time, first_trip_label, class: "form__label--inline" %>
-            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.start_time), data: [type: "time"] %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.start_time), data: [type: "time"] %>
+            </div>
             <%= label form, :end_time, "until", class: "form__label--inline-divider" %>
-            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.end_time), data: [type: "time"] %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.end_time), data: [type: "time"] %>
+            </div>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@schedules, "trip_start_time", "trip_end_time") %>
         </div>
@@ -40,9 +44,13 @@ first_trip_padding_class = if @trip.roundtrip == "true", do: "", else: "form__se
         <div class="form-group form__section">
           <div class="form-group form-inline form__group--inline">
             <%= label form, :return_start_time, "Return trip", class: "form__label--inline" %>
-            <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_start_time), data: [type: "time"] %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_start_time), data: [type: "time"] %>
+            </div>
             <%= label form, :return_end_time, "until", class: "form__label--inline-divider" %>
-            <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_end_time), data: [type: "time"] %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_end_time), data: [type: "time"] %>
+            </div>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
         </div>

--- a/apps/concierge_site/lib/templates/v2/trip/times.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/times.html.eex
@@ -23,9 +23,13 @@ first_trip_padding_class = if @round_trip == "true", do: "", else: "form__sectio
           <span class="form__label"><%= time_label %></span>
           <div class="form-group form-inline form__group--inline">
             <%= label form, :start_time, first_trip_label, class: "form__label--inline" %>
-            <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "8:00 AM", data: [type: "time"]  %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "8:00 AM", data: [type: "time"]  %>
+            </div>
             <%= label form, :end_time, "until", class: "form__label--inline-divider" %>
-            <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "9:00 AM", data: [type: "time"] %>
+            <div class="flatpickr-calendar-container">
+              <%= text_input form, :end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "9:00 AM", data: [type: "time"] %>
+            </div>
           </div>
           <%= ConciergeSite.ScheduleHelper.render(@schedules, "trip_start_time", "trip_end_time") %>
         </div>
@@ -34,9 +38,13 @@ first_trip_padding_class = if @round_trip == "true", do: "", else: "form__sectio
           <div class="form-group form__section">
             <div class="form-group form-inline form__group--inline">
               <%= label form, :return_start_time, "Return trip", class: "form__label--inline" %>
-              <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "5:00 PM", data: [type: "time"] %>
+              <div class="flatpickr-calendar-container">
+                <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "5:00 PM", data: [type: "time"] %>
+              </div>
               <%= label form, :return_end_time, "until", class: "form__label--inline-divider" %>
-              <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "6:00 PM", data: [type: "time"] %>
+              <div class="flatpickr-calendar-container">
+                <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: "6:00 PM", data: [type: "time"] %>
+              </div>
             </div>
             <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
           </div>


### PR DESCRIPTION
[Accessibility:  tabbing into time-selector loses tab-position in page](https://app.asana.com/0/529741067494252/690312643165479/f)

Currently, the time selector appends its HTML nodes to the body of the page which causes a disruption in the tab-flow of the page, effectively returning the user to the top of the page and never allowing them to tab past the first time selector they enter into.

This PR does a few things:
- wraps the time selector in a container
- causes the time selector to append to the container (not body)
- overrides the inline positioning of the component with new position styles

The time input is on the edit subscription page and the last step of the commuter trip creation process.