### PR TITLE
Fix the sorting of Green Line stops

### DIFF
--- a/apps/alert_processor/lib/model/route.ex
+++ b/apps/alert_processor/lib/model/route.ex
@@ -23,8 +23,13 @@ defmodule AlertProcessor.Model.Route do
         }
   @type route_id :: String.t()
   @type route_type :: 0 | 1 | 2 | 3 | 4
+  @type stop_name :: String.t()
   @type stop_id :: String.t()
-  @type stop :: {String.t(), stop_id, {float(), float()}}
+  @type latitude :: float()
+  @type longitude :: float()
+  @type stop_lat_lon :: {latitude, longitude}
+  @type stop_wheelchair_boarding :: integer
+  @type stop :: {stop_name, stop_id, stop_lat_lon, stop_wheelchair_boarding}
 
   @type t :: %__MODULE__{
           direction_names: [String.t()],

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -1,4 +1,5 @@
 defmodule AlertProcessor.ServiceInfoCacheTest do
+  @moduledoc false
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   alias AlertProcessor.{Model.Route, ServiceInfoCache}
@@ -293,6 +294,23 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
              ServiceInfoCache.get_route(pid, "Orange")
 
     assert {:ok, %Route{route_id: "Green"}} = ServiceInfoCache.get_route(pid, "Green")
+  end
+
+  test "get_route orders stops correctly for all Green branches combined", %{pid: pid} do
+    assert {:ok, %Route{route_id: "Green", stop_list: stop_list}} =
+             ServiceInfoCache.get_route(pid, "Green")
+
+    northeastern_index =
+      Enum.find_index(stop_list, fn {_name, id, _lat_lon, _wheelchair_boarding} ->
+        id == "place-nuniv"
+      end)
+
+    park_index =
+      Enum.find_index(stop_list, fn {_name, id, _lat_lon, _wheelchair_boarding} ->
+        id == "place-pktrm"
+      end)
+
+    assert northeastern_index < park_index
   end
 
   test "get_route/2 finds correct red line shape for given stops", %{pid: pid} do

--- a/apps/concierge_site/lib/schedule.ex
+++ b/apps/concierge_site/lib/schedule.ex
@@ -1,4 +1,7 @@
 defmodule ConciergeSite.Schedule do
+  @moduledoc """
+  The schedule for a route or trip.
+  """
   alias AlertProcessor.{ApiClient, DayType, ExtendedTime, ServiceInfoCache}
   alias AlertProcessor.Model.{Route, Subscription, TripInfo}
   alias ConciergeSite.Schedule
@@ -11,18 +14,18 @@ defmodule ConciergeSite.Schedule do
   @type t :: %{route_mode_id_key: TripInfo.t()}
 
   @doc """
-  Determine the direction (0 for outbound or 1 for inbound) from some combination of a route stop list, string-formatted direction, origin, and destination.
+  Determine the direction (0 for counter to the order of the stop list, or 1 for with the order of the stop list) from some combination of a route stop list, string-formatted direction, origin, and destination.
 
     iex> Schedule.determine_direction_id(nil, "0", nil, nil)
     0
     iex> Schedule.determine_direction_id(nil, "1", nil, nil)
     1
     iex> stop_list = [{"Readville", "Readville", {42.238405, -71.133246}, 1}, {"Fairmount", "Fairmount", {42.253638, -71.11927}, 1}, {"Morton Street", "Morton Street", {42.280994, -71.085475}, 1}, {"Talbot Avenue", "Talbot Avenue", {42.292246, -71.07814}, 1}, {"Four Corners/Geneva", "Four Corners / Geneva", {42.305037, -71.076833}, 1}, {"Uphams Corner", "Uphams Corner", {42.31867, -71.069072}, 1}, {"Newmarket", "Newmarket", {42.326701, -71.066314}, 1}, {"South Station", "place-sstat", {42.352271, -71.055242}, 1}]
-    iex> inner_stop = "Newmarket"
-    iex> outer_stop = "Uphams Corner"
-    iex> Schedule.determine_direction_id(stop_list, nil, inner_stop, outer_stop)
+    iex> earlier_stop = "Uphams Corner"
+    iex> later_stop = "Newmarket"
+    iex> Schedule.determine_direction_id(stop_list, nil, later_stop, earlier_stop)
     0
-    iex> Schedule.determine_direction_id(stop_list, nil, outer_stop, inner_stop)
+    iex> Schedule.determine_direction_id(stop_list, nil, earlier_stop, later_stop)
     1
   """
   @spec determine_direction_id(

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -1,4 +1,5 @@
 defmodule ConciergeSite.ScheduleTest do
+  @moduledoc false
   use ExUnit.Case
   alias ConciergeSite.Schedule
   alias AlertProcessor.ExtendedTime


### PR DESCRIPTION
When all branches are combined into a single Green route.

Add additional testing in other areas I looked at along the way.

Clarify the description & tests for Schedule.determine_direction_id:
The direction doesn't actually correspond to inbound and outbound, but rather
correlates to the order of the stops in the stop list.

Asana ticket: https://app.asana.com/0/529741067494252/841220924033024