### PR TITLE
remove schedules for shuttles

### DIFF
--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -8,6 +8,27 @@ defmodule ConciergeSite.ScheduleTest do
 
   doctest Schedule
 
+  test "remove_shuttle_schedules/2" do
+    shuttle_schedule = %{
+      "relationships" => %{
+        "route" => %{
+          "data" => %{"id" => "shuttle-route", "type" => "route"}
+        }
+      }
+    }
+
+    line_schedule = %{
+      "relationships" => %{
+        "route" => %{
+          "data" => %{"id" => "line-route", "type" => "route"}
+        }
+      }
+    }
+
+    assert [line_schedule] ==
+             Schedule.remove_shuttle_schedules([shuttle_schedule, line_schedule], "line-route")
+  end
+
   test "get_schedules_for_input/4" do
     legs = ["CR-Newburyport"]
     origins = ["place-north"]


### PR DESCRIPTION
Now that the Transit Data team is doing more work to incorporate shuttle data, some of the API responses contain data that T-Alerts code did not anticipate.

In this case, it requests some `Schedules`, but some of them reference a different `Route` than the route that is being requested.

The change here is to:
- filter out schedules that have a mismatched route
- allow `map_common_trips` to accept an empty array
