### PR TITLE
Fix text replacement bug (when hour is 12)

### DIFF
--- a/apps/alert_processor/lib/rules_engine/text_replacement.ex
+++ b/apps/alert_processor/lib/rules_engine/text_replacement.ex
@@ -104,10 +104,12 @@ defmodule AlertProcessor.TextReplacement do
       |> String.split(time_regex, trim: true)
       |> Enum.map(&String.to_integer/1)
 
-    if Regex.match?(~r/[pP][mM]/, time_with_ampm) do
-      Time.from_erl!({hour + 12, minute, 0})
-    else
-      Time.from_erl!({hour, minute, 0})
+    pm_match? = Regex.match?(~r/[pP][mM]/, time_with_ampm)
+
+    case {pm_match?, hour} do
+      {false, hour} when hour == 12 -> Time.from_erl!({0, minute, 0})
+      {true, hour} when hour < 12 -> Time.from_erl!({hour + 12, minute, 0})
+      _ -> Time.from_erl!({hour, minute, 0})
     end
   end
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
@@ -158,7 +158,7 @@ defmodule AlertProcessor.TextReplacementTest do
       assert TextReplacement.parse_target(fourth) == %{0 => {{"123", "Lowell", ~T[11:20:00]}, fourth}}
     end
 
-    test "parses time" do
+    test "parses time with different AM/PM combinations" do
       first = "Lowell line 12 (11:20am from Lowell)"
       second = "Lowell line 12 (11:20 AM from Lowell)"
       third = "Lowell line 12 (11:20 PM from Lowell)"
@@ -168,6 +168,42 @@ defmodule AlertProcessor.TextReplacementTest do
       assert TextReplacement.parse_target(second) == %{0 => {{"12", "Lowell", ~T[11:20:00]}, second}}
       assert TextReplacement.parse_target(third) == %{0 => {{"12", "Lowell", ~T[23:20:00]}, third}}
       assert TextReplacement.parse_target(fourth) == %{0 => {{"12", "Lowell", ~T[23:20:00]}, fourth}}
+    end
+
+    test "parses time for all hours of the day" do
+      expected = %{
+        "12:00am" => ~T[00:00:00],
+        "1:00am" => ~T[01:00:00],
+        "2:00am" => ~T[02:00:00],
+        "3:00am" => ~T[03:00:00],
+        "4:00am" => ~T[04:00:00],
+        "5:00am" => ~T[05:00:00],
+        "6:00am" => ~T[06:00:00],
+        "7:00am" => ~T[07:00:00],
+        "8:00am" => ~T[08:00:00],
+        "9:00am" => ~T[09:00:00],
+        "10:00am" => ~T[10:00:00],
+        "11:00am" => ~T[11:00:00],
+        "12:00pm" => ~T[12:00:00],
+        "1:00pm" => ~T[13:00:00],
+        "2:00pm" => ~T[14:00:00],
+        "3:00pm" => ~T[15:00:00],
+        "4:00pm" => ~T[16:00:00],
+        "5:00pm" => ~T[17:00:00],
+        "6:00pm" => ~T[18:00:00],
+        "7:00pm" => ~T[19:00:00],
+        "8:00pm" => ~T[20:00:00],
+        "9:00pm" => ~T[21:00:00],
+        "10:00pm" => ~T[22:00:00],
+        "11:00pm" => ~T[23:00:00],
+      }
+
+      for hour <- 1..12, am_pm <- ["am", "pm"] do
+        time = "#{hour}:00#{am_pm}"
+        text = "Lowell line 12 (#{time} from Lowell)"
+        %{0 => {{_, _, time_result}, _}} = TextReplacement.parse_target(text)
+        assert time_result == Map.get(expected, time)
+      end
     end
 
     test "parse station" do


### PR DESCRIPTION
Why:

* While we were looking into a reported bug about the text replacement
feature not working on SMS, we found a bug in the `TextReplacement`
module that caused it to crash. The bug was that with a time of 12pm,
the logic incorrectly parses it as hour 24. Similarly with a time
of 12am, the logic in place incorrectly parses it as hour 12. For 12pm,
we should parse it as hour 12 and for 12am we should parse it as hour 0.
* Asana link: https://app.asana.com/0/529741067494252/706446575079957

This change addresses the need by:

* Editing `TextReplacement.parse_time/1` to parse 12pm as hour 12, and
12am as hour 0.