### PR TITLE
Update AlertParserMock to handle all duration types

### DIFF
--- a/apps/alert_processor/test/support/mocks/alert_parser_mock.ex
+++ b/apps/alert_processor/test/support/mocks/alert_parser_mock.ex
@@ -12,11 +12,23 @@ defmodule AlertProcessor.AlertParserMock do
   process_alerts/1 send messages to self for tests to be able
   to verify that process_alerts has properly been called.
   """
-  def process_alerts(:recent) do
-    send self(), :processed_alerts
-    [{:ok, []}]
+  def process_alerts(:older) do
+    send_to_self()
   end
+
+  def process_alerts(:recent) do
+    send_to_self()
+  end
+
+  def process_alerts(:anytime) do
+    send_to_self()
+  end
+
   def process_alerts() do
+    send_to_self()
+  end
+
+  defp send_to_self do
     send self(), :processed_alerts
     [{:ok, []}]
   end


### PR DESCRIPTION
This fixes errors that are occasionally thrown when running test suite.

No ticket.