### PR TITLE
Add focus to success and error flash banners

### DIFF
--- a/apps/concierge_site/assets/js/app.js
+++ b/apps/concierge_site/assets/js/app.js
@@ -32,6 +32,7 @@ import phoneMask from "./phone-mask";
 import customTimeSelect from "./custom-time-select";
 import deleteModal from "./delete-modal";
 import tripCard from "./trip-card";
+import flashFocus from "./flash-focus";
 import pubsubFactory from "PubSub";
 const pubsub = new pubsubFactory();
 
@@ -47,3 +48,4 @@ phoneMask();
 customTimeSelect(pubsub);
 deleteModal();
 tripCard();
+flashFocus();

--- a/apps/concierge_site/assets/js/flash-focus.js
+++ b/apps/concierge_site/assets/js/flash-focus.js
@@ -1,0 +1,7 @@
+export default $ => {
+  $ = $ || window.jQuery;
+
+  // Focus flash banners
+  $(".alert.alert-success").focus();
+  $(".error-block-container").focus();
+};

--- a/apps/concierge_site/lib/views/flash_helpers.ex
+++ b/apps/concierge_site/lib/views/flash_helpers.ex
@@ -11,7 +11,7 @@ defmodule ConciergeSite.FlashHelpers do
   """
   def flash_error(conn) do
     if error = get_flash(conn, :error) do
-      content_tag :div, class: "error-block-container" do
+      content_tag :div, class: "error-block-container", tabindex: "0" do
         content_tag :span, error, class: "error-block text-center"
       end
     end
@@ -22,7 +22,7 @@ defmodule ConciergeSite.FlashHelpers do
   """
   def flash_info(conn) do
     if info = get_flash(conn, :info) do
-      content_tag :div, info, class: "alert alert-success text-center"
+      content_tag :div, info, class: "alert alert-success text-center", tabindex: "0"
     end
   end
 end


### PR DESCRIPTION
Why:
• To add focus to banners for screen reader accessibility.
• Asana ticket: https://app.asana.com/0/529741067494252/693372799954560/f