### PR TITLE
Display the elevator and escalator icons below the copy on mobile

### DIFF
--- a/apps/concierge_site/assets/css/v2/_callout.scss
+++ b/apps/concierge_site/assets/css/v2/_callout.scss
@@ -16,6 +16,10 @@
 .callout__content-container {
   display: flex;
   flex-direction: row;
+
+  @media screen and (max-width: 1087px) {
+    flex-direction: column;
+  }
 }
 
 .callout__icons {


### PR DESCRIPTION
Why:
• Currently, when this gray callout box on the initial subscription
builder page is at mobile sizes, the text and icons don't play nicely
with each other.
• Asana ticket: https://app.asana.com/0/529741067494252/711806338554811