### PR TITLE
Add option to update station features on trip edit page

### DIFF
--- a/apps/alert_processor/lib/model/trip.ex
+++ b/apps/alert_processor/lib/model/trip.ex
@@ -61,6 +61,7 @@ defmodule AlertProcessor.Model.Trip do
     end_time
     return_start_time
     return_end_time
+    facility_types
   )a
 
   @doc """

--- a/apps/alert_processor/test/alert_processor/model/trip_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/trip_test.exs
@@ -126,7 +126,8 @@ defmodule AlertProcessor.Model.TripTest do
         start_time: ~T[11:00:00],
         end_time: ~T[13:30:00],
         return_start_time: ~T[17:00:00],
-        return_end_time: ~T[18:30:00]
+        return_end_time: ~T[18:30:00],
+        facility_types: [:elevator]
       }
       trip = insert(:trip, trip_details)
       params = %{
@@ -134,7 +135,8 @@ defmodule AlertProcessor.Model.TripTest do
         end_time: ~T[13:30:00],
         return_start_time: ~T[15:00:00],
         return_end_time: ~T[15:30:00],
-        relevant_days: [:tuesday]
+        relevant_days: [:tuesday],
+        facility_types: [:escalator]
       }
       {:ok, %Trip{} = _} = Trip.update(trip, params)
       updated_trip = Trip.find_by_id(trip.id)
@@ -143,6 +145,7 @@ defmodule AlertProcessor.Model.TripTest do
       assert updated_trip.return_start_time == ~T[15:00:00.000000]
       assert updated_trip.return_end_time == ~T[15:30:00.000000]
       assert updated_trip.relevant_days == [:tuesday]
+      assert updated_trip.facility_types == [:escalator]
     end
 
     test "errors if updated without any days" do

--- a/apps/concierge_site/lib/templates/v2/trip/_station_features.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/_station_features.html.eex
@@ -1,0 +1,25 @@
+<div class="form-group form__section">
+  <%= label @form, :elevator, "Would you like alerts about any of these station features?", class: "form__label" %>
+  <div class="btn-group btn-group-toggle btn__radio--toggle-container" data-toggle="buttons" role="radiogroup">
+    <label role="checkbox" class="<%= ConciergeSite.FacilitiesHelper.checkbox_label_class(@trip, :elevator) %>" tabindex="0">
+      <%= render ConciergeSite.V2.LayoutView, "_icon_elevator.html" %>
+      <%= checkbox @form, :elevator, value: ConciergeSite.FacilitiesHelper.facility_type_value(@trip, :elevator), tabindex: "-1" %>
+      <div>Elevators</div>
+    </label>
+    <label role="checkbox" class="<%= ConciergeSite.FacilitiesHelper.checkbox_label_class(@trip, :escalator) %>" tabindex="0">
+      <%= render ConciergeSite.V2.LayoutView, "_icon_escalator.html" %>
+      <%= checkbox @form, :escalator, value: ConciergeSite.FacilitiesHelper.facility_type_value(@trip, :escalator), tabindex: "-1" %>
+      <div>Escalators</div>
+    </label>
+    <label role="checkbox" class="<%= ConciergeSite.FacilitiesHelper.checkbox_label_class(@trip, :parking_area) %>" tabindex="0">
+      <%= render ConciergeSite.V2.LayoutView, "_icon_parking.html" %>
+      <%= checkbox @form, :parking_area, value: ConciergeSite.FacilitiesHelper.facility_type_value(@trip, :parking_area), tabindex: "-1" %>
+      <div>Parking</div>
+    </label>
+    <label role="checkbox" class="<%= ConciergeSite.FacilitiesHelper.checkbox_label_class(@trip, :bike_storage) %>" tabindex="0">
+      <%= render ConciergeSite.V2.LayoutView, "_icon_bike.html" %>
+      <%= checkbox @form, :bike_storage, value: ConciergeSite.FacilitiesHelper.facility_type_value(@trip, :bike_storage), tabindex: "-1" %>
+      <div>Bike Storage</div>
+    </label>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -56,6 +56,8 @@ first_trip_padding_class = if @trip.roundtrip == true, do: "", else: "form__sect
           </div>
         <% end %>
 
+        <%= render "_station_features.html", form: form, trip: @trip %>
+
         <div class="form__action-buttons--container">
           <%= submit "Update subscription", class: "btn btn-primary btn-login btn-block" %>
           <button type="button" class="btn btn-outline-danger btn-block" data-toggle="modal" data-target="#deleteModal">

--- a/apps/concierge_site/lib/templates/v2/trip/times.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/times.html.eex
@@ -94,6 +94,8 @@ first_trip_padding_class = if @round_trip == "true", do: "", else: "form__sectio
           <%= hidden_input form, :modes, name: "trip[modes][]", value: mode %>
         <% end %>
 
+        <%= render "_station_features.html", form: form, trip: %AlertProcessor.Model.Trip{} %>
+
         <div class="form__action-buttons--container">
           <%= submit "Finish", class: "btn btn-primary float-right form__action-button" %>
           <a href="javascript:history.back()" class="btn btn-outline-primary form__action-button">Back</a>

--- a/apps/concierge_site/lib/views/facilities_helper.ex
+++ b/apps/concierge_site/lib/views/facilities_helper.ex
@@ -1,0 +1,26 @@
+defmodule ConciergeSite.FacilitiesHelper do
+  alias AlertProcessor.Model.Trip
+
+  def checkbox_label_class(trip, facility_type) do
+    base_class = "btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item-connected"
+    active_class = if includes_facility_type(trip, facility_type) do
+      " active"
+    else
+      ""
+    end
+    base_class <> active_class
+  end
+
+  def facility_type_value(trip, type) do
+    to_string(includes_facility_type(trip, type))
+  end
+
+  defp includes_facility_type(%Trip{facility_types: facility_types}, type) do
+    cond do
+      is_list(facility_types) ->
+        type in facility_types
+      true ->
+        false
+    end
+  end
+end

--- a/apps/concierge_site/test/web/views/facilities_helper_test.exs
+++ b/apps/concierge_site/test/web/views/facilities_helper_test.exs
@@ -1,0 +1,39 @@
+defmodule ConciergeSite.FacilitiesHelperTest do
+  use ConciergeSite.ConnCase
+  alias ConciergeSite.FacilitiesHelper
+  alias AlertProcessor.Model.Trip
+
+  setup do
+    trip_with_escalator = %Trip{
+      id: Ecto.UUID.generate(),
+      alert_priority_type: :low,
+      relevant_days: [:monday],
+      start_time: ~T[09:00:00],
+      end_time: ~T[10:00:00],
+      roundtrip: false,
+      facility_types: [:elevator, :escalator, :parking_area]
+    }
+    
+    trip_without_escalator = %Trip{
+      id: Ecto.UUID.generate(),
+      alert_priority_type: :low,
+      relevant_days: [:monday],
+      start_time: ~T[09:00:00],
+      end_time: ~T[10:00:00],
+      roundtrip: false,
+      facility_types: [:elevator, :parking_area]
+    }
+
+    {:ok, trips: [trip_with_escalator, trip_without_escalator]}
+  end
+
+  test "checkbox_label_class/2", %{trips: [trip_with_escalator, trip_without_escalator]} do
+    assert FacilitiesHelper.checkbox_label_class(trip_with_escalator, :escalator) == "btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item-connected active"
+    assert FacilitiesHelper.checkbox_label_class(trip_without_escalator, :escalator) == "btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item-connected"
+  end
+
+  test "facility_type_value/2", %{trips: [trip_with_escalator, trip_without_escalator]} do
+    assert FacilitiesHelper.facility_type_value(trip_with_escalator, :escalator) == "true"
+    assert FacilitiesHelper.facility_type_value(trip_without_escalator, :escalator) == "false"
+  end
+end


### PR DESCRIPTION
Why:
• Currently we only allow users to edit the days and times of their
subscription within the edit page. There has been some customer feedback (from
the feedback form + IHCD) that users would like to add alerts for these
features after they have created a subscription.
• Asana link: https://app.asana.com/0/529741067494252/713859172395813