### PR TITLE
Always send notifications for high priority alerts

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -50,8 +50,8 @@ defmodule AlertProcessor.AlertParser do
         }"
       end)
 
-      if alert_filter_duration_type == :older do	
-        Reminders.async_schedule_reminders(alerts_needing_notifications)	
+      if alert_filter_duration_type == :older do
+        Reminders.async_schedule_reminders(alerts_needing_notifications)
       end
 
       SubscriptionFilterEngine.schedule_all_notifications(
@@ -332,7 +332,8 @@ defmodule AlertProcessor.AlertParser do
     end
   end
 
-  def parse_severity(sev) when sev >= 9, do: :extreme
+  def parse_severity(sev) when sev == 10, do: :high_priority
+  def parse_severity(sev) when sev == 9, do: :extreme
   def parse_severity(sev) when sev >= 7, do: :severe
   def parse_severity(sev) when sev >= 5, do: :moderate
   def parse_severity(sev) when is_integer(sev), do: :minor

--- a/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
+++ b/apps/alert_processor/lib/reminders/processor/subscriptions_to_remind.ex
@@ -32,7 +32,7 @@ defmodule AlertProcessor.Reminders.Processor.SubscriptionsToRemind do
     Enum.reduce(notifications, [], fn notification, subscriptions_to_remind ->
       if reminder_due?(notification, alert, now) do
         notification.subscriptions
-        |> Enum.filter(&NotificationWindowFilter.within_notification_window?(&1, now))
+        |> Enum.filter(&NotificationWindowFilter.within_notification_window?(&1, alert, now))
         |> put_notification_type_to_send()
         |> Enum.concat(subscriptions_to_remind)
       else

--- a/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_window_filter.ex
@@ -14,27 +14,34 @@ defmodule AlertProcessor.NotificationWindowFilter do
 
   """
 
-  alias AlertProcessor.Model.Subscription
+  alias AlertProcessor.Model.{Alert, Subscription}
 
   @doc """
   Accepts a list of subscriptions and returns a filtered list of subscriptions
   that could be notified on a given day and time per their notification window.
 
   """
-  @spec filter([Subscription.t()], DateTime.t()) :: [Subscription.t()]
-  def filter(subscriptions, now) do
+  @spec filter([Subscription.t()], Alert.t(), DateTime.t()) :: [Subscription.t()]
+  def filter(subscriptions, alert, now) do
     Enum.filter(subscriptions, fn subscription ->
-      within_notification_window?(subscription, now)
+      within_notification_window?(subscription, alert, now)
     end)
   end
 
   @doc """
   Returns true if the given datetime is within the subscription's notification
-  window. Returns false if it's not.
+  window.
+
+  Returns true if the alert is high priority, regardless of the subscription's
+  notification window.
+
+  Returns false if it's not a high priority alert, nor within the window.
 
   """
-  @spec within_notification_window?(Subscription.t(), DateTime.t()) :: boolean
-  def within_notification_window?(subscription, now) do
+  @spec within_notification_window?(Subscription.t(), Alert.t(), DateTime.t()) :: boolean
+  def within_notification_window?(_subscription, %Alert{severity: :high_priority}, _now), do: true
+
+  def within_notification_window?(subscription, _alert, now) do
     start_time = subscription.start_time
     end_time = subscription.end_time
     multiday? = span_multiple_days?(start_time, end_time)

--- a/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/sent_alert_filter.ex
@@ -18,19 +18,19 @@ defmodule AlertProcessor.SentAlertFilter do
     recent_outdated_notifications
     |> Enum.map(fn notification ->
       notification.subscriptions
-      |> notification_window_filter(now)
+      |> notification_window_filter(alert, now)
       |> put_notification_type_to_send(alert)
     end)
     |> List.flatten()
   end
 
-  defp notification_window_filter(subscriptions, now) do
+  defp notification_window_filter(subscriptions, alert, now) do
     Enum.filter(subscriptions, fn subscription ->
       # We extend the subscription's end time because we only want to send
       # notifications for updates that occur between the subscription's start
       # time and it's end time plus one hour.
       modified_subscription = extend_subscription_end_time(subscription)
-      NotificationWindowFilter.within_notification_window?(modified_subscription, now)
+      NotificationWindowFilter.within_notification_window?(modified_subscription, alert, now)
     end)
   end
 

--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -67,7 +67,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
       SentAlertFilter.filter(alert, recent_outdated_notifications, now)
 
     subscriptions_to_test
-    |> @notification_window_filter.filter(now)
+    |> @notification_window_filter.filter(alert, now)
     |> InformedEntityFilter.filter(alert: alert)
     |> ActivePeriodFilter.filter(alert: alert)
     |> Kernel.++(subscriptions_to_auto_resend)

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_window_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_window_filter_test.exs
@@ -1,11 +1,21 @@
 defmodule AlertProcessor.NotificationWindowFilterTest do
   @moduledoc false
   use ExUnit.Case, async: true
+  alias AlertProcessor.Model.Alert
   alias AlertProcessor.NotificationWindowFilter
   import AlertProcessor.Factory
 
-  describe "filter/2" do
-    test "within notification window" do
+  describe "filter/3" do
+    setup do
+      alert = %Alert{
+        id: "123",
+        severity: :extreme
+      }
+
+      {:ok, alert: alert}
+    end
+
+    test "within notification window", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -17,11 +27,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       monday_at_7am = DateTime.from_naive!(~N[2018-04-02 08:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], monday_at_7am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, monday_at_7am)
       assert result == [subscription]
     end
 
-    test "within notification window (start after end)" do
+    test "within notification window (start after end)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -33,11 +44,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       monday_at_7am = DateTime.from_naive!(~N[2018-04-02 07:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], monday_at_7am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, monday_at_7am)
       assert result == [subscription]
     end
 
-    test "outside notification window (start after end)" do
+    test "outside notification window (start after end)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -49,11 +61,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       monday_at_10am = DateTime.from_naive!(~N[2018-04-02 10:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], monday_at_10am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, monday_at_10am)
       assert result == []
     end
 
-    test "outside notification window (day mismatch: sunday)" do
+    test "outside notification window (day mismatch: sunday)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -65,11 +78,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       sunday_at_7am = DateTime.from_naive!(~N[2018-04-01 07:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], sunday_at_7am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, sunday_at_7am)
       assert result == []
     end
 
-    test "outside notification window (day mismatch: thursday)" do
+    test "outside notification window (day mismatch: thursday)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -82,11 +96,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       thursday_at_7am = DateTime.from_naive!(~N[2018-04-05 07:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], thursday_at_7am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, thursday_at_7am)
       assert result == []
     end
 
-    test "outside notification window (day match but time before window)" do
+    test "outside notification window (day match but time before window)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -98,11 +113,12 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       monday_at_6am = DateTime.from_naive!(~N[2018-04-02 06:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], monday_at_6am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, monday_at_6am)
       assert result == []
     end
 
-    test "outside notification window (day match but time after window)" do
+    test "outside notification window (day match but time after window)", %{alert: alert} do
       trip = build(:trip)
 
       subscription_details = [
@@ -114,8 +130,28 @@ defmodule AlertProcessor.NotificationWindowFilterTest do
 
       subscription = build(:subscription, subscription_details)
       monday_at_10am = DateTime.from_naive!(~N[2018-04-02 10:00:00], "Etc/UTC")
-      result = NotificationWindowFilter.filter([subscription], monday_at_10am)
+
+      result = NotificationWindowFilter.filter([subscription], alert, monday_at_10am)
       assert result == []
+    end
+
+    test "high priority alerts pass regardless of notification window", %{alert: alert} do
+      high_priority_alert = %Alert{alert | severity: :high_priority}
+      trip = build(:trip)
+
+      # This would fail the pure notification window test
+      subscription_details = [
+        relevant_days: ~w(monday)a,
+        start_time: ~T[08:00:00],
+        end_time: ~T[09:00:00],
+        trip: trip
+      ]
+
+      subscription = build(:subscription, subscription_details)
+      monday_at_6am = DateTime.from_naive!(~N[2018-04-02 06:00:00], "Etc/UTC")
+
+      result = NotificationWindowFilter.filter([subscription], high_priority_alert, monday_at_6am)
+      assert result == [subscription]
     end
   end
 end

--- a/apps/alert_processor/test/support/mocks/notification_window_filter_mock.ex
+++ b/apps/alert_processor/test/support/mocks/notification_window_filter_mock.ex
@@ -1,5 +1,5 @@
 defmodule AlertProcessor.NotificationWindowFilterMock do
   @moduledoc false
 
-  def filter(subscriptions, _now), do: subscriptions
+  def filter(subscriptions, _alert, _now), do: subscriptions
 end


### PR DESCRIPTION
Regardless of the subscription's notification window.

Asana ticket: [Create the "High priority" T-Alerts feature](https://app.asana.com/0/555089885850811/944631250248260)