### PR TITLE
Fix the missing account deletion confirmation button

### DIFF
--- a/apps/concierge_site/assets/js/app.js
+++ b/apps/concierge_site/assets/js/app.js
@@ -29,7 +29,8 @@ import daySelector from "./day-selector";
 import schedule from "./schedule";
 import phoneMask from "./phone-mask";
 import customTimeSelect from "./custom-time-select";
-import tripIndex from "./trip-index";
+import deleteModal from "./delete-modal";
+import tripCard from "./trip-card";
 import pubsubFactory from "PubSub";
 const pubsub = new pubsubFactory();
 
@@ -44,4 +45,5 @@ daySelector();
 schedule(pubsub);
 phoneMask();
 customTimeSelect(pubsub);
-tripIndex();
+deleteModal();
+tripCard();

--- a/apps/concierge_site/assets/js/delete-modal.js
+++ b/apps/concierge_site/assets/js/delete-modal.js
@@ -7,6 +7,7 @@ export default $ => {
     const tripId = $(e.relatedTarget).data("trip-id");
     const token = $(e.relatedTarget).data("token");
     if (!tripId) {
+      // The confirmation button has already been set up in the _delete_modal partial
       return;
     }
 
@@ -23,33 +24,14 @@ export default $ => {
       );
   });
 
-  // make entire trip card clickable
-  $("div[data-trip-card='link']").on("click", function(e) {
-    // bail out if the delete modal link is clicked
-    const isModal = $(e.target).data("toggle") == "modal" ? true : false;
-    if (isModal) {
-      return;
-    }
-
-    const $targetEl = $(e.target);
-    const $parentEl = $($targetEl).parents("div[data-trip-card='link']");
-    const linkType = $parentEl.data("link-type");
-    const tripId = $parentEl.data("trip-id");
-    if (!tripId) {
-      return;
-    }
-    const urlBase = (linkType == "accessibility") ? "/accessibility_trips" : "/trips";
-    window.location = `${urlBase}/${tripId}/edit`;
-  });
-
   // make delete modal / links accessible
   $("a[data-toggle='modal']").on("keypress", triggerClick());
-};
 
-function triggerClick() {
-  return function (e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $(e.target).click();
-  };
-}
+  function triggerClick() {
+    return function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      $(e.target).click();
+    };
+  }
+};

--- a/apps/concierge_site/assets/js/trip-card.js
+++ b/apps/concierge_site/assets/js/trip-card.js
@@ -1,0 +1,22 @@
+export default $ => {
+  $ = $ || window.jQuery;
+
+  // make entire trip card clickable
+  $("div[data-trip-card='link']").on("click", function(e) {
+    // bail out if the delete modal link is clicked
+    const isModal = $(e.target).data("toggle") == "modal" ? true : false;
+    if (isModal) {
+      return;
+    }
+
+    const $targetEl = $(e.target);
+    const $parentEl = $($targetEl).parents("div[data-trip-card='link']");
+    const linkType = $parentEl.data("link-type");
+    const tripId = $parentEl.data("trip-id");
+    if (!tripId) {
+      return;
+    }
+    const urlBase = (linkType == "accessibility") ? "/accessibility_trips" : "/trips";
+    window.location = `${urlBase}/${tripId}/edit`;
+  });
+};

--- a/apps/concierge_site/lib/templates/v2/account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/account/edit.html.eex
@@ -50,4 +50,5 @@
     </div>
   </div>
 </div>
-<%= render ConciergeSite.V2.TripView, "_delete_modal.html", assigns %>
+
+<%= render ConciergeSite.V2.LayoutView, "_delete_modal.html", assigns %>

--- a/apps/concierge_site/lib/templates/v2/layout/_delete_modal.html.eex
+++ b/apps/concierge_site/lib/templates/v2/layout/_delete_modal.html.eex
@@ -3,11 +3,23 @@
     <div class="modal-content">
       <div class="modal-body text-center">
         <div class="my-2">
-          Are you sure you want to delete this subscription?
+          Are you sure you want to delete
+          <%= if assigns[:conn].request_path == "/account/edit" do %>
+            your account?
+          <% else %>
+            this subscription?
+          <% end %>
         </div>
         <div class="my-3" data-modal="action_container">
+          <%# Editing an individual trip %>
           <%= if assigns[:trip] do %>
             <%= link to: v2_trip_path(@conn, :delete, assigns[:trip]), method: :delete, class: "btn btn-primary" do %>
+              Yes, delete
+            <% end %>
+          <% end %>
+          <%# Editing an account %>
+          <%= if assigns[:conn].request_path == "/account/edit" do %>
+            <%= link to: v2_account_path(@conn, :delete), method: :delete, class: "btn btn-primary" do %>
               Yes, delete
             <% end %>
           <% end %>

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -41,25 +41,25 @@ first_trip_padding_class = if @trip.roundtrip == "true", do: "", else: "form__se
         </div>
 
         <%= if @trip.roundtrip do %>
-        <div class="form-group form__section">
-          <div class="form-group form-inline form__group--inline">
-            <%= label form, :return_start_time, "Return trip", class: "form__label--inline" %>
-            <div class="flatpickr-calendar-container">
-              <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_start_time), data: [type: "time"] %>
+          <div class="form-group form__section">
+            <div class="form-group form-inline form__group--inline">
+              <%= label form, :return_start_time, "Return trip", class: "form__label--inline" %>
+              <div class="flatpickr-calendar-container">
+                <%= text_input form, :return_start_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_start_time), data: [type: "time"] %>
+              </div>
+              <%= label form, :return_end_time, "until", class: "form__label--inline-divider" %>
+              <div class="flatpickr-calendar-container">
+                <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_end_time), data: [type: "time"] %>
+              </div>
             </div>
-            <%= label form, :return_end_time, "until", class: "form__label--inline-divider" %>
-            <div class="flatpickr-calendar-container">
-              <%= text_input form, :return_end_time, type: "text", class: "form-control form__time--inline", step: "60", required: true, value: ConciergeSite.TimeHelper.format_time(@trip.return_end_time), data: [type: "time"] %>
-            </div>
+            <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
           </div>
-          <%= ConciergeSite.ScheduleHelper.render(@return_schedules, "trip_return_start_time", "trip_return_end_time") %>
-        </div>
-      <% end %>
+        <% end %>
 
         <div class="form__action-buttons--container">
           <%= submit "Update subscription", class: "btn btn-primary btn-login btn-block" %>
           <button type="button" class="btn btn-outline-danger btn-block" data-toggle="modal" data-target="#deleteModal">
-          Delete this subscription
+            Delete this subscription
           </button>
         </div>
       <% end %>
@@ -67,4 +67,4 @@ first_trip_padding_class = if @trip.roundtrip == "true", do: "", else: "form__se
   </div>
 </div>
 
-<%= render ConciergeSite.V2.TripView, "_delete_modal.html", assigns %>
+<%= render ConciergeSite.V2.LayoutView, "_delete_modal.html", assigns %>

--- a/apps/concierge_site/lib/templates/v2/trip/index.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/index.html.eex
@@ -19,4 +19,4 @@
   </div>
 </div>
 
-<%= render ConciergeSite.V2.TripView, "_delete_modal.html", assigns %>
+<%= render ConciergeSite.V2.LayoutView, "_delete_modal.html", assigns %>


### PR DESCRIPTION
[Bug: Clicking "Delete my account" brings up a modal with only one button](https://app.asana.com/0/529741067494252/701031133452750)

Split trip-index JS file into trip-card and delete-modal.

Move delete modal partial into the layout directory - it is used for
account deletion in addition to trip deletion.