### PR TITLE
show expanded green line routes for accessibility trip

### DIFF
--- a/apps/concierge_site/lib/templates/v2/accessibility_trip/new.html.eex
+++ b/apps/concierge_site/lib/templates/v2/accessibility_trip/new.html.eex
@@ -15,7 +15,8 @@
 
         <div class="form-group form__section">
           <%= label form, :routes, "Would you like alerts for all stations on a line?", class: "form__label" %>
-          <%= ConciergeSite.RouteSelectHelper.render(:trip, :routes, @changeset.changes[:routes] || [], multiple: "multiple", no_default: true, no_bus: true) %>
+          <%= ConciergeSite.RouteSelectHelper.render(:trip, :routes, @changeset.changes[:routes] || [], multiple: "multiple",
+                                                                     no_default: true, no_bus: true, separate_green: true) %>
           <%= if @changeset.errors[:routes], do: error_tag @changeset, :routes %>
         </div>
 

--- a/apps/concierge_site/lib/views/route_select_helper.ex
+++ b/apps/concierge_site/lib/views/route_select_helper.ex
@@ -10,10 +10,11 @@ defmodule ConciergeSite.RouteSelectHelper do
     content_tag :select, attributes(input_name, field, attrs) do
       default = if attrs[:no_default] == true, do: [], else: default_option()
       bus_options = if attrs[:no_bus] == true, do: [], else: option_group("Bus", :bus, selected)
+      subway_option = if attrs[:separate_green] == true, do: :subway_all_green, else: :subway
 
       [
         default,
-        option_group("Subway", :subway, selected),
+        option_group("Subway", subway_option, selected),
         option_group("Commuter Rail", :cr, selected),
         option_group("Ferry", :ferry, selected),
         bus_options
@@ -66,6 +67,19 @@ defmodule ConciergeSite.RouteSelectHelper do
       {:red, "Red", "Red Line"},
       {:orange, "Orange", "Orange Line"},
       {:green, "Green", "Green Line"},
+      {:blue, "Blue", "Blue Line"},
+      {:mattapan, "Mattapan", "Mattapan Trolley"}
+    ]
+  end
+
+  defp get_routes(:subway_all_green) do
+    [
+      {:red, "Red", "Red Line"},
+      {:orange, "Orange", "Orange Line"},
+      {:"green-b", "Green-B", "Green Line B"},
+      {:"green-c", "Green-C", "Green Line C"},
+      {:"green-d", "Green-D", "Green Line D"},
+      {:"green-e", "Green-E", "Green Line E"},
       {:blue, "Blue", "Blue Line"},
       {:mattapan, "Mattapan", "Mattapan Trolley"}
     ]

--- a/apps/concierge_site/test/web/views/route_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/route_select_helper_test.exs
@@ -41,5 +41,17 @@ defmodule ConciergeSite.RouteSelectHelperTest do
 
       refute html =~ "Silver Line SL5"
     end
+
+    test "collapsed Green Line" do
+      html = Phoenix.HTML.safe_to_string(ConciergeSite.RouteSelectHelper.render(:foo, :bar, [], multiple: "multiple", no_default: true))
+      assert html =~ "<option data-icon=\"green\" value=\"Green~~Green Line~~subway\">Green Line</option>"
+      refute html =~ "<option data-icon=\"green-b\" value=\"Green-B~~Green Line B~~subway_all_green\">Green Line B</option>"
+    end
+
+    test "expanded Green Line" do
+      html = Phoenix.HTML.safe_to_string(ConciergeSite.RouteSelectHelper.render(:foo, :bar, [], multiple: "multiple", no_default: true, separate_green: true))
+      assert html =~ "<option data-icon=\"green-b\" value=\"Green-B~~Green Line B~~subway_all_green\">Green Line B</option>"
+      refute html =~ "<option data-icon=\"green\" value=\"Green~~Green Line~~subway\">Green Line</option>"
+    end
   end
 end


### PR DESCRIPTION
[(2) Entire Green Line accessibility subscriptions not working](https://app.asana.com/0/529741067494252/731401852721699/f)

Add some options to show all Green line routes.

---

![screen shot 2018-07-11 at 11 55 26 am](https://user-images.githubusercontent.com/988609/42584516-571e9c28-8501-11e8-8731-7cd84833eb4f.png)
