### PR TITLE
Add better support for SMS opt-outs

### DIFF
--- a/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
+++ b/apps/alert_processor/lib/dissemination/sms_opt_out_worker.ex
@@ -109,6 +109,6 @@ defmodule AlertProcessor.SmsOptOutWorker do
 
   @spec update_users_opted_out([User.id()]) :: [User.id()]
   defp update_users_opted_out(user_ids) do
-    User.remove_users_phone_number(user_ids, "sms-opt-out")
+    User.opt_users_out_of_sms(user_ids)
   end
 end

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -82,6 +82,12 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
     subscriptions
     |> Enum.group_by(& &1.user)
     |> Map.to_list()
+    |> reject_users_with_no_communication_mode()
     |> Scheduler.schedule_notifications(alert)
+  end
+
+  defp reject_users_with_no_communication_mode(subscriptions_by_user) do
+    subscriptions_by_user
+    |> Enum.reject(fn {user, _subscriptions} -> user.communication_mode == "none" end)
   end
 end

--- a/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/sms_opt_out_worker_test.exs
@@ -11,6 +11,8 @@ defmodule AlertProcessor.SmsOptOutWorkerTest do
     assert_received :list_phone_numbers_opted_out
     reloaded_user = Repo.one(from(u in User, where: u.id == ^user.id))
     assert reloaded_user.phone_number == nil
+    assert reloaded_user.sms_opted_out_at != nil
+    assert reloaded_user.communication_mode == "none"
   end
 
   test "worker fetches list of opted out phone numbers from aws sns and doesnt update for numbers not in list" do

--- a/apps/concierge_site/assets/css/app.scss
+++ b/apps/concierge_site/assets/css/app.scss
@@ -97,6 +97,22 @@ h6 {
       }
     }
   }
+
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:active,
+  &.disabled:focus {
+    background-color: #f0f4f5 !important;
+    border-color: #949899 !important;
+    color: #afb3b6;
+    cursor: not-allowed;
+
+    path,
+    circle {
+      fill: #f0f4f5;
+      stroke: #afb3b6;
+    }
+  }
 }
 
 .btn.btn-primary {

--- a/apps/concierge_site/assets/js/radio-toggle.js
+++ b/apps/concierge_site/assets/js/radio-toggle.js
@@ -88,7 +88,7 @@ function toggleEvents($) {
     switch (inputName) {
       case "user[sms_toggle]":
         const $phoneContainerEl = $("div[data-phone='input']");
-        if (inputValue == "true") {
+        if (inputValue == "true" && !$labelEl.hasClass("disabled")) {
           $phoneContainerEl.removeClass("d-none");
           $phoneContainerEl.find("input").attr("required", "required");
           setTimeout(() => {

--- a/apps/concierge_site/lib/templates/account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit.html.eex
@@ -1,3 +1,5 @@
+<% alias AlertProcessor.Model.User %>
+
 <h1 class="heading__title">My account settings</h1>
 <%= flash_error(@conn) %>
 
@@ -13,15 +15,15 @@
               <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: @changeset.data.phone_number == nil %>
               <div>Email me</div>
             </label>
-            <label data-id="sms" role="radio" aria-checked="<%= if @changeset.data.phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if @changeset.data.phone_number != nil, do: "active" %>" tabindex="0">
+            <label data-id="sms" role="radio" aria-checked="<%= if @changeset.data.phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}), do: "disabled" %> <%= if !User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) and @changeset.data.phone_number != nil, do: "active" %>" tabindex="0">
               <%= render ConciergeSite.LayoutView, "_icon_sms.html" %>
-              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: @changeset.data.phone_number != nil %>
+              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: @changeset.data.phone_number != nil, disabled: User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) %>
               <div>Text me</div>
             </label>
           </div>
         </div>
 
-        <div class="form-group my-4 <%= if @changeset.data.phone_number == nil, do: "d-none" %>" data-phone="input">
+        <div class="form-group my-4 <%= if @changeset.data.communication_mode == "none" or @changeset.data.phone_number == nil, do: "d-none" %>" data-phone="input">
           <%= label form, :phone_number, "What’s your mobile phone number?", class: "form__label d-block" %>
           <%= error_tag form, :phone_number %>
           <%= telephone_input form, :phone_number, autocomplete: "off", placeholder: "###-###-####", class: "form-control d-inline-block form__phone--input", data: [toggle: "input"] %>

--- a/apps/concierge_site/lib/views/flash_helpers.ex
+++ b/apps/concierge_site/lib/views/flash_helpers.ex
@@ -12,7 +12,7 @@ defmodule ConciergeSite.FlashHelpers do
   def flash_error(conn) do
     if error = get_flash(conn, :error) do
       content_tag :div, class: "error-block-container", tabindex: "0" do
-        content_tag(:span, error, class: "error-block text-center")
+        content_tag(:span, error, class: "error-block")
       end
     end
   end
@@ -31,7 +31,7 @@ defmodule ConciergeSite.FlashHelpers do
   """
   def flash_info(conn) do
     if info = get_flash(conn, :info) do
-      content_tag(:div, info, class: "alert alert-success text-center", tabindex: "0")
+      content_tag(:div, info, class: "alert alert-success", tabindex: "0")
     end
   end
 end

--- a/apps/concierge_site/test/web/controllers/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/account_controller_test.exs
@@ -131,6 +131,7 @@ defmodule ConciergeSite.AccountControllerTest do
 
       assert html_response(conn, 302) =~ "/trips"
       assert updated_user.phone_number == "5555555555"
+      assert updated_user.communication_mode == "sms"
     end
 
     test "POST /account/edit error", %{conn: conn} do


### PR DESCRIPTION
Update the communication_mode when the user updates their settings.
Record an opt out time and set communication mode to none when a user opts out.
Don't send notifications to users with communication_mode set to none.
Disable "Text me" button when opted out of SMS & display a message.

Asana ticket: https://app.asana.com/0/529741067494252/781426141248145

**NB: After deploying this we'll want to run the following SQL query on production:**

    UPDATE users
    SET communication_mode = 'sms'
    WHERE phone_number IS NOT null;