### PR TITLE
Remove a redundant notification query method

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -98,22 +98,6 @@ defmodule AlertProcessor.Model.Notification do
     )
   end
 
-  def most_recent_for_subscriptions_and_alerts(alerts) do
-    alert_ids = Enum.map(alerts, & &1.id)
-
-    Repo.all(
-      from(
-        n in __MODULE__,
-        where: n.alert_id in ^alert_ids,
-        where: n.status == "sent",
-        preload: [subscriptions: :user],
-        distinct: [:alert_id, :user_id],
-        order_by: [desc: n.last_push_notification],
-        select: n
-      )
-    )
-  end
-
   def most_recent_for_alerts(alerts) do
     alert_ids = Enum.map(alerts, & &1.id)
 
@@ -124,7 +108,7 @@ defmodule AlertProcessor.Model.Notification do
         where: n.status == "sent",
         preload: [subscriptions: :user],
         distinct: [:alert_id, :user_id],
-        order_by: [desc: n.inserted_at],
+        order_by: [desc: n.last_push_notification],
         select: n
       )
     )

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -25,7 +25,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
   def schedule_all_notifications(alerts, alert_filter_duration_type \\ :anytime) do
     start_time = Time.utc_now()
     active_subscriptions = Subscription.all_active_for_alerts(alerts)
-    recent_notifications = Notification.most_recent_for_subscriptions_and_alerts(alerts)
+    recent_notifications = Notification.most_recent_for_alerts(alerts)
     schedule_notifications(active_subscriptions, recent_notifications, alerts)
 
     Logger.info(fn ->

--- a/apps/alert_processor/test/alert_processor/model/notification_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/notification_test.exs
@@ -127,61 +127,6 @@ defmodule AlertProcessor.Model.NotificationTest do
     assert returned_notification_id == saved_notification_1.id
   end
 
-  test "most_recent_for_subscriptions_and_alerts/1 only returns latest notification by last_push_notification for alert/user combo" do
-    now = DateTime.utc_now()
-    later = Calendar.DateTime.add!(now, 1800)
-    user1 = insert(:user)
-    sub1 = insert(:subscription, user: user1)
-
-    notification1 =
-      struct(
-        Notification,
-        Map.merge(@base_attrs, %{
-          user: user1,
-          last_push_notification: now,
-          notification_subscriptions: [%NotificationSubscription{subscription: sub1}]
-        })
-      )
-
-    {:ok, saved_notification_1} = Notification.save(notification1, :sent)
-
-    notification2 =
-      struct(
-        Notification,
-        Map.merge(@base_attrs, %{
-          user: user1,
-          last_push_notification: later,
-          notification_subscriptions: [%NotificationSubscription{subscription: sub1}]
-        })
-      )
-
-    {:ok, saved_notification_2} = Notification.save(notification2, :sent)
-
-    notification3 =
-      struct(
-        Notification,
-        Map.merge(@base_attrs, %{
-          user: user1,
-          last_push_notification: now,
-          alert_id: "55555",
-          notification_subscriptions: [%NotificationSubscription{subscription: sub1}]
-        })
-      )
-
-    {:ok, saved_notification_3} = Notification.save(notification3, :sent)
-
-    notifications =
-      Notification.most_recent_for_subscriptions_and_alerts([%{id: "12345678"}, %{id: "55555"}])
-
-    returned_notification_ids = Enum.map(notifications, & &1.id)
-    refute Enum.member?(returned_notification_ids, saved_notification_1.id)
-    assert Enum.member?(returned_notification_ids, saved_notification_2.id)
-    assert Enum.member?(returned_notification_ids, saved_notification_3.id)
-    [returned_notification1, returned_notification2] = notifications
-    assert [sub1.id] == Enum.map(returned_notification1.subscriptions, & &1.id)
-    assert [sub1.id] == Enum.map(returned_notification2.subscriptions, & &1.id)
-  end
-
   describe "most_recent_for_alerts/1" do
     test "returns most recent notification by inserted_at" do
       user = insert(:user)

--- a/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/sent_alert_filter_test.exs
@@ -282,7 +282,7 @@ defmodule AlertProcessor.SentAlertFilterTest do
         |> Repo.all()
         |> Repo.preload(:user)
 
-      notifications = Notification.most_recent_for_subscriptions_and_alerts([alert])
+      notifications = Notification.most_recent_for_alerts([alert])
 
       loaded_subscription =
         notifications


### PR DESCRIPTION
Notification.most_recent_for_subscriptions_and_alerts and
Notification.most_recent_for_alerts were identical, save the ordering.
Remove the one with the less accurate name.