### PR TITLE
Edit replace_text/2 to replace ok/error tuple

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -3,11 +3,26 @@ defmodule AlertProcessor.NotificationBuilder do
   Responsible for construction of Notifications from an Alert and Subscription
   """
 
+  require Logger
   alias AlertProcessor.TextReplacement
   alias AlertProcessor.Model.Notification
 
   def build_notification({user, subscriptions}, alert) do
-    alert = TextReplacement.replace_text(alert, subscriptions)
+    alert_text_replaced = replace_text(alert, subscriptions)
+    do_build_notification({user, subscriptions}, alert_text_replaced)
+  end
+
+  defp replace_text(alert, subscriptions) do
+    case TextReplacement.replace_text(alert, subscriptions) do
+      {:ok, modified_alert} ->
+        modified_alert
+      {:error, error} ->
+        Logger.warn(fn -> "Error replacing text: alert_id=#{inspect alert.id} error=#{inspect error}" end)
+        alert
+    end
+  end
+
+  defp do_build_notification({user, subscriptions}, alert) do
     %Notification{
       alert_id: alert.id,
       user: user,

--- a/apps/alert_processor/lib/rules_engine/text_replacement.ex
+++ b/apps/alert_processor/lib/rules_engine/text_replacement.ex
@@ -5,6 +5,15 @@ defmodule AlertProcessor.TextReplacement do
   alias Calendar.Strftime
 
   def replace_text(alert, subscriptions) do
+    try do
+      {:ok, replace_text!(alert, subscriptions)}
+    rescue
+      error ->
+        {:error, error}
+    end
+  end
+
+  def replace_text!(alert, subscriptions) do
     if Alert.commuter_rail_alert?(alert) do
       {stop_schedules, trip_schedules} = build_schedule_mapping(alert.informed_entities)
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
@@ -11,7 +11,7 @@ defmodule AlertProcessor.TextReplacementTest do
     {:ok, user: user}
   end
 
-  describe "replace_text/2" do
+  describe "replace_text!/2" do
     test "returns default text if not commuter rail subscription" do
       alert = %Alert{
         header: "test",
@@ -20,7 +20,7 @@ defmodule AlertProcessor.TextReplacementTest do
       }
       subscription = %Subscription{}
 
-      assert TextReplacement.replace_text(alert, [subscription]) == alert
+      assert TextReplacement.replace_text!(alert, [subscription]) == alert
     end
 
     test "if user doesn't have matching subscription, return original text", %{user: user} do
@@ -34,7 +34,7 @@ defmodule AlertProcessor.TextReplacementTest do
         informed_entities: commuter_rail_subscription_entities()
       }
 
-      assert TextReplacement.replace_text(alert, [sub]) == alert
+      assert TextReplacement.replace_text!(alert, [sub]) == alert
     end
 
     test "if subscription matches alert, and user has different origin station, replace text" do
@@ -85,7 +85,7 @@ defmodule AlertProcessor.TextReplacementTest do
         description: "Affected trips: Newburyport Train 180 (22:17 pm from Chelsea)"
       }
 
-      assert TextReplacement.replace_text(alert, [sub]) == Map.merge(alert, expected)
+      assert TextReplacement.replace_text!(alert, [sub]) == Map.merge(alert, expected)
     end
 
     test "if subscription matches alert and the origin station's id differs from its name, replace text" do
@@ -136,7 +136,26 @@ defmodule AlertProcessor.TextReplacementTest do
         description: "Affected trips: Fairmount Train 752 (22:17 pm from Four Corners/Geneva)"
       }
 
-      assert TextReplacement.replace_text(alert, [sub]) == Map.merge(alert, expected)
+      assert TextReplacement.replace_text!(alert, [sub]) == Map.merge(alert, expected)
+    end
+  end
+
+  describe "replace_text/2" do
+    test "returns :ok tuple with no errors" do
+      alert = %Alert{}
+      subscription = %Subscription{}
+
+      assert {:ok, ^alert} = TextReplacement.replace_text(alert, [subscription])
+    end
+
+    test "returns :error tuple with invalid hour" do
+      alert = %Alert{
+        header: "Newburyport Train 180 (25:25 pm from Newburyport)",
+        informed_entities: [%InformedEntity{route_type: 2}],
+      }
+      subscription = %Subscription{}
+
+      assert {:error, _} = TextReplacement.replace_text(alert, [subscription])
     end
   end
 


### PR DESCRIPTION
Why:

* Moving forward we want to make sure we don't error out (blow up) and
cause no notifications to be sent out if the `TextReplacement` module
encounters an error for some reason.
* Asana link: https://app.asana.com/0/529741067494252/707721440108567

This change addresses the need by:

* Edit `TextReplacement.replace_text/2` to return an ok/error tuple.
* Edit `NotificationBuilder.build_notification/2` to account for the
change mentioned above and to log a warning if it can't replace the text
for an alert.