### PR TITLE
Use npx for running brunch

### DIFF
--- a/apps/concierge_site/assets/package.json
+++ b/apps/concierge_site/assets/package.json
@@ -2,8 +2,8 @@
   "repository": {},
   "license": "MIT",
   "scripts": {
-    "deploy": "brunch build --production",
-    "watch": "brunch watch --stdin"
+    "deploy": "npx brunch build --production",
+    "watch": "npx brunch watch --stdin"
   },
   "dependencies": {
     "PubSub": "^3.4.0",


### PR DESCRIPTION
Allows you to run brunch without specifying the node_modules path.