### PR TITLE
Ignore any notification we are unable to save

### DIFF
--- a/apps/alert_processor/test/alert_processor/rules_engine/scheduler_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/scheduler_test.exs
@@ -36,5 +36,24 @@ defmodule AlertProcessor.SchedulerTest do
       {:ok, queued_notification} = SendingQueue.pop()
       assert notification == queued_notification
     end
+
+    test "ignores notifications that can't be saved", %{time: time} do
+      # User is intentionally *not* saved to the database.
+      # This replicates the race condition of an account being deleted while alerts are being matched.
+      user = build(:user)
+      sub = insert(:subscription, user: user)
+
+      alert = %Alert{
+        id: "1",
+        header: "test",
+        active_period: [%{start: time.two_days_from_now, end: time.three_days_from_now}],
+        service_effect: "test",
+        last_push_notification: DateTime.utc_now()
+      }
+
+      {:ok, [_notification]} = Scheduler.schedule_notifications([{user, [sub]}], alert)
+      {:ok, queued_notification} = SendingQueue.pop()
+      assert queued_notification == nil
+    end
   end
 end


### PR DESCRIPTION
This might happen e.g. due to a race condition if an account is deleted
while alerts are being matched.

Asana ticket: https://app.asana.com/0/529741067494252/767025370928484