### PR TITLE
filter out all_clears that don't get sent

### DIFF
--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_courtesy_email_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_courtesy_email_test.exs
@@ -34,11 +34,25 @@ defmodule AlertProcessor.AlertCourtesyEmailTest do
              AlertCourtesyEmail.send_courtesy_emails([@saved_alert], [
                %{
                  @alert
-                 | closed_timestamp: DateTime.from_naive!(~N[2018-01-01 09:30:00.000], "Etc/UTC")
+                 | closed_timestamp: DateTime.from_naive!(~N[2018-01-01 09:30:00.000], "Etc/UTC"),
+                   last_push_notification:
+                     DateTime.from_naive!(~N[2018-01-01 09:30:00.000], "Etc/UTC")
                }
              ])
 
     assert notification.type == :all_clear
+  end
+
+  test "do not send all clear courtesy email when closed_timestamp does not match last_push_notification" do
+    assert [] =
+             AlertCourtesyEmail.send_courtesy_emails([@saved_alert], [
+               %{
+                 @alert
+                 | closed_timestamp: DateTime.from_naive!(~N[2018-01-01 09:30:00.000], "Etc/UTC"),
+                   last_push_notification:
+                     DateTime.from_naive!(~N[2017-01-01 09:30:00.000], "Etc/UTC")
+               }
+             ])
   end
 
   test "does not send courtesy email when ids do not match" do


### PR DESCRIPTION
[(2) Ensure there's a way to receive a 'courtesy copy' of all alerts that are sent](https://app.asana.com/0/529741067494252/791039552737801/f)

This PR addresses the update in the ticket:
```make sure that we don't send courtesy emails for all clear that we don't send to subscribers```