### PR TITLE
Ignore alerts without informed_entity

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -34,7 +34,9 @@ defmodule AlertProcessor.AlertParser do
 
   @spec remove_ignored([map]) :: [map]
   def remove_ignored(alerts) do
-    filter_invalid_key_value(alerts, "last_push_notification_timestamp")
+    alerts
+    |> filter_invalid_key_value("last_push_notification_timestamp")
+    |> filter_invalid_key_value("informed_entity")
   end
 
   @spec filter_invalid_key_value([map], String.t) :: [map]

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -229,7 +229,26 @@ defmodule AlertProcessor.AlertParserTest do
   end
 
   describe "remove_ignored/1" do
-    @valid_alert %{"active_period" => [%{"start" => 1507661322}], "last_push_notification_timestamp" => 1507661322}
+    @valid_alert %{
+      "active_period" => [%{"start" => 1507661322}],
+      "last_push_notification_timestamp" => 1507661322,
+      "informed_entity" => [
+        %{
+          "activities" => ["BOARD", "EXIT", "RIDE"],
+          "agency_id" => "1",
+          "route_id" => "Boat-F1",
+          "route_type" => 4,
+          "trip" => %{
+            "route_id" => "Boat-F1",
+            "trip_id" => "Boat-F1-1000-Hingham-Weekday"
+          }
+        }
+      ]
+    }
+
+    test "remove alert when informed_entity is not available"  do
+      assert AlertParser.remove_ignored([Map.delete(@valid_alert, "informed_entity")]) == []
+    end
 
     test "remove alert when last_push_notification_timestamp is not available"  do
       assert AlertParser.remove_ignored([Map.delete(@valid_alert, "last_push_notification_timestamp")]) == []


### PR DESCRIPTION
Why:

* On June 7, 2018 we noticed crashes on production related to an alert
that didn't contain an `informed_entity`. After investigating it was
apparent that this was a user error and we only want to process alerts
that do contain an `informed_entity`.
* Asana link: https://app.asana.com/0/529741067494252/705951109963539

This change addresses the need by:

* Editing `AlertParser` to ignore alerts without an `informed_entity`.