### PR TITLE
Add a migration to add travel times to the subscriptions table

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20180627212459_add_travel_start_and_end_times_to_subscriptions.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180627212459_add_travel_start_and_end_times_to_subscriptions.exs
@@ -1,0 +1,10 @@
+defmodule AlertProcessor.Repo.Migrations.AddTravelStartAndEndTimesToSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      add :travel_start_time, :time
+      add :travel_end_time, :time
+    end
+  end
+end


### PR DESCRIPTION
This is an initial step towards a new travel window for CR and Ferry.

Asana ticket: https://app.asana.com/0/529741067494252/725425865897761