### PR TITLE
Convert `Enum.map/2 |> Enum.into/2` to `Enum.into/3`

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -404,9 +404,7 @@ defmodule AlertProcessor.AlertParser do
 
   defp translate_api_informed_entities(api_entities) do
     Enum.map(api_entities, fn entity ->
-      entity
-      |> Enum.map(&translate_api_informed_entity_key(&1, entity))
-      |> Enum.into(%{})
+      Map.new(entity, &translate_api_informed_entity_key(&1, entity))
     end)
   end
 

--- a/apps/alert_processor/lib/memory.ex
+++ b/apps/alert_processor/lib/memory.ex
@@ -44,11 +44,7 @@ defmodule AlertProcessor.Memory do
   %{atom: -7, atom_used: -5, binary: -3, code: -1, ets: 1, processes: 3, processes_used: 5, system: 7, total: 9}
   """
   @spec diff(t, t) :: t
-  def diff(b, a) do
-    b
-    |> Enum.map(fn {key, value} -> {key, value - a[key]} end)
-    |> Enum.into(%{})
-  end
+  def diff(b, a), do: Map.new(b, fn {key, value} -> {key, value - a[key]} end)
 
   @doc """
   Convert a memory struct to a loggable string.

--- a/apps/concierge_site/lib/param_parsers/trip_params.ex
+++ b/apps/concierge_site/lib/param_parsers/trip_params.ex
@@ -26,11 +26,8 @@ defmodule ConciergeSite.ParamParsers.TripParams do
   end
 
   @spec sanitize_trip_params(map) :: map
-  def sanitize_trip_params(trip_params) when is_map(trip_params) do
-    trip_params
-    |> Enum.map(&sanitize_trip_param/1)
-    |> Enum.into(%{})
-  end
+  def sanitize_trip_params(trip_params) when is_map(trip_params),
+    do: Map.new(trip_params, &sanitize_trip_param/1)
 
   @valid_time_keys ~w(start_time end_time return_start_time return_end_time alert_time)
   defp sanitize_trip_param({time_key, time_value}) when time_key in @valid_time_keys do

--- a/apps/concierge_site/lib/schedule.ex
+++ b/apps/concierge_site/lib/schedule.ex
@@ -254,21 +254,19 @@ defmodule ConciergeSite.Schedule do
   @spec categorize_by_weekend([Schedule.t()], boolean) :: Schedule.t()
   defp categorize_by_weekend(schedules, weekend?) do
     schedules
-    |> Enum.map(fn {key, trips} -> {key, trips |> Enum.map(&Map.put(&1, :weekend?, weekend?))} end)
-    |> Enum.into(%{})
+    |> Map.new(fn {key, trips} -> {key, trips |> Enum.map(&Map.put(&1, :weekend?, weekend?))} end)
   end
 
   @spec interleave_schedule_trips(Schedule.t(), Schedule.t()) :: Schedule.t()
   defp interleave_schedule_trips(weekday_schedules, weekend_schedules) do
     # weekday_schedules and weekend_schedules should contain the same keys
     weekday_schedules
-    |> Enum.map(fn {key, _} ->
+    |> Map.new(fn {key, _} ->
       {
         key,
         merge_and_sort_trips(weekday_schedules[key], weekend_schedules[key])
       }
     end)
-    |> Enum.into(%{})
   end
 
   @spec merge_and_sort_trips([TripInfo.t()], [TripInfo.t()]) :: [TripInfo.t()]


### PR DESCRIPTION
`Enum.into/3` is more efficient than `Enum.map/2 |> Enum.into/2` says
credo.

Work towards https://app.asana.com/0/529741067494252/830957847699954