### PR TITLE
Fix failing test due to live data change

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -151,7 +151,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
       assert route == %AlertProcessor.Model.Route{
                direction_names: ["Outbound", "Inbound"],
                headsigns: %{0 => ["Logan Airport", "Silver Line Way"], 1 => ["South Station"]},
-               long_name: "Logan Airport - South Station",
+               long_name: "Logan Airport Terminals - South Station",
                order: 0,
                route_id: "741",
                route_type: 3,
@@ -161,7 +161,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                  {"Courthouse", "place-crtst", {42.35245, -71.04685}, 1},
                  {"South Station", "place-sstat", {42.352271, -71.055242}, 1}
                ],
-               direction_destinations: ["Logan Airport", "South Station"]
+               direction_destinations: ["Logan Airport Terminals", "South Station"]
              }
     end
 


### PR DESCRIPTION
Context: The `alert_processor` tests use ExVCR to record and replay requests made _during_ the tests. However, when the application starts up, it preloads a large amount of data and saves it in a local cache file (this latter part is only done in dev and test). Since this preload occurs outside of any test, ExVCR doesn't catch it.

Combine this with the fact that I already had the local cache file stored in my dev environment, and the Semaphore environment is a blank slate with no cache files, and the result is a test failure that reliably happens on Semaphore (because it's hitting live data) but reliably doesn't happen on my dev machine (because it's hitting the cache).