### PR TITLE
Handle email coming in as a List

### DIFF
--- a/apps/concierge_site/lib/dissemination/deliver_later_strategy.ex
+++ b/apps/concierge_site/lib/dissemination/deliver_later_strategy.ex
@@ -17,11 +17,19 @@ defmodule ConciergeSite.Dissemination.DeliverLaterStrategy do
         # Consciously dropping the email on the floor if we get an SMTP error.
         # Once we learn more about why we are getting these occasionally we might want to take better action.
         e in SMTPError ->
-          Logger.error(fn -> "SMTP error sending to #{email.to}: #{e.message}" end)
+          Logger.error(fn -> "SMTP error sending to #{email_address(email.to)}: #{e.message}" end)
 
         e ->
-          Logger.error(fn -> "Unknown error sending to #{email.to}: #{inspect(e)}" end)
+          Logger.error(fn ->
+            "Unknown error sending to #{email_address(email.to)}: #{inspect(e)}"
+          end)
       end
     end)
   end
+
+  defp email_address(email) when is_list(email), do: email |> List.first() |> email_address()
+
+  defp email_address({_, email}), do: email
+
+  defp email_address(email), do: email
 end

--- a/apps/concierge_site/test/lib/dissemination/deliver_later_strategy_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/deliver_later_strategy_test.exs
@@ -22,7 +22,11 @@ defmodule ConciergeSite.Dissemination.DeliverLaterStrategyTest do
 
     test "handles SMTPError" do
       task =
-        DeliverLaterStrategy.deliver_later(MockSMTPErrorAdapter, %{to: "Mock email address"}, %{})
+        DeliverLaterStrategy.deliver_later(
+          MockSMTPErrorAdapter,
+          %{to: [nil: "Mock email address"]},
+          %{}
+        )
 
       ref = Process.monitor(task.pid)
 


### PR DESCRIPTION
We were getting a bug where the email was coming in as a list like:
`[nil: "address@example.com"]`. This change allows us to handle that
data format as well as a plain string.

Asana ticket: https://app.asana.com/0/529741067494252/799263185248532