### PR TITLE
Remove unnecessary trip preload

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -20,8 +20,6 @@ defmodule AlertProcessor.NotificationWindowFilter do
   Accepts a list of subscriptions and returns a filtered list of subscriptions
   that could be notified on a given day and time per their notification window.
 
-  *Important Note:* Subscriptions are expected to have their trip preloaded.
-
   """
   @spec filter([Subscription.t], DateTime.t) :: [Subscription.t]
   def filter(subscriptions, now \\ Calendar.DateTime.now!("America/New_York")) do

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -16,7 +16,6 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
     |> Repo.all()
     |> Repo.preload(:user)
     |> Repo.preload(:informed_entities)
-    |> Repo.preload(:trip)
 
     start_time = Time.utc_now()
 


### PR DESCRIPTION
Why:

* Preloading subscription trips in `SubscriptionFilterEngine` was only
necessary in the past, when the `NotificationWindowFilter` start time
was affected by the trip's `alert_time_difference_in_minutes` value.
* Trello link: n/a