### PR TITLE
Don't include a token in email manage subscription links

### DIFF
--- a/apps/concierge_site/lib/dissemination/email.ex
+++ b/apps/concierge_site/lib/dissemination/email.ex
@@ -46,7 +46,7 @@ defmodule ConciergeSite.Dissemination.Email do
   )
 
   def confirmation_email(user) do
-    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url()
     feedback_url = MailHelper.feedback_url()
 
     base_email()
@@ -71,7 +71,7 @@ defmodule ConciergeSite.Dissemination.Email do
   )
 
   def targeted_notification_email(user, subject, body) do
-    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url()
     feedback_url = MailHelper.feedback_url()
 
     base_email()

--- a/apps/concierge_site/lib/dissemination/notification_email.ex
+++ b/apps/concierge_site/lib/dissemination/notification_email.ex
@@ -27,7 +27,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmail do
   @doc "notification_email/1 takes a notification and builds an email to be sent to user."
   @spec notification_email(Notification.t()) :: Elixir.Bamboo.Email.t()
   def notification_email(%Notification{user: user} = notification) do
-    manage_subscriptions_url = MailHelper.manage_subscriptions_url(user)
+    manage_subscriptions_url = MailHelper.manage_subscriptions_url()
     feedback_url = MailHelper.feedback_url()
     notification_email_subject = email_subject(notification)
 

--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -7,7 +7,6 @@ defmodule ConciergeSite.Helpers.MailHelper do
   @template_dir Application.get_env(:concierge_site, :mail_template_dir)
 
   alias AlertProcessor.Model.{Alert, InformedEntity}
-  alias ConciergeSite.Auth.Token
   alias ConciergeSite.Router.Helpers
   alias AlertProcessor.Helpers.ConfigHelper
   require EEx
@@ -100,10 +99,7 @@ defmodule ConciergeSite.Helpers.MailHelper do
   defp logo_for_subway(nil),
     do: Helpers.static_url(ConciergeSite.Endpoint, "/images/icons/icn_facility.png")
 
-  def manage_subscriptions_url(user) do
-    {:ok, token, _permissions} = Token.issue(user, [:manage_subscriptions], {30, :days})
-    Helpers.trip_url(ConciergeSite.Endpoint, :index, token: token)
-  end
+  def manage_subscriptions_url(), do: Helpers.trip_url(ConciergeSite.Endpoint, :index)
 
   def feedback_url do
     case ConfigHelper.get_string(:feedback_url, :concierge_site) do

--- a/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
+++ b/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
@@ -1,7 +1,6 @@
 defmodule ConcerigeSite.Helpers.MailHelperTest do
   @moduledoc false
   use ConciergeSite.DataCase, async: true
-  import AlertProcessor.Factory
   alias ConciergeSite.Helpers.MailHelper
   alias AlertProcessor.{Model.Alert, Model.InformedEntity}
 
@@ -104,10 +103,9 @@ defmodule ConcerigeSite.Helpers.MailHelperTest do
 
   describe "manage_subscription_url" do
     test "generates url with token" do
-      user = insert(:user)
-      url = MailHelper.manage_subscriptions_url(user)
+      url = MailHelper.manage_subscriptions_url()
       assert url =~ "http"
-      assert url =~ ~r/trips\?token=(.+)/
+      assert url =~ ~r/trips$/
     end
   end
 


### PR DESCRIPTION
Logging a user in automatically is a problem if the user forwards an
email to someone else.

Asana ticket: https://app.asana.com/0/529741067494252/783281337255523