### PR TITLE
verify that subscription is being loaded when notifications are queried

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
@@ -236,6 +236,12 @@ defmodule AlertProcessor.SentAlertFilterTest do
 
       notifications = Notification.most_recent_for_subscriptions_and_alerts([alert])
 
+      loaded_subscription = notifications
+      |> List.first
+      |> Map.get(:subscriptions)
+      |> List.first
+      assert loaded_subscription.start_time == ~T[10:00:00.000000]
+      
       assert {[], []} ==
         SentAlertFilter.filter(subscriptions, alert, notifications, @monday_at_8am)
 


### PR DESCRIPTION
[(2) Hotfix cleanup - adding unit test for users preloaded](https://app.asana.com/0/529741067494252/725950716290390/f)

small check to see if a notification that was returned had preloaded a subscription