### PR TITLE
Remove configuration for undefined checks

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -121,11 +121,7 @@
         {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
 
         # Deprecated checks (these will be deleted after a grace period)
-        {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
-        {Credo.Check.Warning.NameRedeclarationByCase, false},
-        {Credo.Check.Warning.NameRedeclarationByDef, false},
-        {Credo.Check.Warning.NameRedeclarationByFn, false}
+        {Credo.Check.Readability.Specs, false}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #


### PR DESCRIPTION
Credo has apparently removed these deprecated checks.

Builds on https://github.com/mbta/alerts_concierge/pull/1019