### PR TITLE
fix alert replacement bug

### DIFF
--- a/apps/alert_processor/lib/rules_engine/text_replacement.ex
+++ b/apps/alert_processor/lib/rules_engine/text_replacement.ex
@@ -56,12 +56,12 @@ defmodule AlertProcessor.TextReplacement do
   end
 
   defp replace_schedule(replacement_data, alert) do
-    for {key, replacement_pairs} <- replacement_data, into: %{} do
+    for {key, [replacement_pairs | _]} <- replacement_data, into: %{} do
       if replacement_pairs == [] do
         {key, Map.get(alert, key)}
       else
         text =
-          replacement_pairs
+          [replacement_pairs]
           |> Enum.map(fn({_original, replacement, text}) ->
             new_text = serialize(replacement)
             substitute(text, new_text)


### PR DESCRIPTION
[(?) CR/ferry email notification rendering bug](https://app.asana.com/0/529741067494252/735356474046542/f)

This is a band-aid fix to a bigger problem.

This code was written with the expectation that the text-to-replace in an alert would only ever be matched once, despite the data being stored in a list.  Because it combines all the text from all the matches, when an alert contained multiple matches, the entire text of the description was being concatenated for each match.

This function is using the wrong data-structures and so subsequently uses the wrong algorithm to process the data.  This fix doesn't solve the underlying conceptual problems, it just causes the processing to treat the data-structures as they were falsely assumed to be (only ever one match).