### PR TITLE
Fix trip card destination for round trips

### DIFF
--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -123,7 +123,7 @@ defmodule ConciergeSite.TripCardHelper do
   @spec stops([Subscription.t]) :: Phoenix.HTML.safe
   defp stops(subscriptions) do
     origin = List.first(subscriptions).origin
-    destination = List.last(subscriptions).destination
+    destination = List.first(subscriptions).destination
 
     content_tag :span, class: "trip__card--stops" do
       case {origin, destination} do


### PR DESCRIPTION
Why:
• Stops show up correctly in trip card in 'My subscriptions' list but
incorrectly within the 'Edit' view.
• When a trip contains multiple subscriptions, the destination of the
last leg is the same as the origin of the first.
• Asana ticket: https://app.asana.com/0/529741067494252/706446575079953