### PR TITLE
Remove unused worker pool configuration

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -47,12 +47,8 @@ config :alert_processor,
     {:system, "DATABASE_URL_DEV",
      "postgresql://postgres:postgres@localhost:5432/alert_concierge_dev"}
 
-# Config for Rate Limiter. Scale: time period in ms. Limit: # of requests per time period. Send Rate: ms delay between send
-config :alert_processor,
-  pool_size: 2,
-  overflow: 1,
-  rate_limit_scale: {:system, "RATE_LIMIT_SCALE", "3600000"},
-  rate_limit: {:system, "RATE_LIMIT", "30"}
+# Number of workers for sending notifications
+config :alert_processor, notification_workers: 2
 
 # Config for db migration function
 config :alert_processor, :migration_task, AlertProcessor.ReleaseTasks.Dev

--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -27,9 +27,7 @@ config :alert_processor, database_url: {:system, "DATABASE_URL_TEST"}
 
 config :alert_processor, :notification_window_filter, AlertProcessor.NotificationWindowFilterMock
 
-config :alert_processor,
-  pool_size: 0,
-  overflow: 0
+config :alert_processor, notification_workers: 0
 
 config :exvcr,
   vcr_cassette_library_dir: "test/fixture/vcr_cassettes",

--- a/apps/alert_processor/lib/supervisor.ex
+++ b/apps/alert_processor/lib/supervisor.ex
@@ -17,9 +17,6 @@ defmodule AlertProcessor.Supervisor do
     Reminders
   }
 
-  @worker_pool_size Application.get_env(:alert_processor, :pool_size)
-  @worker_pool_overflow Application.get_env(:alert_processor, :overflow)
-
   def start_link do
     Supervisor.start_link(__MODULE__, [])
   end
@@ -30,8 +27,7 @@ defmodule AlertProcessor.Supervisor do
     message_worker_config = [
       name: {:local, :message_worker},
       worker_module: NotificationWorker,
-      size: @worker_pool_size,
-      max_overflow: @worker_pool_overflow
+      size: Application.get_env(:alert_processor, :notification_workers)
     ]
 
     children = [


### PR DESCRIPTION
* The configs `rate_limit` and `rate_limit_scale` are not referenced anywhere in the current code, and their corresponding env vars do not appear in any deployed environment.

* Poolboy's `max_overflow` option only comes into effect when a process attempts to check out a worker from the pool but there are none free. We never check out workers from this pool, as they work independently and constantly in the background; we are essentially using Poolboy as a slightly fancier `DynamicSupervisor`.

* `pool_size` is renamed to `notification_workers` to make the scope of the configuration more clear.