### PR TITLE
Adds reminder and update prefix to email subjects

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_smser.ex
+++ b/apps/alert_processor/lib/dissemination/notification_smser.ex
@@ -8,14 +8,15 @@ defmodule AlertProcessor.NotificationSmser do
 
   @doc "notification_sms/1 takes the notification to be sent via sms."
   @spec notification_sms(Notification.t) :: ExAws.Operation.Query.t
-  def notification_sms(%Notification{header: header, closed_timestamp: nil, phone_number: phone_number}) do
-    ExAws.SNS.publish(header, [phone_number: "+1#{phone_number}"])
-  end
-  def notification_sms(%Notification{header: header, phone_number: phone_number}) do
-    ExAws.SNS.publish(closed_text(header), [phone_number: "+1#{phone_number}"])
+  def notification_sms(%Notification{header: header, type: type, phone_number: phone_number}) do
+    header
+    |> add_type_prefix(type)
+    |> ExAws.SNS.publish([phone_number: "+1#{phone_number}"])
   end
 
-  defp closed_text(text) do
+  defp add_type_prefix(text, :all_clear) do
     "All clear (re: #{text})"
   end
+
+  defp add_type_prefix(text, _), do: text
 end

--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -5,6 +5,8 @@ defmodule AlertProcessor.Model.Notification do
 
   alias AlertProcessor.Model.{Alert, User}
 
+  @type notification_type :: :initial | :update | :reminder | :all_clear
+
   @type t :: %__MODULE__{
     alert_id: String.t | nil,
     user_id: String.t | nil,
@@ -18,7 +20,8 @@ defmodule AlertProcessor.Model.Notification do
     status: atom,
     last_push_notification: DateTime.t | nil,
     alert: Alert.t | nil,
-    closed_timestamp: DateTime.t | nil
+    closed_timestamp: DateTime.t | nil,
+    type: notification_type | nil
  }
 
   use Ecto.Schema
@@ -44,6 +47,7 @@ defmodule AlertProcessor.Model.Notification do
     field :last_push_notification, :utc_datetime
     field :alert, :string, virtual: true
     field :closed_timestamp, :utc_datetime
+    field :type, AlertProcessor.AtomType
 
     timestamps()
   end

--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -80,6 +80,7 @@ defmodule AlertProcessor.Model.Subscription do
     field :rank, :integer
     field :return_trip, :boolean
     field :facility_types, {:array, AlertProcessor.AtomType}
+    field :notification_type_to_send, AlertProcessor.AtomType, virtual: true
 
     timestamps()
   end

--- a/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
+++ b/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
@@ -33,6 +33,7 @@ defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemind do
       if reminder_due?(notification, alert, now) do
         notification.subscriptions
         |> Enum.filter(&NotificationWindowFilter.within_notification_window?(&1, now))
+        |> put_notification_type_to_send()
         |> Enum.concat(subscriptions_to_remind)
       else
         subscriptions_to_remind
@@ -56,5 +57,11 @@ defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemind do
   defp reminder_time_later_than_inserted_at?(reminder_time, inserted_at) do
     inserted_at = DateTime.from_naive!(inserted_at, "Etc/UTC")
     DateTime.compare(reminder_time, inserted_at) == :gt
+  end
+
+  defp put_notification_type_to_send(subscriptions) do
+    Enum.map(subscriptions, fn subscription ->
+      Map.put(subscription, :notification_type_to_send, :reminder)
+    end)
   end
 end

--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -37,7 +37,8 @@ defmodule AlertProcessor.NotificationBuilder do
       last_push_notification: alert.last_push_notification,
       alert: alert,
       notification_subscriptions: Enum.map(subscriptions, & %AlertProcessor.Model.NotificationSubscription{subscription_id: &1.id}),
-      closed_timestamp: alert.closed_timestamp
+      closed_timestamp: alert.closed_timestamp,
+      type: List.first(subscriptions).notification_type_to_send || :initial
     }
   end
 end

--- a/apps/alert_processor/priv/repo/migrations/20180627190847_add_type_to_notifications.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180627190847_add_type_to_notifications.exs
@@ -1,0 +1,9 @@
+defmodule AlertProcessor.Repo.Migrations.AddTypeToNotifications do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      add :type, :string
+    end
+  end
+end

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_smser_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_smser_test.exs
@@ -27,7 +27,8 @@ defmodule AlertProcessor.NotificationSmserTest do
       header: @message,
       email: nil,
       phone_number: @phone_number,
-      closed_timestamp: DateTime.utc_now()
+      closed_timestamp: DateTime.utc_now(),
+      type: :all_clear
     }
 
     sms_operation = NotificationSmser.notification_sms(notification)

--- a/apps/alert_processor/test/alert_processor/reminders/processor/subscriptions_to_remind_test.exs
+++ b/apps/alert_processor/test/alert_processor/reminders/processor/subscriptions_to_remind_test.exs
@@ -223,5 +223,41 @@ defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemindTest do
         SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_7_30am})
       assert returned_subscription.id == subscription.id
     end
+
+    test "adds `:notification_type_to_send` of `:reminder` to returned subscriptions" do
+      monday_april_2_at_8am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
+      monday_april_9_at_7_30am = DateTime.from_naive!(~N[2018-04-09 07:30:00], "Etc/UTC")
+      monday_april_9_at_7_45am = DateTime.from_naive!(~N[2018-04-09 07:45:00], "Etc/UTC")
+      user = build(:user)
+      subscription_details = %{
+        user: user,
+        start_time: ~T[07:00:00],
+        end_time: ~T[08:00:00],
+        relevant_days: [:monday]
+      }
+      subscription = build(:subscription, subscription_details)
+      alert = %Alert{
+        id: "123",
+        last_push_notification: monday_april_2_at_8am,
+        reminder_times: [monday_april_9_at_7_30am]
+      }
+      notification = %Notification{
+        alert_id: "123",
+        user_id: user.id,
+        email: "a@b.com",
+        header: "You are being notified",
+        service_effect: "test",
+        description: "test",
+        status: :sent,
+        last_push_notification: monday_april_2_at_8am,
+        subscriptions: [subscription],
+        inserted_at: DateTime.to_naive(monday_april_2_at_8am),
+      }
+
+      assert [subscription_to_remind] =
+        SubscriptionsToRemind.perform({alert, [notification], monday_april_9_at_7_45am})
+      assert subscription_to_remind.id == subscription.id
+      assert subscription_to_remind.notification_type_to_send == :reminder
+    end
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -60,7 +60,8 @@ defmodule AlertProcessor.NotificationBuilderTest do
       notification_subscriptions: [%AlertProcessor.Model.NotificationSubscription{
         subscription_id: sub.id
       }],
-      closed_timestamp: alert.closed_timestamp
+      closed_timestamp: alert.closed_timestamp,
+      type: :initial
     }
 
     assert expected_notification == notification

--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -65,8 +65,14 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
     {notification, "#{subject} #{recurrence}"}
   end
 
-  defp subject_closed({%Notification{closed_timestamp: nil}, _} = pair), do: pair
-  defp subject_closed({notification, subject}) do
+  defp subject_closed({%Notification{type: :all_clear} = notification, subject}) do
     {notification, "All clear (re: #{subject})"}
   end
+  defp subject_closed({%Notification{type: :update} = notification, subject}) do
+    {notification, "Update (re: #{subject})"}
+  end
+  defp subject_closed({%Notification{type: :reminder} = notification, subject}) do
+    {notification, "Reminder (re: #{subject})"}
+  end
+  defp subject_closed({_, _} = pair), do: pair
 end

--- a/apps/concierge_site/lib/mail_templates/notification.html.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.html.eex
@@ -114,7 +114,7 @@
             <span style="width: 24px; height: 24px;">
             <img src="<%= ConciergeSite.Helpers.MailHelper.logo_for_alert(notification.alert) %>" alt="<%= ConciergeSite.Helpers.MailHelper.alt_text_for_alert(notification.alert) %>" style="border: 0; line-height: 100%; outline: none; text-decoration: none;">
           </span>
-            <%= if notification.closed_timestamp do %>
+            <%= if notification.type == :all_clear do %>
               All clear (re: <%= notification.service_effect %>)
             <% else %>
               <%= notification.service_effect %>

--- a/apps/concierge_site/lib/mail_templates/notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.txt.eex
@@ -1,4 +1,4 @@
-<%= if notification.closed_timestamp do %>
+<%= if notification.type == :all_clear do %>
 All clear (re: <%= notification.service_effect %>)
 
 The issue described below has ended:

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -37,7 +37,11 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
   end
 
   test "text_email/1 includes content for closed alerts" do
-    notification = %{@notification | closed_timestamp: DateTime.utc_now()}
+    notification = %{
+      @notification |
+      closed_timestamp: DateTime.utc_now(),
+      type: :all_clear
+    }
     email = NotificationEmail.notification_email(notification)
     body = email.text_body
 
@@ -59,7 +63,11 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
   end
 
   test "html_email/1 includes content for closed alerts" do
-    notification = %{@notification | closed_timestamp: DateTime.utc_now()}
+    notification = %{
+      @notification |
+      closed_timestamp: DateTime.utc_now(),
+      type: :all_clear
+    }
     email = NotificationEmail.notification_email(notification)
     body = email.html_body
 
@@ -101,10 +109,41 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
 
     test "closed alert" do
       alert = %{@alert | timeframe: "starting September 1", recurrence: "on weekends"}
-      notification = %{@notification | alert: alert, closed_timestamp: DateTime.utc_now()}
+      notification = %{
+        @notification |
+        alert: alert,
+        closed_timestamp: DateTime.utc_now(),
+        type: :all_clear
+      }
       subject = NotificationEmail.email_subject(notification)
 
       assert subject == "All clear (re: Starting September 1: Red line delay on weekends)"
+    end
+
+    test "updated alert" do
+      alert = %{@alert | timeframe: "starting September 1", recurrence: "on weekends"}
+      notification = %{
+        @notification |
+        alert: alert,
+        closed_timestamp: DateTime.utc_now(),
+        type: :update
+      }
+      subject = NotificationEmail.email_subject(notification)
+
+      assert subject == "Update (re: Starting September 1: Red line delay on weekends)"
+    end
+
+    test "reminder alert" do
+      alert = %{@alert | timeframe: "starting September 1", recurrence: "on weekends"}
+      notification = %{
+        @notification |
+        alert: alert,
+        closed_timestamp: DateTime.utc_now(),
+        type: :reminder
+      }
+      subject = NotificationEmail.email_subject(notification)
+
+      assert subject == "Reminder (re: Starting September 1: Red line delay on weekends)"
     end
   end
 end


### PR DESCRIPTION
Why:

* For users to know if the alert they're getting is an update or a
reminder of a notification they already received.
* Asana link: https://app.asana.com/0/529741067494252/698364926706784

This change addresses the need by:

* Adding `:notification_type_to_send` virtual field to subscription
model.
* Adding `:type` field to notification model.
* Editing `SentAlertFilter` to add a `:notification_type_to_send` to the
subscriptions that are an 'update' or 'all clear' accordingly.
* Editing `Reminders.Processor.SubscriptionsToRemind` to add a
`:notification_type_to_send` of `:reminder` to subscriptions it returns.
* Editing `NotificationBuilder` to add `type` as indicated by the
subscription's `:notification_type_to_send` value.
* Editing `notification_email.ex` to use the new notification type field
to add prefixes to email subjects.
* Editing `notification.txt.eex` and `notification.html.eex` to use the
new notification type field to trigger 'all clear` only related
messaging.
* Editing `notification_smser.ex` to use the new notification type field
to trigger 'all clear' messaging.