### PR TITLE
fix service info cache (GTFS change)

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -219,7 +219,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                short_name: "",
                stop_list: [
                  {"Charlestown", "Boat-Charlestown", {42.373334, -71.05416}, 1},
-                 {"Boston (Long Wharf)", "Boat-Long", {42.360018, -71.050247}, 1}
+                 {"Long Wharf (South)", "Boat-Long-South", {42.359448, -71.050498}, 1}
                ]
              },
              %AlertProcessor.Model.Route{
@@ -232,11 +232,11 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                short_name: "",
                stop_list: [
                  {"Hingham", "Boat-Hingham", {42.252643, -70.919875}, 1},
-                 {"Boston (Rowes Wharf)", "Boat-Rowes", {42.355721, -71.049897}, 1},
+                 {"Rowes Wharf", "Boat-Rowes", {42.355721, -71.049897}, 1},
                  {"George's Island", "Boat-George", {42.319742, -70.930427}, 1},
                  {"Hull", "Boat-Hull", {42.303251, -70.920215}, 1},
-                 {"Logan Airport", "Boat-Logan", {42.359789, -71.02734}, 1},
-                 {"Boston (Long Wharf)", "Boat-Long", {42.360018, -71.050247}, 1}
+                 {"Logan Airport Ferry Terminal", "Boat-Logan", {42.359789, -71.02734}, 1},
+                 {"Long Wharf (North)", "Boat-Long", {42.360795, -71.049976}, 1}
                ]
              }
            ] = route_info


### PR DESCRIPTION
NO TICKET

looks like a recent change in GTFS is causing one of the Service Info cache tests to fail.