### PR TITLE
Improve notification performance logging

### DIFF
--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -3,6 +3,7 @@ defmodule AlertProcessor.Model.Alert do
   Representation of alert received from MBTA /alerts endpoint
   """
   alias AlertProcessor.{
+    AlertFilters,
     Model.InformedEntity,
     Model.Subscription,
     Helpers.DateTimeHelper,
@@ -25,7 +26,9 @@ defmodule AlertProcessor.Model.Alert do
     :duration_certainty,
     :created_at,
     :closed_timestamp,
-    :reminder_times
+    :reminder_times,
+    :tracking_duration_type,
+    :tracking_fetched_at
   ]
 
   @type informed_entity :: [
@@ -55,7 +58,9 @@ defmodule AlertProcessor.Model.Alert do
           duration_certainty: {:estimated, pos_integer} | :known,
           created_at: DateTime.t(),
           closed_timestamp: DateTime.t() | nil,
-          reminder_times: [DateTime.t()] | nil
+          reminder_times: [DateTime.t()] | nil,
+          tracking_duration_type: AlertFilters.duration_type() | nil,
+          tracking_fetched_at: DateTime.t() | nil
         }
 
   @doc """

--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -24,9 +24,7 @@ defmodule AlertProcessor.Model.Notification do
           last_push_notification: DateTime.t() | nil,
           alert: Alert.t() | nil,
           closed_timestamp: DateTime.t() | nil,
-          type: notification_type | nil,
-          tracking_optimal_time: DateTime.t() | nil,
-          tracking_matched_time: DateTime.t() | nil
+          type: notification_type | nil
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -49,8 +47,6 @@ defmodule AlertProcessor.Model.Notification do
     field(:alert, :string, virtual: true)
     field(:closed_timestamp, :utc_datetime)
     field(:type, AlertProcessor.AtomType)
-    field(:tracking_optimal_time, :utc_datetime, virtual: true)
-    field(:tracking_matched_time, :utc_datetime, virtual: true)
 
     timestamps()
   end

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -4,7 +4,6 @@ defmodule AlertProcessor.NotificationBuilderTest do
   import AlertProcessor.Factory
   alias AlertProcessor.{Model, NotificationBuilder}
   alias AlertProcessor.Model.{Notification, InformedEntity}
-  alias AlertProcessor.Helpers.DateTimeHelper
   alias Model.Alert
   alias Calendar.DateTime, as: DT
 
@@ -12,6 +11,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
     now = DT.from_date_and_time_and_zone!({2018, 1, 11}, {14, 10, 55}, "Etc/UTC")
     two_days_ago = DT.subtract!(now, 172_800)
     one_day_ago = DT.subtract!(now, 86_400)
+    one_hour_ago = DT.subtract!(now, 3600)
     thirty_minutes_from_now = DT.add!(now, 1800)
     one_hour_from_now = DT.add!(now, 3600)
     one_day_from_now = DT.add!(now, 86_400)
@@ -23,6 +23,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
       thirty_minutes_from_now: thirty_minutes_from_now,
       two_days_ago: two_days_ago,
       one_day_ago: one_day_ago,
+      one_hour_ago: one_hour_ago,
       one_hour_from_now: one_hour_from_now,
       one_day_from_now: one_day_from_now,
       two_days_from_now: two_days_from_now,
@@ -37,7 +38,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
     {:ok, est_time: est_time, now: now}
   end
 
-  test "build notification struct", %{est_time: est_time, now: now} do
+  test "build notification struct", %{est_time: est_time} do
     user = insert(:user)
     sub = insert(:subscription, user: user)
 
@@ -45,14 +46,10 @@ defmodule AlertProcessor.NotificationBuilderTest do
       id: "1",
       header: nil,
       active_period: [%{start: est_time.two_days_from_now, end: est_time.three_days_from_now}],
-      last_push_notification: now
+      last_push_notification: est_time.one_hour_ago
     }
 
-    notification = NotificationBuilder.build_notification({user, [sub]}, alert, now)
-    local_now = DateTimeHelper.datetime_to_local(now)
-
-    subscription_start =
-      DT.from_date_and_time_and_zone!({2018, 1, 11}, {10, 0, 0}, "America/New_York")
+    notification = NotificationBuilder.build_notification({user, [sub]}, alert)
 
     expected_notification = %Notification{
       alert_id: "1",
@@ -73,9 +70,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
         }
       ],
       closed_timestamp: alert.closed_timestamp,
-      type: :initial,
-      tracking_matched_time: local_now,
-      tracking_optimal_time: subscription_start
+      type: :initial
     }
 
     assert expected_notification == notification
@@ -93,7 +88,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
     }
 
     function = fn ->
-      NotificationBuilder.build_notification({user, [subscription]}, alert, now)
+      NotificationBuilder.build_notification({user, [subscription]}, alert)
     end
 
     expected_log =
@@ -102,24 +97,5 @@ defmodule AlertProcessor.NotificationBuilderTest do
         "reason: :invalid_time\"}"
 
     assert ExUnit.CaptureLog.capture_log(function) =~ expected_log
-  end
-
-  test "converts tracking_optimal_time to current time if it's in the future", %{
-    est_time: est_time,
-    now: now
-  } do
-    user = insert(:user)
-    subscription = insert(:subscription, user: user, start_time: ~T[09:00:00])
-
-    alert = %Alert{
-      id: "1",
-      header: nil,
-      active_period: [%{start: est_time.now, end: est_time.three_days_from_now}],
-      last_push_notification: est_time.thirty_minutes_from_now
-    }
-
-    notification = NotificationBuilder.build_notification({user, [subscription]}, alert, now)
-
-    assert notification.tracking_optimal_time == DateTimeHelper.datetime_to_local(now)
   end
 end


### PR DESCRIPTION
The existing logging here had an issue where it relied on a calculated "optimal time" to have delivered the notification, which often ended up in the future, causing the measurements to be negative. This was partly because there are many complexities in how we decide when to send a notification, and the calculation could not account for all of them.

To instead provide a concrete "start" to the processing timeline, this change records the time when we fetched the alert that eventually caused a notification to be sent. We add this as a field on our in-memory-only Alert struct, so we don't have to separately pass it all the way through the data pipeline.

Notably, this can't tell us the time between an alert being created or updated, and the app ingesting it. This is especially relevant given the delays on processing older alerts. But looking at an alert's timestamp doesn't always give a meaningful answer, since we can intentionally send notifications many hours after an update (based on users' time windows). This is what the "optimal time" was trying to get at.

Other new information being logged:

* The IDs of all resources involved, in case we need to track them down

* The type of notification, since we may e.g. consider the performance of initial/update notifications to be more important than reminders

* The time bucket (recent/older/oldest) of the alert-processing run that generated the notification, for similar reasons

* The severity of the alert — "high priority" alerts always generate immediate notifications, so with these we can actually use the alert timestamp as an indicator of true end-to-end processing time

### Manual testing

Tested on dev-green and confirmed not to break anything obvious — I successfully received an SMS notification from a test alert I created and updated on `al-test`, and the logging comes out as it should in Splunk.

### Devops impact

We currently have no alerts that trigger from the `notification time` logging this removes, and just one graph on the production dashboard ("Time In Sending Queue") relies on it. This will break continuity on that graph, as the metric it used will be superseded by `seconds_processing` (and I intend to update the graph to use this).