### PR TITLE
fix warning message caused by hard-coding value

### DIFF
--- a/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/confirmation.txt.eex
@@ -2,7 +2,7 @@ Thanks for signing up for T-Alerts Beta!
 
 If you have immediate feedback about the sign up process, or related to any alerts as you start to receive them, we’d love to hear it. 
 
-Provide feedback now! https://www.mbta.com/beta-alerts-feedback
+Provide feedback now! <%= feedback_url %>
 
 Get the most from your T-Alerts account by signing in!  You can:
 


### PR DESCRIPTION
NO TICKET

I noticed this the other day, there is warning being emitted due to an unused variable in a template. The value was hard coded, but the variable should have been used.

---
![screen shot 2018-06-05 at 2 02 29 pm](https://user-images.githubusercontent.com/988609/40994131-7412a378-68c9-11e8-92a9-6e7840521430.png)
