### PR TITLE
log value as nil if it doesn't exist

### DIFF
--- a/apps/concierge_site/lib/dissemination/deliver_later_strategy.ex
+++ b/apps/concierge_site/lib/dissemination/deliver_later_strategy.ex
@@ -7,7 +7,7 @@ defmodule ConciergeSite.Dissemination.DeliverLaterStrategy do
     Task.async(fn ->
       try do
         result = adapter.deliver(email, config)
-        Logger.info(fn -> "Email result: #{inspect(result)}, notification_id: #{email.private.notification_id}" end)
+        Logger.info(fn -> "Email result: #{inspect(result)}, notification_id: #{email.private[:notification_id]}" end)
         result
       rescue
         # Consciously dropping the email on the floor if we get an SMTP error.


### PR DESCRIPTION
NO TICKET

The app was crashing when the log was trying to reference a key that didn't exist