### PR TITLE
Configure API URL in test to match fixtures

### DIFF
--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -21,6 +21,8 @@ config :alert_processor, :alert_parser, AlertProcessor.AlertParserMock
 
 config :alert_processor, :mailer, AlertProcessor.MailerMock
 
+config :alert_processor, api_url: "https://dev.api.mbtace.com/"
+
 config :alert_processor, database_url: {:system, "DATABASE_URL_TEST"}
 
 config :alert_processor, :notification_window_filter, AlertProcessor.NotificationWindowFilterMock


### PR DESCRIPTION
Ignore the env setting to ensure that tests behave properly no matter
what server you are pointing at for development (e.g. maybe you have
changed it to point to https://green.dev.api.mbtace.com/).

No ticket