### PR TITLE
use erlang 20.3.8.7 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20 as builder
+FROM erlang:20.3.8.7 as builder
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.6.5" \


### PR DESCRIPTION
NO TICKET

seeing this error when attempting a dev build: `no matching manifest for linux/amd64 in the manifest list entries`. Should be resolved by setting the specific version number.