### PR TITLE
update choicesjs to commit in official repo

### DIFF
--- a/apps/concierge_site/assets/package.json
+++ b/apps/concierge_site/assets/package.json
@@ -10,7 +10,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "bootstrap": "^4.1.0",
-    "choices.js": "git+https://git@github.com/mbta/Choices.git#rpm-add-highlight-choice-event",
+    "choices.js": "git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5",
     "elem-dataset": "^1.1.1",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",

--- a/apps/concierge_site/assets/yarn.lock
+++ b/apps/concierge_site/assets/yarn.lock
@@ -1059,9 +1059,9 @@ check-dependencies@~1.0.1:
     minimist "^1.2.0"
     semver "^5.3.0"
 
-"choices.js@git+https://git@github.com/mbta/Choices.git#rpm-add-highlight-choice-event":
+"choices.js@git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5":
   version "4.0.0"
-  resolved "git+https://git@github.com/mbta/Choices.git#7ef478b711f1fcb4daa0e6131fa96ab529efd0b4"
+  resolved "git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5"
   dependencies:
     classnames "^2.2.5"
     core-js "^2.5.6"


### PR DESCRIPTION
NO TICKET

I broke our JS build last night when I removed a branch from the MBTA fork of the ChoicesJS project.  I removed it because our work was merged into the official project (and I forgot we had referenced our fork!).

This PR references our commit to the official repo. We are using a pre-release version, so I want to peg us to this commit until the next version of the library is officially released.