### PR TITLE
Convert tracking_optimal_time to current time if it's in the future

### DIFF
--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -58,7 +58,7 @@ defmodule AlertProcessor.NotificationBuilder do
          subscriptions,
          now
        ) do
-    local_alert_start_time = DateTimeHelper.datetime_to_local(last_push_notification)
+    local_alert_start_time = local_date_time_no_later_than_now(last_push_notification, now)
 
     Enum.reduce(subscriptions, local_alert_start_time, fn %{start_time: start_time},
                                                           last_start_time ->
@@ -68,5 +68,12 @@ defmodule AlertProcessor.NotificationBuilder do
         do: notification_window_start_date_time,
         else: last_start_time
     end)
+  end
+
+  defp local_date_time_no_later_than_now(date_time, now) do
+    with local_now <- DateTimeHelper.datetime_to_local(now),
+         local_date_time <- DateTimeHelper.datetime_to_local(date_time) do
+      if local_date_time <= local_now, do: local_date_time, else: local_now
+    end
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -102,4 +102,23 @@ defmodule AlertProcessor.NotificationBuilderTest do
 
     assert ExUnit.CaptureLog.capture_log(function) =~ expected_log
   end
+
+  test "converts tracking_optimal_time to current time if it's in the future", %{
+    est_time: est_time,
+    now: now
+  } do
+    user = insert(:user)
+    subscription = insert(:subscription, user: user, start_time: ~T[09:00:00])
+
+    alert = %Alert{
+      id: "1",
+      header: nil,
+      active_period: [%{start: est_time.now, end: est_time.three_days_from_now}],
+      last_push_notification: est_time.thirty_minutes_from_now
+    }
+
+    notification = NotificationBuilder.build_notification({user, [subscription]}, alert, now)
+
+    assert notification.tracking_optimal_time == DateTimeHelper.datetime_to_local(now)
+  end
 end


### PR DESCRIPTION
Hopefully this deals with negative timing we are seeing in the logs.

No ticket.