### PR TITLE
filter out Red line shuttles by priority

### DIFF
--- a/apps/alert_processor/lib/service_info/service_info_cache.ex
+++ b/apps/alert_processor/lib/service_info/service_info_cache.ex
@@ -643,7 +643,11 @@ defmodule AlertProcessor.ServiceInfoCache do
   defp fetch_route_branches("Red") do
     {:ok, route_shapes} = ApiClient.route_shapes("Red")
 
-    Enum.map(route_shapes, fn %{"relationships" => %{"stops" => %{"data" => stops}}} ->
+    route_shapes
+    |> Enum.reject(fn %{"attributes" => %{"priority" => priority}} ->
+      priority == -1
+    end)
+    |> Enum.map(fn %{"relationships" => %{"stops" => %{"data" => stops}}} ->
       Enum.map(stops, & &1["id"])
     end)
   end


### PR DESCRIPTION
NO TICKET: fix test that is failing on master

Due to shuttles, there are some additional `shapes` that appear in the API response for the Red line. This change removes any `shape` with a priority of `-1`.