### PR TITLE
Unnecessary call in NotificationWindowFilter

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -22,7 +22,7 @@ defmodule AlertProcessor.NotificationWindowFilter do
 
   """
   @spec filter([Subscription.t], DateTime.t) :: [Subscription.t]
-  def filter(subscriptions, now \\ Calendar.DateTime.now!("America/New_York")) do
+  def filter(subscriptions, now) do
     Enum.filter(subscriptions, fn(subscription) ->
       within_notification_window?(subscription, now)
     end)

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -45,7 +45,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
       SentAlertFilter.filter(subscriptions, alert, notifications, now)
 
     subscriptions_to_test
-    |> @notification_window_filter.filter()
+    |> @notification_window_filter.filter(now)
     |> InformedEntityFilter.filter(alert: alert)
     |> ActivePeriodFilter.filter(alert: alert)
     |> Kernel.++(subscriptions_to_auto_resend)

--- a/apps/alert_processor/test/support/mocks/notification_window_filter_mock.ex
+++ b/apps/alert_processor/test/support/mocks/notification_window_filter_mock.ex
@@ -1,5 +1,5 @@
 defmodule AlertProcessor.NotificationWindowFilterMock do
   @moduledoc false
 
-  def filter(subscriptions), do: subscriptions
+  def filter(subscriptions, _now), do: subscriptions
 end


### PR DESCRIPTION
Why:

* To improve matching time. Not a huge deal, but this also makes it
easier to "freeze" time when load testing.
* Asana link: https://app.asana.com/0/529741067494252/714677169100846

This change addresses the need by:

* Editing `SubscriptionFilterEngine.determine_recipients/4` to pass the
current datetime to the `@notification_window_filter`
(`NotificationWindowFilter`)
* Editing `NotificationWindowFilter.filter/2` to not call
`Calendar.DateTime.now!("America/New_York")` and require a current
datetime as the second argument. Before, the second argument was
optional.
* Editing `NotificationWindowFilterMock` to account for the changes
above.