### PR TITLE
allow notification.header db field to store longer strings

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20181129190220_notificate_header_to_text.exs
+++ b/apps/alert_processor/priv/repo/migrations/20181129190220_notificate_header_to_text.exs
@@ -1,0 +1,9 @@
+defmodule AlertProcessor.Repo.Migrations.NotificateHeaderToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      modify :header, :text
+    end
+  end
+end


### PR DESCRIPTION
[CRASH: T-Alerts re: Notification header field size limit](https://app.asana.com/0/477545582537986/925286048963245/f)

A dev-ops page was sent this morning because the application was unresponsive for a period of time due to application crashes. An example of the crash can be seen here:

https://mbta.splunkcloud.com/en-US/app/search/show_source?sid=1543518809.1614487&offset=47&latest_time=

Basically, header text coming in the the realtime GTFS Alerts feed will not exceed 255 characters, however, if the alert is updated we will add a prefix to the header (such as `Updated: `) which can make the text too long to store in the notifications table due to a character length restriction in the `header` field.  This change converts the header to a `TEXT` field type so a length restriction will no longer be applied.