### PR TITLE
Darken button text color when hovered

### DIFF
--- a/apps/concierge_site/assets/css/app_v2.scss
+++ b/apps/concierge_site/assets/css/app_v2.scss
@@ -60,12 +60,25 @@ body {
 
   &:hover {
     background-color: $light-blue;
+    color: $gray-dark;
   }
 
   &.active, &:active {
     background-color: $light-blue !important;
     border-color: $brand-primary !important;
     color: $gray-dark !important;
+
+    div {
+      color: $gray-dark;
+    }
+
+    &[data-id="roundtrip"],
+    &[data-id="oneway"] {
+      path {
+        fill: $gray-dark;
+        mask: none;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Why:
• Currently our hover state for various buttons within the application
is a light blue, with the font color within remaining as is. Although
the current behavior technically meets accessibility standards, IHCD has
suggested changing the font color to black upon hover (this mimics what
the website does as well).
• Asana ticket: https://app.asana.com/0/529741067494252/709448677329001