### PR TITLE
Remove notification_time from subscriptions

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20180628145148_remove_notification_time_from_subscriptions.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180628145148_remove_notification_time_from_subscriptions.exs
@@ -1,0 +1,15 @@
+defmodule AlertProcessor.Repo.Migrations.RemoveNotificationTimeFromSubscriptions do
+  use Ecto.Migration
+
+  def up do
+    alter table(:subscriptions) do
+      remove :notification_time
+    end
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      add :notification_time, :time
+    end
+  end
+end


### PR DESCRIPTION
It is no longer used anywhere and is null for all production records.

No ticket.