### PR TITLE
lock project to Elixir 1.6.5 and Erlang/OTP 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM elixir:1.6 as builder
+FROM erlang:20 as builder
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.5" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="defe2bed953ee729addf1121db3fa42a618ef1d6c57a1f489da03b0e7a626e89" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean
 
 ENV MIX_ENV=prod
 


### PR DESCRIPTION
[Fix ehmon report bug](https://app.asana.com/0/529741067494252/727041786268829/f)

After our ECS environments automatically updated from 1.6.5 to 1.6.6 ehmon started emitting errors:

```
[error] (#PID<0.1384.0> :ehmon_report_srv:90) class=:error err=:function_clause
stack="[{:ehmon, :format_value, [:undefined], [file: '/app/deps/ehmon/src/ehmon.erl', line: 100]}, {:ehmon, :"-report_string/1-lc$^0/1-0-", 1, [file: '/app/deps/ehmon/src/ehmon.erl', line: 86]}, {:ehmon, :"-report_string/1-lc$^0/1-0-", 1, [file: '/app/deps/ehmon/src/ehmon.erl', line: 87]}, {:ehmon, :report_string, 1, [file: '/app/deps/ehmon/src/ehmon.erl', line: 87]}, {:ehmon, :info_report, 1, [file: '/app/deps/ehmon/src/ehmon.erl', line: 35]}, {:ehmon_report_srv, :do_report, 1, [file: '/app/deps/ehmon/src/ehmon_report_srv.erl', line: 87]}, {:ehmon_report_srv, :handle_info, 2, [file: '/app/deps/ehmon/src/ehmon_report_srv.erl', line: 66]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 637]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 711]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]"
```
---

This change locks us to `1.6.5`.

I looked to see if there was an official `1.6.5` docker container, but there is only a `1.6` that they keep changing... which is pretty wack.

This is a copy/paste from the official report for when the `1.6` dockerfile reference Elixir `1.6.5`. 

---

It is working on dev green:

<img width="1212" alt="screen shot 2018-06-29 at 2 54 20 pm" src="https://user-images.githubusercontent.com/988609/42109651-6580506c-7bac-11e8-968e-a816be63dcc7.png">
