### PR TITLE
Remove the alert_time_difference_in_minutes field from the trips table

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20180628144348_remove_alert_time_difference_in_minutes_from_trips.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180628144348_remove_alert_time_difference_in_minutes_from_trips.exs
@@ -1,0 +1,15 @@
+defmodule AlertProcessor.Repo.Migrations.RemoveAlertTimeDifferenceInMinutesFromTrips do
+  use Ecto.Migration
+
+  def up do
+    alter table(:trips) do
+      remove :alert_time_difference_in_minutes
+    end
+  end
+
+  def down do
+    alter table(:trips) do
+      add :alert_time_difference_in_minutes, :integer, null: false, default: 60
+    end
+  end
+end


### PR DESCRIPTION
This property is no longer in use anywhere.

No ticket.