### PR TITLE
test: increase the number of login attempts

### DIFF
--- a/apps/concierge_site/test/web/controllers/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/session_controller_test.exs
@@ -64,7 +64,7 @@ defmodule ConciergeSite.SessionControllerTest do
     params = %{"user" => %{"email" => "test2@email.com", "password" => "11111111111"}}
 
     login_attempts =
-      for _ <- 1..11 do
+      for _ <- 1..21 do
         post(conn, session_path(conn, :create), params)
       end
 


### PR DESCRIPTION
Since Hammer uses buckets, it's possible to split our requests across a
bucket and therefore not hit the limit. By increasing the count to double the
limit, we ensure we'll hit it even if it's across two buckets.