### PR TITLE
test: update Commuter Rail trip names

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -342,7 +342,8 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
   end
 
   test "get_trip_name", %{pid: pid} do
-    assert {:ok, "822"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Fall-19-822")
+    assert {:ok, "040"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Fall-19-040")
+    assert {:ok, "300"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Fall-19-300")
   end
 
   test "get_facility_map", %{pid: pid} do


### PR DESCRIPTION
The trip IDs for Providence changed, so switch to another branch. 

Also, add a test that we don't strip off a leading 0.