### PR TITLE
Upgrade to the latest version of credo and begin some improvements

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20180322200228_subscription_facility_types.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180322200228_subscription_facility_types.exs
@@ -1,9 +1,9 @@
-defmodule Elixir.AlertProcessor.Repo.Migrations.Subscription_facility_types do
+defmodule Elixir.AlertProcessor.Repo.Migrations.SubscriptionFacilityTypes do
   use Ecto.Migration
 
   def change do
     alter table(:subscriptions) do
-      add :facility_types, {:array, :string}, null: false, default: []
+      add(:facility_types, {:array, :string}, null: false, default: [])
     end
   end
 end

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -215,7 +215,7 @@ defmodule AlertProcessor.AlertParserTest do
       assert %AlertProcessor.Model.Alert{
                active_period: [%{start: start_datetime, end: end_datetime}],
                created_at: created_at_datetime,
-               duration_certainty: {:estimated, 14400},
+               duration_certainty: {:estimated, 14_400},
                effect_name: "Delay",
                header: "Red Line experiencing minor delays",
                id: "115513",
@@ -245,7 +245,7 @@ defmodule AlertProcessor.AlertParserTest do
       assert %AlertProcessor.Model.Alert{
                active_period: [%{start: _start_datetime, end: end_datetime}],
                created_at: created_at_datetime,
-               duration_certainty: {:estimated, 14400},
+               duration_certainty: {:estimated, 14_400},
                effect_name: "Delay",
                header: "Red Line experiencing minor delays",
                id: "115513",

--- a/apps/alert_processor/test/alert_processor/model/subscription_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/subscription_test.exs
@@ -332,7 +332,7 @@ defmodule AlertProcessor.Model.SubscriptionTest do
       Subscription.set_versioned_subscription(multi)
 
       assert [sub | _] = Subscription |> Repo.all() |> Repo.preload(:informed_entities)
-      refute length(sub.informed_entities) == 0
+      refute Enum.empty?(sub.informed_entities)
     end
 
     test "associates versions of informed entities with version of subscription" do
@@ -363,8 +363,8 @@ defmodule AlertProcessor.Model.SubscriptionTest do
       Subscription.set_versioned_subscription(multi)
 
       assert [sub1, sub2 | _] = Subscription |> Repo.all() |> Repo.preload(:informed_entities)
-      refute length(sub1.informed_entities) == 0
-      refute length(sub2.informed_entities) == 0
+      refute Enum.empty?(sub1.informed_entities)
+      refute Enum.empty?(sub2.informed_entities)
     end
 
     test "associates versions of informed entities with version of round_trip subscription" do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule AlertsConcierge.Mixfile do
   # and cannot be accessed from applications inside the apps folder
   defp deps do
     [
-      {:credo, "~> 0.7", only: [:dev, :test]},
+      {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
       {:distillery, "~> 1.5", runtime: false},
       {:excoveralls, "~> 0.5", only: [:dev, :test]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
-  "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.10.1", "e85efaf2dd7054399083ab2c6a5199f6cb1805de1a5b00d9e8c5f07033407b1f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},


### PR DESCRIPTION
• Credo version 0.10.0
• Format large numbers with underscores
• Camel-case the module name
• Use Enum.empty? instead of length == 0

This starts work on https://app.asana.com/0/529741067494252/830957847699954