### PR TITLE
Display the final leg's destination in the trip card

### DIFF
--- a/apps/concierge_site/lib/views/trip_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_card_helper.ex
@@ -104,7 +104,7 @@ defmodule ConciergeSite.TripCardHelper do
   @spec routes([Subscription.t]) :: [Phoenix.HTML.safe]
   defp routes(subscriptions) do
     subscriptions
-    |> Enum.reject(& &1.return_trip)
+    |> exclude_return_trip_subscriptions()
     |> collapse_duplicate_green_legs()
     |> Enum.map(fn (subscription) ->
       content_tag :div, class: "trip__card--route-container" do
@@ -122,8 +122,10 @@ defmodule ConciergeSite.TripCardHelper do
 
   @spec stops([Subscription.t]) :: Phoenix.HTML.safe
   defp stops(subscriptions) do
-    origin = List.first(subscriptions).origin
-    destination = List.first(subscriptions).destination
+    first_trip_subscriptions = subscriptions |>
+      exclude_return_trip_subscriptions()
+    origin = List.first(first_trip_subscriptions).origin
+    destination = List.last(first_trip_subscriptions).destination
 
     content_tag :span, class: "trip__card--stops" do
       case {origin, destination} do
@@ -249,5 +251,10 @@ defmodule ConciergeSite.TripCardHelper do
                                                                             token: get_csrf_token()] do
       "Delete"
     end
+  end
+
+  defp exclude_return_trip_subscriptions(subscriptions) do
+    subscriptions
+    |> Enum.reject(& &1.return_trip)
   end
 end


### PR DESCRIPTION
Why:
• Trip card only destination of first leg rather than the final leg.
• Asana link: https://app.asana.com/0/529741067494252/728169399208095

I previously made a change (48a5f1a0ab539c5a181ea067cc374dd580f4e389)
attempting to fix a different issue where the destination of the final
leg of the return trip was being shown, which was the same as the
origin. My fix at the time was to only use the initial leg's origin and
destination, but that was incomplete. Instead we want to look at all
legs in the first trip, but not those in the return trip.