### PR TITLE
Create a trip review card

### DIFF
--- a/apps/concierge_site/assets/css/app_v2.scss
+++ b/apps/concierge_site/assets/css/app_v2.scss
@@ -8,6 +8,7 @@
 @import "v2/footer";
 @import "v2/forms";
 @import "v2/trip-card";
+@import "v2/trip-review-card";
 @import "vendor/select2/select2";
 @import "vendor/select2/select2-bootstrap4";
 @import "v2/help_text";

--- a/apps/concierge_site/assets/css/v2/_trip-card.scss
+++ b/apps/concierge_site/assets/css/v2/_trip-card.scss
@@ -120,3 +120,8 @@
     }
   }
 }
+
+.trip__editpage {
+  border-bottom: 1px solid $pale-grey;
+  padding-bottom: 2.5rem;
+}

--- a/apps/concierge_site/assets/css/v2/_trip-review-card.scss
+++ b/apps/concierge_site/assets/css/v2/_trip-review-card.scss
@@ -1,0 +1,40 @@
+.trip-review {
+  h3 {
+    font-size: 1.17rem;
+  }
+}
+
+.trip-review--trip {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+@include media-breakpoint-down(sm) {
+  .trip-review--trip + .trip-review--trip {
+    margin-top: 1rem;
+  }
+}
+
+.trip-review--card {
+  border-color: #b0b5c0;
+  flex: 1 1 auto;
+  line-height: 1.5rem;
+  padding: .75rem;
+}
+
+.trip-review--trip-leg + .trip-review--trip-leg {
+  margin-top: 0.5rem;
+}
+
+.trip-review--route-icon {
+  display: inline-block;
+  margin-right: 4px;
+  transform: translate(0px, 4px);
+}
+
+.trip-review--route {
+  font-weight: bold;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/edit.html.eex
@@ -15,8 +15,8 @@ first_trip_padding_class = if @trip.roundtrip == true, do: "", else: "form__sect
 <div class="container container__inner">
   <div class="row justify-content-md-center">
     <div class="col-sm-12">
-      <div class="my-4 trip__editpage">
-        <%= ConciergeSite.TripCardHelper.display(@conn, @trip) %>
+      <div class="trip__editpage">
+        <%= ConciergeSite.TripReviewCardHelper.render(@trip) %>
       </div>
 
       <%= form_for @changeset, v2_trip_path(@conn, :update, @trip), [as: :trip, id: "commute-edit-form"], fn form -> %>

--- a/apps/concierge_site/lib/templates/v2/trip/times.html.eex
+++ b/apps/concierge_site/lib/templates/v2/trip/times.html.eex
@@ -1,5 +1,3 @@
-<h1 class="heading__title">Personalize my subscription</h1>
-<%= flash_error(@conn) %>
 <%
 time_label = if @round_trip == "true" do
   "When would you like to receive alerts for your first trip?"
@@ -8,6 +6,11 @@ else
 end
 first_trip_padding_class = if @round_trip == "true", do: "", else: "form__section"
 %>
+
+<h1 class="heading__title">Personalize my subscription</h1>
+<%= flash_error(@conn) %>
+
+<%= ConciergeSite.TripReviewCardHelper.render(@partial_subscriptions) %>
 
 <div class="container container__inner">
   <div class="row justify-content-md-center">

--- a/apps/concierge_site/lib/views/icon_view_helper.ex
+++ b/apps/concierge_site/lib/views/icon_view_helper.ex
@@ -198,4 +198,29 @@ defmodule ConciergeSite.IconViewHelper do
     </svg>
     """)
   end
+
+  @spec icon_for_route(atom | String.t, atom | String.t) :: Phoenix.HTML.safe
+  def icon_for_route(mode, route) when is_bitstring(mode) do
+    mode
+    |> atomize()
+    |> icon_for_route(route)
+  end
+
+  def icon_for_route(mode, route) when is_bitstring(route) do
+    icon_for_route(mode, atomize(route))
+  end
+
+  def icon_for_route(_, "Mattapan"), do: icon(:mattapan)
+  def icon_for_route(:subway, routes) when is_list(routes), do: Enum.map(routes, fn(route) -> icon_for_route(:subway, route) end)
+  def icon_for_route(:subway, route), do: icon(route)
+  def icon_for_route(:cr, _), do: icon(:commuter_rail)
+  def icon_for_route(:bus, _), do: icon(:bus)
+  def icon_for_route(:ferry, _), do: icon(:ferry)
+
+  @spec atomize(String.t) :: atom
+  defp atomize(str) do
+    str
+    |> String.downcase()
+    |> String.to_atom()
+  end
 end

--- a/apps/concierge_site/lib/views/route_helper.ex
+++ b/apps/concierge_site/lib/views/route_helper.ex
@@ -1,0 +1,65 @@
+defmodule ConciergeSite.RouteHelper do
+  alias AlertProcessor.ServiceInfoCache
+  alias AlertProcessor.Model.Subscription
+
+  @doc """
+  Get the name of a given route or routes.
+
+    iex> ConciergeSite.RouteHelper.route_name("Green")
+    "Green Line"
+    iex> ConciergeSite.RouteHelper.route_name("Green-B")
+    "Green Line B"
+    iex> ConciergeSite.RouteHelper.route_name(["Green-B", "Green-D"])
+    "Green Line"
+    iex> ConciergeSite.RouteHelper.route_name("CR-Worcester")
+    "Framingham/Worcester Line"
+    iex> ConciergeSite.RouteHelper.route_name("39")
+    "Route 39"
+  """
+  @spec route_name(String.t) :: String.t
+  def route_name(routes) when is_list(routes), do: "Green Line"
+  def route_name("Green"), do: "Green Line"
+  def route_name("Green-B"), do: "Green Line B"
+  def route_name("Green-C"), do: "Green Line C"
+  def route_name("Green-D"), do: "Green Line D"
+  def route_name("Green-E"), do: "Green Line E"
+
+  def route_name(route_id) do
+    {:ok, route} = ServiceInfoCache.get_route(route_id)
+    case route.long_name do
+      "" -> "Route #{route.short_name}"
+      _ -> route.long_name
+    end
+  end
+
+  @doc """
+  Get the name of a stop.
+
+    iex> ConciergeSite.RouteHelper.stop_name("place-davis")
+    "Davis"
+  """
+  @spec stop_name(String.t) :: String.t
+  def stop_name(stop_id) do
+    {:ok, {name, _, _, _}} = ServiceInfoCache.get_stop(stop_id)
+    name
+  end
+
+  @spec collapse_duplicate_green_legs([Subscription.t]) :: [Subscription.t] 
+  def collapse_duplicate_green_legs(subscriptions) do
+    Enum.reduce(subscriptions, [], fn(subscription, unique_subscriptions) ->
+      case Enum.find_index(unique_subscriptions, fn(%{origin: origin, destination: destination}) ->
+        subscription.route_type == 0 && origin == subscription.origin && destination == subscription.destination
+      end) do
+        nil -> unique_subscriptions ++ [subscription]
+        index -> List.update_at(unique_subscriptions, index, fn(original_subscription) ->
+          %{original_subscription | route: add_route_to_subscription(original_subscription.route, subscription.route) }
+        end)
+      end
+    end)
+  end
+
+  @spec add_route_to_subscription([String.t] | String.t, String.t) :: [String.t] 
+  defp add_route_to_subscription(original, additional) when is_list(original), do: original ++ [additional]
+  defp add_route_to_subscription(original, additional), do: [original, additional]
+
+end

--- a/apps/concierge_site/lib/views/trip_review_card_helper.ex
+++ b/apps/concierge_site/lib/views/trip_review_card_helper.ex
@@ -1,0 +1,127 @@
+defmodule ConciergeSite.TripReviewCardHelper do
+  import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3]
+  alias AlertProcessor.Model.{Subscription, Trip}
+  alias AlertProcessor.ServiceInfoCache
+  alias ConciergeSite.{IconViewHelper, RouteHelper}
+
+  @doc """
+  Render a trip review card for a trip
+  """
+  @spec render(Trip.t) :: Phoenix.HTML.safe
+  def render(%Trip{subscriptions: subscriptions, roundtrip: roundtrip?}) do
+    subscriptions
+    |> RouteHelper.collapse_duplicate_green_legs()
+    |> Enum.sort(&(&1.rank <= &2.rank))
+    |> row(roundtrip?)
+  end
+
+  @spec render([Subscription.t]) :: Phoenix.HTML.safe
+  def render(subscriptions), do: row(subscriptions, includes_return_trip_subscriptions(subscriptions))
+
+  @spec row([Subscription.t], boolean) :: Phoenix.HTML.safe
+  defp row(subscriptions, roundtrip?) do
+    content_tag :div, class: "trip-review row" do
+      row_content(subscriptions, roundtrip?)
+    end
+  end
+
+  @spec row_content([Subscription.t], boolean) :: Phoenix.HTML.safe
+  defp row_content(subscriptions, false), do: one_way_trip(subscriptions)
+  defp row_content(subscriptions, true), do: subscriptions |> split_round_trip_subscriptions() |> round_trip()
+
+  @spec one_way_trip([Subscription.t]) :: Phoenix.HTML.safe
+  defp one_way_trip(subscriptions) do
+    content_tag :div, class: "trip-review--trip col-md-6" do
+      [
+        content_tag(:h3, "My Trip"),
+        card(subscriptions)
+      ]
+    end
+  end
+
+  @spec round_trip({[Subscription.t], [Subscription.t]}) :: [Phoenix.HTML.safe]
+  defp round_trip({initial_trip_subscriptions, return_trip_subscriptions}) do
+    [
+      content_tag :div, class: "trip-review--trip col-md-6" do
+        [
+          content_tag(:h3, "First trip"),
+          card(initial_trip_subscriptions)
+        ]
+      end,
+      content_tag :div, class: "trip-review--trip col-md-6" do
+        [
+          content_tag(:h3, "Return trip"),
+          return_trip_subscriptions |> Enum.reverse() |> card()
+        ]
+      end
+    ]
+  end
+
+  @spec card([Subscription.t]) :: Phoenix.HTML.safe
+  defp card(subscriptions) do
+    content_tag :div, class: "card trip-review--card" do
+      for subscription <- subscriptions, do: leg(subscription)
+    end
+  end
+
+  @spec leg(Subscription.t) :: Phoenix.HTML.safe
+  defp leg(%Subscription{} = subscription) do
+    content_tag :div, class: "trip-review--trip-leg" do
+      [
+        route(subscription),
+        route_description(subscription)
+      ]
+    end
+  end
+
+  @spec route(Subscription.t) :: Phoenix.HTML.safe
+  defp route(%Subscription{type: type, route: route}) do
+    content_tag :div, class: "trip-review--route-container" do
+      [
+        content_tag :span, class: "trip-review--route-icon" do
+          IconViewHelper.icon_for_route(type, route)
+        end,
+        content_tag :span, class: "trip-review--route" do
+          RouteHelper.route_name(route)
+        end
+      ]
+    end
+  end
+
+  @spec card(Subscription.t) :: Phoenix.HTML.safe
+  defp route_description(%Subscription{origin: origin, destination: destination, route: route, direction_id: direction_id}) do
+    case {origin, destination, route, direction_id} do
+      {nil, nil, route_id, direction_id} -> headsign(route_id, direction_id)
+      {origin_id, destination_id, _, _} -> origin_destination(origin_id, destination_id)
+    end
+  end
+
+  @spec origin_destination(String.t, String.t) :: Phoenix.HTML.safe
+  defp origin_destination(origin_id, destination_id) do
+    content_tag :div, class: "trip-review--origin-destination" do
+      "#{RouteHelper.stop_name(origin_id)} — #{RouteHelper.stop_name(destination_id)}"
+    end
+  end
+
+  @spec headsign(String.t, non_neg_integer) :: Phoenix.HTML.safe
+  defp headsign(route_id, direction_id) do
+    content_tag :div, class: "trip-review--headsign" do
+      direction_headsign(route_id, direction_id)
+    end
+  end
+
+  @spec direction_headsign(String.t, non_neg_integer) :: [String.t]
+  defp direction_headsign(route_id, direction_id) do
+    headsign_default = if direction_id == 0, do: ["Outbound"], else: ["Inbound"]
+    {:ok, route} = ServiceInfoCache.get_route(route_id)
+    Map.get(route.headsigns, direction_id, headsign_default)
+    |> Enum.intersperse(" ● ")
+  end
+
+  @spec includes_return_trip_subscriptions([Subscription.t]) :: boolean
+  defp includes_return_trip_subscriptions(subscriptions), do: Enum.any?(subscriptions, &(&1.return_trip))
+
+  @spec split_round_trip_subscriptions([Subscription.t]) :: {[Subscription.t], [Subscription.t]}
+  defp split_round_trip_subscriptions(subscriptions), do: Enum.split_with(subscriptions, &(not &1.return_trip))
+
+end

--- a/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/v2/trip_controller_test.exs
@@ -542,9 +542,9 @@ defmodule ConciergeSite.V2.TripControllerTest do
 
     test "bus", %{conn: conn, user: user} do
       trip = %{
-        destinations: [""],
-        legs: ["741"],
-        origins: [""],
+        destinations: [],
+        legs: ["41 - 1"],
+        origins: [],
         round_trip: "true",
         modes: ["bus"]
       }

--- a/apps/concierge_site/test/web/views/icon_view_helper_test.exs
+++ b/apps/concierge_site/test/web/views/icon_view_helper_test.exs
@@ -1,0 +1,14 @@
+defmodule ConciergeSite.IconViewHelperTest do
+  use ExUnit.Case
+  alias ConciergeSite.IconViewHelper
+
+  test "icon/1 returns raw code for an svg" do
+    {:safe, html} = IconViewHelper.icon(:red)
+    assert html =~ "<svg"
+  end
+
+  test "icon_for_route/2 returns raw code for an svg given a route" do
+    {:safe, html} = IconViewHelper.icon_for_route(:cr, "CR-Worcester")
+    assert html =~ "<svg"
+  end
+end

--- a/apps/concierge_site/test/web/views/route_helper_test.exs
+++ b/apps/concierge_site/test/web/views/route_helper_test.exs
@@ -1,0 +1,7 @@
+defmodule ConciergeSite.RouteHelperTest do
+  use ExUnit.Case
+  alias ConciergeSite.RouteHelper
+
+  doctest RouteHelper
+
+end

--- a/apps/concierge_site/test/web/views/trip_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_card_helper_test.exs
@@ -130,9 +130,6 @@ defmodule ConciergeSite.TripCardHelperTest do
       refute html =~ "One-way"
       assert html =~ "Round-trip"
       assert html =~ "9:00A - 10:00A,  1:00P -  2:00P"
-
-      html = Phoenix.HTML.safe_to_string(TripCardHelper.display(conn, trip_with_subscriptions))
-      assert html =~ "<div class=\"card trip__card trip__card--display btn"
     end
 
     test "accessiblity", %{conn: conn} do

--- a/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
@@ -1,0 +1,146 @@
+defmodule ConciergeSite.TripReviewCardHelperTest do
+  use ConciergeSite.ConnCase
+  alias ConciergeSite.TripReviewCardHelper
+  alias AlertProcessor.Model.{Subscription, Trip}
+
+  describe "render/1" do
+    test "generates html for a trip review card given a list of partial Subscriptions" do
+      subscriptions = [
+        %Subscription{
+          type: :subway,
+          route: "Red",
+          origin: "place-alfcl",
+          destination: "place-portr",
+          direction_id: 0,
+          rank: 1,
+          return_trip: false
+        },
+        %Subscription{
+          type: :subway,
+          route: "Orange",
+          origin: "place-chncl",
+          destination: "place-ogmnl",
+          direction_id: 1,
+          rank: 2,
+          return_trip: false
+        },
+        %Subscription{
+          type: :subway,
+          route: "Green",
+          origin: "place-lake",
+          destination: "place-kencl",
+          direction_id: 0,
+          rank: 3,
+          return_trip: false
+        }
+      ]
+
+      html = Phoenix.HTML.safe_to_string(TripReviewCardHelper.render(subscriptions))
+
+      assert html =~ "<div class=\"trip-review"
+    end
+
+    test "generates html for a trip review card given a Trip" do
+      trip = %Trip{
+        id: Ecto.UUID.generate(),
+        alert_priority_type: :low,
+        relevant_days: [:monday],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        roundtrip: false
+      }
+      trip_with_subscriptions = %{
+        trip
+        | subscriptions: [
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Red",
+              origin: "place-alfcl",
+              destination: "place-portr",
+              direction_id: 0,
+              rank: 1
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Orange",
+              origin: "place-chncl",
+              destination: "place-ogmnl",
+              direction_id: 1,
+              rank: 2
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Green",
+              origin: "place-lake",
+              destination: "place-kencl",
+              direction_id: 0,
+              rank: 3
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Green-B",
+              origin: "place-lake",
+              destination: "place-kencl",
+              direction_id: 0,
+              rank: 3
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Blue",
+              origin: "place-wondl",
+              destination: "place-bomnl",
+              direction_id: 0,
+              rank: 4
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :subway,
+              route: "Mattapan",
+              origin: "place-asmnl",
+              destination: "place-matt",
+              direction_id: 0,
+              rank: 5
+            }),
+            add_subscription_for_trip(trip, %{type: :bus, route: "57A", direction_id: 0, rank: 6}),
+            add_subscription_for_trip(trip, %{type: :bus, route: "741", direction_id: 0, rank: 6}),
+            add_subscription_for_trip(trip, %{
+              type: :cr,
+              route: "CR-Haverhill",
+              origin: "Melrose Highlands",
+              destination: "place-north",
+              direction_id: 1,
+              rank: 7
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :ferry,
+              route: "Boat-F4",
+              origin: "Boat-Long",
+              destination: "Boat-Charlestown",
+              direction_id: 0,
+              rank: 8
+            })
+          ]
+      }
+
+      html = Phoenix.HTML.safe_to_string(TripReviewCardHelper.render(trip_with_subscriptions))
+
+      assert html =~ "<div class=\"trip-review"
+    end
+  end
+
+  defp add_subscription_for_trip(trip, params) do
+    %Subscription{
+      user_id: trip.user_id,
+      trip_id: trip.id,
+      alert_priority_type: trip.alert_priority_type,
+      relevant_days: trip.relevant_days,
+      start_time: trip.start_time,
+      end_time: trip.end_time,
+      type: params[:type],
+      route: params[:route],
+      origin: params[:origin],
+      destination: params[:destination],
+      direction_id: params[:direction_id],
+      rank: params[:rank]
+    }
+  end
+end


### PR DESCRIPTION
Adding a visual confirmation of what we're storing for first trip and
return trip on the trip create and edit pages.

Why:  Particularly for users who have multi-leg roundtrips, it can be
unclear what we're actually storing for them as their subscription on
the backend. This also serves as confirmation for the stops that the
user has selected.

Asana ticket: https://app.asana.com/0/529741067494252/705823114976616