### PR TITLE
change error messages on sign-up form

### DIFF
--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -7,7 +7,7 @@ defmodule AlertProcessor.Model.UserTest do
   @valid_account_attrs %{
     "email" => "test@email.com",
     "password" => "Password1",
-    "sms_toggle" => "false"
+    "communication_mode" => "email"
   }
   @invalid_attrs %{}
   @password "password1"
@@ -36,7 +36,7 @@ defmodule AlertProcessor.Model.UserTest do
       assert {:ok, user} =
                User.create_account(
                  Map.merge(@valid_account_attrs, %{
-                   "sms_toggle" => "true",
+                   "communication_mode" => "sms",
                    "phone_number" => "555-555-1234"
                  })
                )
@@ -53,7 +53,7 @@ defmodule AlertProcessor.Model.UserTest do
       assert {:ok, user} =
                User.update_account(
                  user,
-                 %{"phone_number" => "5550000000", "sms_toggle" => "true"},
+                 %{"phone_number" => "5550000000", "communication_mode" => "sms"},
                  user.id
                )
 
@@ -77,7 +77,11 @@ defmodule AlertProcessor.Model.UserTest do
       user = insert(:user)
 
       assert {:error, changeset} =
-               User.update_account(user, %{"phone_number" => "not a phone number"}, user.id)
+               User.update_account(
+                 user,
+                 %{"phone_number" => "not a phone number", "communication_mode" => "sms"},
+                 user.id
+               )
 
       refute changeset.valid?
     end
@@ -146,13 +150,13 @@ defmodule AlertProcessor.Model.UserTest do
       refute changeset.valid?
     end
 
-    test "if sms_toggle is true, will validate phone number" do
+    test "if communication_mode is sms, will validate phone number" do
       changeset =
         User.create_account_changeset(
           %User{},
           Map.merge(@valid_account_attrs, %{
             "phone_number" => "2342342344",
-            "sms_toggle" => "true"
+            "communication_mode" => "sms"
           })
         )
 
@@ -161,15 +165,19 @@ defmodule AlertProcessor.Model.UserTest do
       assert changeset.valid?
     end
 
-    test "if sms_toggle is false, phone_number (if present) will be ignored" do
+    test "if communication_mode is email, phone_number (if present) will be ignored" do
+      params =
+        @valid_account_attrs
+        |> Map.put("phone_number", "2342342344")
+
       changeset =
         User.create_account_changeset(
           %User{},
-          Map.put(@valid_account_attrs, "phone_number", "2342342344")
+          params
         )
 
       %{changes: changes} = changeset
-      refute Map.has_key?(changes, :phone_number)
+      assert changes.phone_number == nil
       assert changeset.valid?
     end
   end

--- a/apps/concierge_site/assets/css/_forms.scss
+++ b/apps/concierge_site/assets/css/_forms.scss
@@ -56,14 +56,12 @@ label.form__label--inline {
   margin-top: 0.5rem;
 
   span {
+    color: #b3000f;
     display: block;
-    margin: 0.5rem;
     padding: 0.4rem;
 
-    &:before {
-      @include fa-icon();
-      content: $fa-var-exclamation-circle;
-      margin-right: 0.25rem;
+    &:first-letter {
+      text-transform: capitalize;
     }
   }
 }

--- a/apps/concierge_site/assets/css/_stop_selector.scss
+++ b/apps/concierge_site/assets/css/_stop_selector.scss
@@ -2,4 +2,8 @@
   .choices__list--dropdown .choices__item--selectable {
     padding-right: 0;
   }
+
+  &.choices {
+    margin-bottom: 0;
+  }
 }

--- a/apps/concierge_site/assets/js/radio-toggle.js
+++ b/apps/concierge_site/assets/js/radio-toggle.js
@@ -88,15 +88,16 @@ function toggleEvents($) {
     switch (inputName) {
       case "user[sms_toggle]":
         const $phoneContainerEl = $("div[data-phone='input']");
+        const $communicationModelEl = $("#user_communication_mode");
         if (inputValue == "true" && !$labelEl.hasClass("disabled")) {
           $phoneContainerEl.removeClass("d-none");
-          $phoneContainerEl.find("input").attr("required", "required");
+          $communicationModelEl.val("sms");
           setTimeout(() => {
             $phoneContainerEl.find("input").focus();
           }, 250);
         } else {
+          $communicationModelEl.val("email");
           $phoneContainerEl.addClass("d-none");
-          $phoneContainerEl.find("input").removeAttr("required");
         }
         break;
 

--- a/apps/concierge_site/lib/controllers/accessibility_trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/accessibility_trip_controller.ex
@@ -167,19 +167,19 @@ defmodule ConciergeSite.AccessibilityTripController do
   end
 
   defp validate_days(%{changes: %{relevant_days: []}} = changeset) do
-    add_error(changeset, :relevant_days, "at least one day must be selected")
+    add_error(changeset, :relevant_days, "Please select at least one day to continue.")
   end
 
   defp validate_days(changeset), do: changeset
 
   defp validate_features(%{changes: %{elevator: "false", escalator: "false"}} = changeset) do
-    add_error(changeset, :escalator, "at least one accessibility feature must be selected")
+    add_error(changeset, :escalator, "Please select at least one station feature.")
   end
 
   defp validate_features(changeset), do: changeset
 
   defp validate_stops(%{changes: %{stops: [], routes: []}} = changeset) do
-    add_error(changeset, :stops, "must choose at least one stop or line")
+    add_error(changeset, :stops, "Please select a stop to continue.")
   end
 
   defp validate_stops(changeset), do: changeset

--- a/apps/concierge_site/lib/controllers/account_controller.ex
+++ b/apps/concierge_site/lib/controllers/account_controller.ex
@@ -85,8 +85,8 @@ defmodule ConciergeSite.AccountController do
     redirect(conn, to: page_path(conn, :account_deleted))
   end
 
-  def options_new(conn, _params, user, _claims) do
-    changeset = User.update_account_changeset(user)
+  def options_new(conn, params, user, _claims) do
+    changeset = User.update_account_changeset(user, params)
 
     render(conn, "options_new.html", changeset: changeset, user: user, sms_toggle: false)
   end

--- a/apps/concierge_site/lib/templates/account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit.html.eex
@@ -3,6 +3,15 @@
 <h1 class="heading__title">Settings</h1>
 <%= flash_error(@conn) %>
 
+<%
+  communication_mode = if @changeset.data.phone_number == nil && Map.get(@changeset.changes, :communication_mode, @changeset.data.communication_mode) != "sms" do
+    "email"
+  else
+    "sms"
+  end
+%>
+
+
 <div class="container container__inner">
   <div class="row justify-content-md-center">
     <div class="col-sm-12">
@@ -10,29 +19,30 @@
         <div class="form-group form__section--top">
           <%= label form, :sms_toggle, "I’d like to receive alert notifications by:", class: "form__label" %>
           <div class="btn-group btn-group-toggle btn__radio--toggle-container" data-toggle="buttons" role="radiogroup">
-            <label data-id="email" role="radio" aria-checked="<%= if @changeset.data.phone_number == nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if @changeset.data.phone_number == nil, do: "active" %>" tabindex="0">
+            <label data-id="email" role="radio" aria-checked="<%= if communication_mode == "email", do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if communication_mode == "email", do: "active" %>" tabindex="0">
               <%= render ConciergeSite.LayoutView, "_icon_email.html" %>
               <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: @changeset.data.phone_number == nil %>
               <div>Email me</div>
             </label>
-            <label data-id="sms" role="radio" aria-checked="<%= if @changeset.data.phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}), do: "disabled" %> <%= if !User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) and @changeset.data.phone_number != nil, do: "active" %>" tabindex="0">
+            <label data-id="sms" role="radio" aria-checked="<%= if communication_mode == "sms", do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}), do: "disabled" %> <%= if !User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) and communication_mode == "sms", do: "active" %>" tabindex="0">
               <%= render ConciergeSite.LayoutView, "_icon_sms.html" %>
               <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: @changeset.data.phone_number != nil, disabled: User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) %>
               <div>Text me</div>
             </label>
           </div>
+          <%= hidden_input form, :communication_mode, value: communication_mode  %>
         </div>
 
-        <div class="form-group my-4 <%= if @changeset.data.communication_mode == "none" or @changeset.data.phone_number == nil, do: "d-none" %>" data-phone="input">
+        <div class="form-group my-4 <%= if communication_mode != "sms", do: "d-none" %>" data-phone="input">
           <%= label form, :phone_number, "My phone number is:", class: "form__label d-block" %>
+          <%= telephone_input form, :phone_number, autocomplete: "off", placeholder: "###-###-####", class: "form-control d-inline-block form__phone--input", data: [toggle: "input"], required: false %>
           <%= error_tag form, :phone_number %>
-          <%= telephone_input form, :phone_number, autocomplete: "off", placeholder: "###-###-####", class: "form-control d-inline-block form__phone--input", data: [toggle: "input"] %>
         </div>
 
         <div class="form-group form__section">
           <%= label form, :email, "My account email:", class: "form__label" %>
+          <%= text_input form, :email, placeholder: "your@email.com", autocomplete: "off", value: @changeset.data.email, class: "form-control fs-hide" %>
           <%= error_tag form, :email %>
-          <%= email_input form, :email, placeholder: "your@email.com", autocomplete: "off", value: @changeset.data.email, class: "form-control fs-hide", required: true %>
           <div class="my-3"><%= link to: account_path(@conn, :edit_password) do %>Change password<% end %>
         </div>
 

--- a/apps/concierge_site/lib/templates/account/new.html.eex
+++ b/apps/concierge_site/lib/templates/account/new.html.eex
@@ -16,15 +16,15 @@
 
         <div class="form-group my-4">
           <%= label f, :email, "Enter your email", class: "form__label" %>
-          <%= error_tag f, :email %>
-          <%= email_input f, :email, placeholder: "your@email.com", class: "form-control", required: true %>
+          <%= text_input f, :email, placeholder: "your@email.com", class: "form-control" %>
+          <%= error_tag f, :email, "Email" %>
         </div>
 
         <div class="form-group my-4">
           <%= label f, :password, "Create a password", class: "form__label" %>
-          <%= error_tag f, :password %>
-          <%= password_input f, :password, placeholder: "Enter your password", class: "form-control", pattern: password_regex_string(), required: true %>
+          <%= password_input f, :password, placeholder: "Enter your password", class: "form-control" %>
           <div class="my-1 form-control__details">At least 6 characters, with one number or special character</div>
+          <%= error_tag f, :password, "Password" %>
         </div>
 
         <div class="form__action-buttons--container">

--- a/apps/concierge_site/lib/templates/account/options_new.html.eex
+++ b/apps/concierge_site/lib/templates/account/options_new.html.eex
@@ -1,30 +1,38 @@
 <h1 class="heading__title">Customize my settings</h1>
 <%= flash_error(@conn) %>
-
+<%
+  communication_mode = if @changeset.data.phone_number == nil && Map.get(@changeset.changes, :communication_mode, @changeset.data.communication_mode) != "sms" do
+    "email"
+  else
+    "sms"
+  end
+%>
 <div class="container container__inner">
   <div class="row justify-content-md-center">
     <div class="col-md-10 col-sm-12">
       <%= form_for @changeset, account_path(@conn, :options_create), [as: :user, method: :post], fn form -> %>
+        <% phone_number = @changeset.data.phone_number || form.params["phone_number"] %>
         <div class="form-group form__section--top">
           <%= label form, :sms_toggle, "How would you like to receive alerts?", class: "form__label" %>
           <div class="btn-group btn-group-toggle btn__radio--toggle-container" data-toggle="buttons" role="radiogroup">
-            <label data-id="email" role="radio" aria-checked="<%= if @changeset.data.phone_number == nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if @changeset.data.phone_number == nil, do: "active" %>" tabindex="0">
+            <label data-id="email" role="radio" aria-checked="<%= if @changeset.data.phone_number == nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if phone_number == nil, do: "active" %>" tabindex="0">
               <%= render ConciergeSite.LayoutView, "_icon_email.html" %>
-              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: @changeset.data.phone_number == nil %>
+              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: phone_number == nil %>
               <div>Email me</div>
             </label>
-            <label data-id="sms" role="radio" aria-checked="<%= if @changeset.data.phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if @changeset.data.phone_number != nil, do: "active" %>" tabindex="0">
+            <label data-id="sms" role="radio" aria-checked="<%= if phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if phone_number != nil, do: "active" %>" tabindex="0">
               <%= render ConciergeSite.LayoutView, "_icon_sms.html" %>
-              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: @changeset.data.phone_number != nil %>
+              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: phone_number != nil %>
               <div>Text me</div>
             </label>
           </div>
+          <%= hidden_input form, :communication_mode, value: communication_mode  %>
         </div>
 
-        <div class="form-group my-4 d-none" data-phone="input">
+        <div class="form-group my-4 <%= if phone_number == nil, do: "d-none", else: "" %>" data-phone="input">
           <%= label form, :phone_number, "What’s your mobile phone number?", class: "form__label d-block" %>
-          <%= error_tag form, :phone_number %>
           <%= telephone_input form, :phone_number, autocomplete: "off", placeholder: "###-###-####", class: "form-control d-inline-block form__phone--input", data: [toggle: "input"] %>
+          <%= error_tag form, :phone_number %>
           <span class="form__phone--note">Your mobile provider’s message rates may apply.</span>
         </div>
 

--- a/apps/concierge_site/lib/templates/session/new.html.eex
+++ b/apps/concierge_site/lib/templates/session/new.html.eex
@@ -15,13 +15,13 @@
       <%= form_for @login_changeset, session_path(@conn, :create), fn f -> %>
         <div class="form-group my-4">
           <%= label f, :email, "Email login", class: "form__label" %>
+          <%= email_input f, :email, placeholder: "your@email.com", class: "form-control" %>
           <%= error_tag f, :email %>
-          <%= email_input f, :email, placeholder: "your@email.com", class: "form-control", required: true %>
         </div>
         <div class="form-group my-4">
           <%= label f, :password, "Password", class: "form__label" %>
+          <%= password_input f, :password, placeholder: "Enter your password", class: "form-control", pattern: password_regex_string() %>
           <%= error_tag f, :password %>
-          <%= password_input f, :password, placeholder: "Enter your password", class: "form-control", pattern: password_regex_string(), required: true %>
           <div class="text-right">
             <%= link "Forgot password?", to: password_reset_path(@conn, :new) %>
         </div>

--- a/apps/concierge_site/lib/views/error_helpers.ex
+++ b/apps/concierge_site/lib/views/error_helpers.ex
@@ -8,13 +8,21 @@ defmodule ConciergeSite.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  def error_tag(form, field) do
+  def error_tag(form, field, name \\ nil) do
     if error = form.errors[field] do
       content_tag :div, class: "error-block-container" do
-        content_tag(:span, translate_error(error), class: "error-block")
+        message =
+          error
+          |> translate_error()
+          |> replace_field_name(name)
+
+        content_tag(:span, message, class: "error-block")
       end
     end
   end
+
+  defp replace_field_name(message, nil), do: message
+  defp replace_field_name(message, name), do: String.replace(message, "This field", name)
 
   @doc """
   Translates an error message using gettext.

--- a/apps/concierge_site/test/web/controllers/account_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/account_controller_test.exs
@@ -17,7 +17,9 @@ defmodule ConciergeSite.AccountControllerTest do
   test "POST /account bad password", %{conn: conn} do
     params = %{"user" => %{"password" => "password", "email" => "test@test.com"}}
     conn = post(conn, account_path(conn, :create), params)
-    assert html_response(conn, 200) =~ "Password must contain one number"
+
+    assert html_response(conn, 200) =~
+             "Password must contain at least 6 characters, with one number or symbol."
   end
 
   test "POST /account bad email", %{conn: conn} do
@@ -29,7 +31,8 @@ defmodule ConciergeSite.AccountControllerTest do
   test "POST /account empty values", %{conn: conn} do
     params = %{"user" => %{"password" => "", "email" => ""}}
     conn = post(conn, account_path(conn, :create), params)
-    assert html_response(conn, 200) =~ "be blank"
+    assert html_response(conn, 200) =~ "Password is required"
+    assert html_response(conn, 200) =~ "Email is required"
   end
 
   test "GET /account/options", %{conn: conn} do
@@ -48,7 +51,7 @@ defmodule ConciergeSite.AccountControllerTest do
     user = insert(:user, phone_number: nil)
 
     user_params = %{
-      sms_toggle: "true",
+      communication_mode: "sms",
       phone_number: "5555555555",
       digest_opt_in: false
     }
@@ -69,7 +72,7 @@ defmodule ConciergeSite.AccountControllerTest do
     user = insert(:user, phone_number: nil)
 
     user_params = %{
-      sms_toggle: "false",
+      communication_mode: "email",
       phone_number: "5555555555"
     }
 
@@ -88,7 +91,7 @@ defmodule ConciergeSite.AccountControllerTest do
     user = insert(:user)
 
     user_params = %{
-      sms_toggle: "true",
+      communication_mode: "sms",
       phone_number: "123"
     }
 
@@ -118,7 +121,7 @@ defmodule ConciergeSite.AccountControllerTest do
       user = insert(:user, phone_number: nil)
 
       user_params = %{
-        sms_toggle: "true",
+        communication_mode: "sms",
         phone_number: "5555555555",
         email: "test@test.com"
       }
@@ -141,7 +144,7 @@ defmodule ConciergeSite.AccountControllerTest do
       user = insert(:user, email: "before@email.com")
 
       user_params = %{
-        sms_toggle: "false",
+        communication_mode: "email",
         email: "taken@email.com"
       }
 
@@ -157,7 +160,7 @@ defmodule ConciergeSite.AccountControllerTest do
       user = insert(:user, phone_number: nil)
 
       user_params = %{
-        sms_toggle: "true",
+        communication_mode: "sms",
         phone_number: "5"
       }
 

--- a/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
@@ -84,7 +84,9 @@ defmodule ConciergeSite.PasswordResetControllerTest do
       }
 
       conn = patch(conn, password_reset_path(conn, :update, reset_token), params)
-      assert html_response(conn, 422) =~ "Password must contain one number or special character"
+
+      assert html_response(conn, 422) =~
+               "Password must contain at least 6 characters, with one number or symbol."
     end
 
     test "with invalid password confirmation", %{conn: conn} do


### PR DESCRIPTION
[(3) Redoing error messaging/design](https://app.asana.com/0/529741067494252/774490674868445/f)

Most of this is pretty straight forward: change some colors, move some error messages, re-phrase some messages. I did need to change the `user.authenticate` function though, because once the HTML5 validation was removed it was causing an error when empty fields were being sent.