### PR TITLE
Log our notification ID with response from SMS sending

### DIFF
--- a/apps/alert_processor/lib/dissemination/dispatcher.ex
+++ b/apps/alert_processor/lib/dissemination/dispatcher.ex
@@ -30,6 +30,7 @@ defmodule AlertProcessor.Dispatcher do
 
   def send_notification(
         %Notification{
+          id: notification_id,
           phone_number: phone_number,
           header: header,
           closed_timestamp: closed_timestamp,
@@ -46,9 +47,9 @@ defmodule AlertProcessor.Dispatcher do
       |> AwsClient.request()
 
     Logger.info(fn ->
-      "SMS notification: header=#{header} user_id=#{user.id} alert_id=#{alert_id} closed_timestamp=#{
-        closed_timestamp
-      } result=#{inspect(result)}"
+      "SMS notification: notification_id=#{notification_id} header=#{header} user_id=#{user.id} alert_id=#{
+        alert_id
+      } closed_timestamp=#{closed_timestamp} result=#{inspect(result)}"
     end)
 
     result

--- a/apps/alert_processor/lib/rules_engine/scheduler.ex
+++ b/apps/alert_processor/lib/rules_engine/scheduler.ex
@@ -25,9 +25,10 @@ defmodule AlertProcessor.Scheduler do
     # save notification in the database before adding to sending queue
     # do this now incase we re-match the same notificaiton before finishing
     # sending from a previous iteration
-    for notification <- notifications do
-      {:ok, _} = Notification.save(notification, :sent)
-    end
+    Enum.map(notifications, fn notification ->
+      {:ok, notification} = Notification.save(notification, :sent)
+      notification
+    end)
 
     SendingQueue.list_enqueue(notifications)
   end

--- a/apps/alert_processor/test/alert_processor/dissemination/dispatcher_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/dispatcher_test.exs
@@ -15,7 +15,7 @@ defmodule AlertProcessor.DispatcherTest do
     ]
   }
 
-  test "notification_email/1 requires a header" do
+  test "send_notification/1 requires a header" do
     notification = %Notification{
       header: nil,
       email: @email,
@@ -26,17 +26,18 @@ defmodule AlertProcessor.DispatcherTest do
     assert {:error, _} = response
   end
 
-  test "notification_email/1 requires an email or phone number" do
+  test "send_notification/1 requires an email or phone number" do
     notification = %Notification{
       header: @body,
       email: nil,
       phone_number: nil
     }
+
     response = Dispatcher.send_notification(notification)
     assert {:error, _} = response
   end
 
-  test "notification_email/1 can send sms" do
+  test "send_notification/1 can send sms" do
     notification = %Notification{
       header: @body,
       email: nil,
@@ -47,7 +48,7 @@ defmodule AlertProcessor.DispatcherTest do
     assert_received :publish
   end
 
-  test "notification_email/1 can send email" do
+  test "send_notification/1 can send email" do
     notification = %Notification{
       header: @body,
       email: @email,
@@ -59,13 +60,14 @@ defmodule AlertProcessor.DispatcherTest do
     assert_received {:sent_notification_email, ^notification}
   end
 
-  test "notification_email/1 cannot send both sms and email" do
+  test "send_notification/1 cannot send both sms and email" do
     notification = %Notification{
       header: @body,
       email: @email,
       phone_number: @phone_number,
       alert: @alert
     }
+
     {:ok, _} = Dispatcher.send_notification(notification)
     refute_received {:sent_notification_email, ^notification}
     assert_received :publish


### PR DESCRIPTION
This log line also includes the `message_id` property from AWS so we can
link the two when looking at both sets of logs.

Asana ticket: https://app.asana.com/0/529741067494252/742189366823081