### PR TITLE
Work around intermittent EXIT in tests

### DIFF
--- a/apps/alert_processor/test/alert_processor/api/alerts_client_test.exs
+++ b/apps/alert_processor/test/alert_processor/api/alerts_client_test.exs
@@ -1,6 +1,6 @@
 defmodule AlertProcessor.AlertsClientTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   import ExUnit.CaptureLog

--- a/apps/alert_processor/test/alert_processor/api/api_client_test.exs
+++ b/apps/alert_processor/test/alert_processor/api/api_client_test.exs
@@ -1,6 +1,6 @@
 defmodule AlertProcessor.ApiClientTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   alias AlertProcessor.{ApiClient}

--- a/apps/alert_processor/test/alert_processor/api/cached_api_client_test.exs
+++ b/apps/alert_processor/test/alert_processor/api/cached_api_client_test.exs
@@ -1,6 +1,6 @@
 defmodule AlertProcessor.CachedApiClientTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   alias AlertProcessor.CachedApiClient

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -1,6 +1,6 @@
 defmodule AlertProcessor.ServiceInfoCacheTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   alias AlertProcessor.{Model.Route, ServiceInfoCache}
 


### PR DESCRIPTION
When run with certain random seeds, the `alert_processor` tests would reliably fail with this error:

```
test routes/2 test with a type value (AlertProcessor.ApiClientTest)
test/alert_processor/api/api_client_test.exs:36
** (EXIT from #PID<0.776.0>) killed
```

Since there was no trace of where the EXIT had come from, it's hard to say what the true cause was. But if the `async: true` was removed from this test file, it would pass.

It appears this might be an interaction betwen ExVCR and HTTPoison; see https://github.com/parroty/exvcr/issues/58 for someone with a similar mysterious EXIT, but theirs persisted even with `async` turned off. In any case, updating both libraries to their latest versions (0.11.0 and 1.6.2 at the time of writing) did not fix the issue.

Given the above, I've removed `async: true` from all tests that were using ExVCR, to head off any other potential errors. This doesn't seem to have any impact on the test runtime.

**Note:** This may not resolve the intermittent `DBConnection.OwnershipError` on CI, which so far I've been unable to reproduce locally.