### PR TITLE
Ensure that a trip falls within the subscription travel window

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -22,6 +22,8 @@ defmodule AlertProcessor.Model.Subscription do
     relevant_days: [relevant_day] | nil,
     start_time: Time.t | nil,
     end_time: Time.t | nil,
+    travel_start_time: Time.t | nil,
+    travel_end_time: Time.t | nil,
     origin: String.t | nil,
     destination: String.t | nil,
     type: subscription_type | nil,
@@ -67,6 +69,8 @@ defmodule AlertProcessor.Model.Subscription do
     field :relevant_days, {:array, AlertProcessor.AtomType}
     field :start_time, :time, null: false
     field :end_time, :time, null: false
+    field :travel_start_time, :time
+    field :travel_end_time, :time
     field :origin, :string
     field :destination, :string
     field :type, AlertProcessor.AtomType
@@ -86,9 +90,9 @@ defmodule AlertProcessor.Model.Subscription do
   end
 
   @permitted_fields ~w(alert_priority_type user_id trip_id relevant_days start_time
-    end_time type rank route return_trip route_type)a
+    end_time travel_start_time travel_end_time type rank route return_trip route_type)a
   @required_fields ~w(alert_priority_type user_id start_time end_time)a
-  @update_permitted_fields ~w(alert_priority_type relevant_days start_time end_time)a
+  @update_permitted_fields ~w(alert_priority_type relevant_days start_time end_time travel_start_time travel_end_time)a
   @valid_days ~w(weekday monday tuesday wednesday thursday friday saturday sunday)a
 
   @doc """

--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -47,7 +47,8 @@ defmodule AlertProcessor.InformedEntityFilter do
 
   defp trip_match?(subscription, %{schedule: schedule} = _informed_entity) do
     with {:ok, trip_departure} <- trip_departure(subscription, schedule) do
-      Time.compare(trip_departure, subscription.start_time) in [:gt, :eq]
+      Time.compare(trip_departure, subscription.travel_start_time || subscription.start_time) in [:gt, :eq] and
+        Time.compare(trip_departure, subscription.travel_end_time || subscription.end_time) in [:lt, :eq]
     else
       _ -> true
     end

--- a/apps/alert_processor/test/alert_processor/model/subscription_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/subscription_test.exs
@@ -10,7 +10,9 @@ defmodule AlertProcessor.Model.SubscriptionTest do
     alert_priority_type: :low,
     relevant_days: [:weekday],
     start_time: ~T[12:00:00],
-    end_time: ~T[18:00:00]
+    end_time: ~T[18:00:00],
+    travel_start_time: ~T[14:00:00],
+    travel_end_time: ~T[16:00:00]
   }
 
   setup do
@@ -23,6 +25,12 @@ defmodule AlertProcessor.Model.SubscriptionTest do
   test "create_changeset/2 with valid parameters", %{valid_attrs: valid_attrs} do
     changeset = Subscription.create_changeset(%Subscription{}, valid_attrs)
     assert changeset.valid?
+  end
+
+  test "create_changeset/2 permits travel_start_time and travel_end_time", %{valid_attrs: valid_attrs} do
+    changeset = Subscription.create_changeset(%Subscription{}, valid_attrs)
+    assert Map.has_key?(changeset.changes, :travel_start_time)
+    assert Map.has_key?(changeset.changes, :travel_end_time)
   end
 
   test "create_changeset/2 requires a user_id", %{valid_attrs: valid_attrs} do

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -4,6 +4,264 @@ defmodule AlertProcessor.InformedEntityFilterTest do
   import AlertProcessor.Factory
 
   describe "subscription_match?/2" do
+    test "returns true for trip match per subscription start time." do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T08:00:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+  
+    test "returns false for trip mismatch per subscription start time" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T07:45:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns false for trip match per subscription end time" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00],
+        end_time: ~T[08:05:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T08:10:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns true for trip match per travel start time." do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[07:00:00],
+        end_time: ~T[09:00:00],
+        travel_start_time: ~T[08:00:00],
+        travel_end_time: ~T[08:05:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T08:00:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns false for trip mismatch per travel start time" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        travel_start_time: ~T[08:05:00],
+        travel_end_time: ~T[08:10:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T08:00:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
+    test "returns false for trip match per travel end time" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        travel_start_time: ~T[08:00:00],
+        travel_end_time: ~T[08:05:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      scheduled_origin_event = %{
+        stop_id: "Fairmount",
+        departure_time: "2018-04-02T08:10:00-04:00"
+      }
+      scheduled_destination_event = %{
+        stop_id: "Newmarket",
+        departure_time: nil
+      }
+      schedule = [scheduled_origin_event, scheduled_destination_event]
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: schedule,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+  
+    test "returns false for trip mismatch if schedule missing event for origin" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: [],
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+  
+    test "returns false for trip mismatch if nil schedule and trip given" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin:  "Fairmount",
+        destination: "Newmarket",
+        facility_types: [],
+        start_time: ~T[08:00:00]
+      ]
+      subscription = build(:subscription, subscription_details)
+      informed_entity_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        stop: nil,
+        activities: nil,
+        schedule: nil,
+        trip: "767"
+      ]
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns true with route type match" do
       route_type =  1
       subscription_details = [
@@ -940,119 +1198,5 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       informed_entity = build(:informed_entity, informed_entity_details)
       assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
-  end
-
-  test "returns true for trip match per subscription origin start time." do
-    scheduled_origin_event = %{
-      stop_id: "Fairmount",
-      departure_time: "2018-04-02T08:00:00-04:00"
-    }
-    scheduled_destination_event = %{
-      stop_id: "Newmarket",
-      departure_time: nil
-    }
-    schedule = [scheduled_origin_event, scheduled_destination_event]
-    subscription_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      origin:  "Fairmount",
-      destination: "Newmarket",
-      facility_types: [],
-      start_time: ~T[08:00:00]
-    ]
-    subscription = build(:subscription, subscription_details)
-    informed_entity_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      stop: nil,
-      activities: nil,
-      schedule: schedule,
-      trip: "767"
-    ]
-    informed_entity = build(:informed_entity, informed_entity_details)
-    assert InformedEntityFilter.subscription_match?(subscription, informed_entity)
-  end
-
-  test "returns false for trip mismatch per subscription origin start time." do
-    scheduled_origin_event = %{
-      stop_id: "Fairmount",
-      departure_time: "2018-04-02T07:45:00-04:00"
-    }
-    scheduled_destination_event = %{
-      stop_id: "Newmarket",
-      departure_time: nil
-    }
-    schedule = [scheduled_origin_event, scheduled_destination_event]
-    subscription_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      origin:  "Fairmount",
-      destination: "Newmarket",
-      facility_types: [],
-      start_time: ~T[08:00:00]
-    ]
-    subscription = build(:subscription, subscription_details)
-    informed_entity_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      stop: nil,
-      activities: nil,
-      schedule: schedule,
-      trip: "767"
-    ]
-    informed_entity = build(:informed_entity, informed_entity_details)
-    refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
-  end
-
-  test "returns false for trip mismatch if schedule missing event for origin" do
-    subscription_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      origin:  "Fairmount",
-      destination: "Newmarket",
-      facility_types: [],
-      start_time: ~T[08:00:00]
-    ]
-    subscription = build(:subscription, subscription_details)
-    informed_entity_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      stop: nil,
-      activities: nil,
-      schedule: [],
-      trip: "767"
-    ]
-    informed_entity = build(:informed_entity, informed_entity_details)
-    refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
-  end
-
-  test "returns false for trip mismatch if nil schedule and trip given" do
-    subscription_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      origin:  "Fairmount",
-      destination: "Newmarket",
-      facility_types: [],
-      start_time: ~T[08:00:00]
-    ]
-    subscription = build(:subscription, subscription_details)
-    informed_entity_details = [
-      route_type: nil,
-      direction_id: nil,
-      route: nil,
-      stop: nil,
-      activities: nil,
-      schedule: nil,
-      trip: "767"
-    ]
-    informed_entity = build(:informed_entity, informed_entity_details)
-    refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
   end
 end


### PR DESCRIPTION
If a travel window isn't defined, default to the notification window.
This provides matching support for the new feature to limit CR and Ferry
trips to a travel window within the larger notification window.

Asana ticket: https://app.asana.com/0/529741067494252/725425865897763