### PR TITLE
Add reminders functionality

### DIFF
--- a/apps/alert_processor/lib/dissemination/sending_queue.ex
+++ b/apps/alert_processor/lib/dissemination/sending_queue.ex
@@ -37,6 +37,16 @@ defmodule AlertProcessor.SendingQueue do
     GenServer.call(name, :pop)
   end
 
+  @doc """
+  Resets state to an empty list.
+
+  For use in tests only.
+  """
+  @spec reset() :: :ok
+  def reset(name \\ __MODULE__) do
+    GenServer.call(name, :reset)
+  end
+
   @doc false
   def handle_call({:list_push, new_notifications}, _from, notifications) do
     newstate = new_notifications ++ notifications
@@ -56,6 +66,11 @@ defmodule AlertProcessor.SendingQueue do
   def handle_call({:push, notification}, _from, notifications) do
     newstate = [notification | notifications]
     {:reply, :ok, Enum.uniq(newstate)}
+  end
+
+  @doc false
+  def handle_call(:reset, _from, _notifications) do
+    {:reply, :ok, []}
   end
 
   @doc false

--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -6,7 +6,8 @@ defmodule AlertProcessor.Model.Alert do
 
   defstruct [:active_period, :effect_name, :id, :header, :informed_entities,
              :severity, :last_push_notification, :service_effect, :description, :url,
-             :timeframe, :recurrence, :duration_certainty, :created_at, :closed_timestamp]
+             :timeframe, :recurrence, :duration_certainty, :created_at, :closed_timestamp,
+             :reminder_times]
 
   @type informed_entity :: [
     %{
@@ -34,7 +35,8 @@ defmodule AlertProcessor.Model.Alert do
     recurrence: String.t,
     duration_certainty: {:estimated, pos_integer} | :known,
     created_at: DateTime.t,
-    closed_timestamp: DateTime.t | nil
+    closed_timestamp: DateTime.t | nil,
+    reminder_times: [DateTime.t] | nil
   }
 
   @route_types %{

--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -103,4 +103,18 @@ defmodule AlertProcessor.Model.Notification do
       select: n
     )
   end
+
+  def most_recent_for_alerts(alerts) do
+    alert_ids = Enum.map(alerts, &(&1.id))
+
+    Repo.all(
+      from n in __MODULE__,
+      where: n.alert_id in ^alert_ids,
+      where: n.status == "sent",
+      preload: [subscriptions: :user],
+      distinct: [:alert_id, :user_id],
+      order_by: [desc: n.inserted_at],
+      select: n
+    )
+  end
 end

--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -61,6 +61,8 @@ defmodule AlertProcessor.Model.Subscription do
     belongs_to :user, User, type: :binary_id
     belongs_to :trip, Trip, type: :binary_id
     has_many :informed_entities, InformedEntity
+    has_many :notification_subscriptions, AlertProcessor.Model.NotificationSubscription
+    has_many :notifications, through: [:notification_subscriptions, :notification]
     field :alert_priority_type, AlertProcessor.AtomType
     field :relevant_days, {:array, AlertProcessor.AtomType}
     field :start_time, :time, null: false

--- a/apps/alert_processor/lib/reminders/processor/processor.ex
+++ b/apps/alert_processor/lib/reminders/processor/processor.ex
@@ -1,0 +1,56 @@
+defmodule AlertProcessor.Reminders.Processor do
+  @moduledoc """
+  Responsible for processing reminders for a list of alerts.
+
+  """
+
+  alias AlertProcessor.Reminders.Processor.SubscriptionsToRemind
+  alias AlertProcessor.Model.{
+    Alert,
+    Notification
+  }
+  alias AlertProcessor.{
+    SendingQueue,
+    NotificationBuilder
+  }
+
+  @doc """
+  Schedules reminders due for a given list of alerts.
+
+  It schedules reminders by following these steps:
+
+  1. Getting the latest notifications for the given alerts
+  2. Determining which of the notifications are due for a reminder
+  3. Building reminder notifications
+  4. Scheduling/enqueueing reminder notifications
+
+  """
+  @spec process_alerts([Alert.t()], DateTime.t()) :: :ok
+  def process_alerts(alerts, now \\ Calendar.DateTime.now!("America/New_York")) do
+    latest_notifications = Notification.most_recent_for_alerts(alerts)
+    for alert <- alerts do
+      relevant_notifications = relevant_notifications(latest_notifications, alert)
+      {alert, relevant_notifications, now}
+      |> SubscriptionsToRemind.perform()
+      |> build_notifications(alert)
+      |> schedule_notifications()
+    end
+
+    :ok
+  end
+
+  defp relevant_notifications(notifications, alert) do
+    Enum.filter(notifications, & &1.alert_id == alert.id)
+  end
+
+  defp build_notifications(subscriptions, alert) do
+    subscriptions
+    |> Enum.group_by(& &1.user)
+    |> Map.to_list()
+    |> Enum.map(& NotificationBuilder.build_notification(&1, alert))
+  end
+
+  defp schedule_notifications(notifications) do
+    SendingQueue.list_enqueue(notifications)
+  end
+end

--- a/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
+++ b/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
@@ -1,0 +1,60 @@
+defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemind do
+  @moduledoc """
+  Responsible for determining which subscriptions should be sent a reminder for
+  a given alert and list of most recently sent notifications.
+
+  """
+
+  alias AlertProcessor.NotificationWindowFilter
+  alias AlertProcessor.Model.{Alert, Subscription, Notification}
+
+  @doc """
+  Accepts an alert and a list of the latest sent notifications for the given
+  alert.
+
+  A note on notifications:
+
+  The notifications passed in as the third argument are expected to be unique
+  per user, relevant to the alert in the first argument, and the latest one
+  inserted to the DB (according to it's `inserted_at` value).
+
+  """
+  @spec perform({Alert.t(), [Notification.t()], DateTime.t()}) :: [Subscription.t()]
+  def perform({alert, notifications, now}) do
+    subscriptions_to_send_reminder(alert, notifications, now)
+  end
+
+  def subscriptions_to_send_reminder(%Alert{reminder_times: nil}, _, _), do: []
+
+  def subscriptions_to_send_reminder(%Alert{reminder_times: []}, _, _), do: []
+
+  def subscriptions_to_send_reminder(alert, notifications, now) do
+    Enum.reduce(notifications, [], fn notification, subscriptions_to_remind ->
+      if reminder_due?(notification, alert, now) do
+        notification.subscriptions
+        |> Enum.filter(&NotificationWindowFilter.within_notification_window?(&1, now))
+        |> Enum.concat(subscriptions_to_remind)
+      else
+        subscriptions_to_remind
+      end
+    end)
+  end
+
+  defp reminder_due?(notification, alert, now) do
+    inserted_at = notification.inserted_at
+
+    Enum.any?(alert.reminder_times, fn reminder_time ->
+      reminder_time_earlier_than_now?(reminder_time, now) &&
+        reminder_time_later_than_inserted_at?(reminder_time, inserted_at)
+    end)
+  end
+
+  defp reminder_time_earlier_than_now?(reminder_time, now) do
+    DateTime.compare(reminder_time, now) == :lt
+  end
+
+  defp reminder_time_later_than_inserted_at?(reminder_time, inserted_at) do
+    inserted_at = DateTime.from_naive!(inserted_at, "Etc/UTC")
+    DateTime.compare(reminder_time, inserted_at) == :gt
+  end
+end

--- a/apps/alert_processor/lib/reminders/reminders.ex
+++ b/apps/alert_processor/lib/reminders/reminders.ex
@@ -1,0 +1,36 @@
+defmodule AlertProcessor.Reminders do
+  @moduledoc """
+  Responsible for scheduling reminders.
+  """
+
+  use GenServer
+  alias __MODULE__
+  alias AlertProcessor.Model.Alert
+
+  def start_link(opts \\ [name: __MODULE__]) do
+    GenServer.start_link(__MODULE__, nil, opts)
+  end
+
+  @spec async_schedule_reminders([Alert.t]) :: :ok
+  def async_schedule_reminders(pid \\ __MODULE__, alerts) do
+    GenServer.cast(pid, {:schedule_reminders, alerts})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{updated_at: DateTime.utc_now()}}
+  end
+
+  @impl true
+  def handle_cast({:schedule_reminders, alerts}, state) do
+    difference = DateTime.diff(DateTime.utc_now(), state.updated_at, :millisecond)
+    new_updated_at =
+      if abs(difference) > :timer.minutes(5) do
+        Reminders.Processor.process_alerts(alerts)
+        DateTime.utc_now()
+      else
+        state.updated_at
+      end
+    {:noreply, Map.put(state, :updated_at, new_updated_at)}
+  end
+end

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -12,7 +12,8 @@ defmodule AlertProcessor.Supervisor do
     NotificationWorker,
     ServiceInfoCache,
     SmsOptOutWorker,
-    Metrics
+    Metrics,
+    Reminders
   }
 
   @worker_pool_size Application.get_env(:alert_processor, :pool_size)
@@ -47,6 +48,7 @@ defmodule AlertProcessor.Supervisor do
       ),
       worker(ServiceInfoCache, []),
       worker(Metrics, []),
+      worker(Reminders, []),
       worker(AlertWorker, []),
       worker(SendingQueue, []),
       worker(SmsOptOutWorker, []),

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -388,5 +388,42 @@ defmodule AlertProcessor.AlertParserTest do
         } = schedule
       end
     end
+
+    test "with reminder_times" do
+      some_timestamp = 1524609934
+      reminder_times = [1515166200, 1515408300]
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp,
+        "reminder_times" => reminder_times
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      expected_reminder_times = Enum.map(reminder_times, & DateTime.from_unix!(&1))
+      assert parsed_alert.reminder_times == expected_reminder_times
+    end
+
+    test "without reminder_times" do
+      some_timestamp = 1524609934
+      alert = %{
+        "id" => "some id",
+        "created_timestamp" => some_timestamp,
+        "duration_certainty" => nil,
+        "effect_detail" => "some_effect",
+        "header_text" => nil,
+        "informed_entity" => [],
+        "service_effect_text" => nil,
+        "severity" => nil,
+        "last_push_notification_timestamp" => some_timestamp,
+      }
+      parsed_alert = AlertParser.parse_alert(alert, %{}, nil)
+      assert parsed_alert.reminder_times == []
+    end
   end
 end

--- a/apps/alert_processor/test/alert_processor/reminders/processor/processor_test.exs
+++ b/apps/alert_processor/test/alert_processor/reminders/processor/processor_test.exs
@@ -1,0 +1,95 @@
+defmodule AlertProcessor.Reminders.ProcessorTest do
+  use AlertProcessor.DataCase
+  use Bamboo.Test
+  import AlertProcessor.Factory
+  alias AlertProcessor.Reminders.Processor
+  alias AlertProcessor.Model.Alert
+  alias AlertProcessor.SendingQueue
+
+  setup do
+    :ok = SendingQueue.reset()
+    :ok
+  end
+
+  describe "process_alerts/2" do
+    test "if reminder due" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_9_at_7_45am = DateTime.from_naive!(~N[2018-04-09 07:45:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am]
+      }
+      notification_details = %{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+      notification = insert(:notification, notification_details)
+      insert(:notification_subscription, notification: notification, subscription: subscription)
+
+      Processor.process_alerts([alert], monday_april_9_at_7_45am)
+
+      assert {:ok, notification} = SendingQueue.pop()
+      [target_subscription_id] =
+        Enum.map(notification.notification_subscriptions, & &1.subscription_id)
+      assert target_subscription_id == subscription.id
+      # SendingQueue.pop/0 returns :error when empty
+      assert :error = SendingQueue.pop()
+    end
+
+    test "if reminder not due yet" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      user = insert(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = insert(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_16_at_7_30am]
+      }
+      notification_details = %{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+      notification = insert(:notification, notification_details)
+      insert(:notification_subscription, notification: notification, subscription: subscription)
+
+      Processor.process_alerts([alert], monday_april_9_at_7_30am)
+
+      # SendingQueue.pop/0 returns :error when empty
+      assert :error = SendingQueue.pop()
+    end
+  end
+end

--- a/apps/alert_processor/test/alert_processor/reminders/processor/subscriptions_to_remind_test.exs
+++ b/apps/alert_processor/test/alert_processor/reminders/processor/subscriptions_to_remind_test.exs
@@ -1,0 +1,227 @@
+defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemindTest do
+  use AlertProcessor.DataCase
+  import AlertProcessor.Factory
+  alias AlertProcessor.Reminders.Processor.SubscriptionsToRemind
+  alias AlertProcessor.Model.{Alert, Notification}
+
+  describe "perform/1" do
+    test "if reminder due" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_9_at_7_45am = DateTime.from_naive!(~N[2018-04-09 07:45:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert [subscription_to_remind] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_7_45am})
+      assert subscription_to_remind.id == subscription.id
+    end
+
+    test "if a second reminder is due" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      tuesday_april_10_at_1pm = DateTime.from_naive!(~N[2018-04-10 13:00:00], "Etc/UTC")
+      monday_april_16_at_7_01am = DateTime.from_naive!(~N[2018-04-16 07:01:00], "Etc/UTC")
+      tuesday_april_17_at_1pm = DateTime.from_naive!(~N[2018-04-17 13:00:00], "Etc/UTC")
+      monday_april_23_at_7_01am = DateTime.from_naive!(~N[2018-04-23 07:01:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [tuesday_april_10_at_1pm, tuesday_april_17_at_1pm]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_16_at_7_01am),
+      }
+
+      assert [subscription_to_remind] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_23_at_7_01am})
+      assert subscription_to_remind.id == subscription.id
+    end
+
+    test "if reminder not due yet" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_16_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert [] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_7_30am})
+    end
+
+    test "if reminder not due yet and multiple reminder times" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      monday_april_23_at_7_30am = DateTime.from_naive!(~N[2018-04-23 07:30:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am, monday_april_23_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_9_at_7_30am),
+      }
+
+      assert [] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_16_at_7_30am})
+    end
+
+    test "with two reminders that were already sent" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_16_at_7_30am = DateTime.from_naive!(~N[2018-04-16 07:30:00], "Etc/UTC")
+      monday_april_23_at_7_30am = DateTime.from_naive!(~N[2018-04-23 07:30:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am, monday_april_16_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_16_at_7_30am),
+      }
+
+      # Note that the second argument is expected to include the latest known
+      # sent notification for a user/alert combination.
+      assert [] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_23_at_7_30am})
+    end
+
+    test "reminders are sent within notification window only" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      friday_april_6_at_1pm = DateTime.from_naive!(~N[2018-04-06 13:00:00], "Etc/UTC")
+      friday_april_6_at_2pm = DateTime.from_naive!(~N[2018-04-06 14:00:00], "Etc/UTC")
+      monday_april_9_at_6am = DateTime.from_naive!(~N[2018-04-09 06:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [friday_april_6_at_1pm]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert [] =
+        SubscriptionsToRemind.perform({alert, [notification], friday_april_6_at_2pm})
+      assert [] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_6am})
+      assert [returned_subscription] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_7_30am})
+      assert returned_subscription.id == subscription.id
+    end
+  end
+end

--- a/apps/alert_processor/test/support/factory.ex
+++ b/apps/alert_processor/test/support/factory.ex
@@ -2,7 +2,7 @@ defmodule AlertProcessor.Factory do
   @moduledoc false
   use ExMachina.Ecto, repo: AlertProcessor.Repo
 
-  alias AlertProcessor.Model.{InformedEntity, Notification, Subscription, User, PasswordReset, Trip}
+  alias AlertProcessor.Model.{InformedEntity, Notification, Subscription, User, PasswordReset, Trip, NotificationSubscription}
   alias Calendar.DateTime
 
   def informed_entity_factory do
@@ -191,5 +191,9 @@ defmodule AlertProcessor.Factory do
       facility_types: [:elevator],
       user: build(:user)
     }
+  end
+
+  def notification_subscription_factory do
+    %NotificationSubscription{}
   end
 end


### PR DESCRIPTION
Why:

* To notify users of reminders as indicated by the alerts feed.
* Asana link: https://app.asana.com/0/529741067494252/656261816861041

This change addresses the need by:

* Editing `AlertParser` to parse reminder times.
* Creating `Reminders` process. This process is responsible for
scheduling reminders for a given list of alerts.
* Adding `Reminders` to `AlertProcessor.Supervisor`.
* Adding `most_recent_for_alerts/1` to `Notification` model, which is
used by the `Reminders.Processor`.
* Other minor changes related to getting the `Reminders` process and
related modules to work.