### PR TITLE
Remove unused TEMP_STATE_KEY config value

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -16,5 +16,4 @@ export SENDER_EMAIL_ADDRESS=alert@mbta.com
 export SERVICE_INFO_UPDATE_INTERVAL=86400000
 export SMTP_PASSWORD=
 export SMTP_USERNAME=
-export TEMP_STATE_KEY=top_secret_key_mix_phx_gen_secret
 export UNSUBSCRIBED_LIST_FETCH_INTERVAL=300000

--- a/apps/concierge_site/config/config.exs
+++ b/apps/concierge_site/config/config.exs
@@ -17,8 +17,6 @@ config :concierge_site, ConciergeSite.Endpoint,
   render_errors: [view: ConciergeSite.ErrorView, accepts: ~w(html json)],
   pubsub: [name: ConciergeSite.PubSub, adapter: Phoenix.PubSub.PG2]
 
-config :concierge_site, temp_state_key: {:system, "TEMP_STATE_KEY", "top_secret_temp_state_key"}
-
 config :concierge_site, :redirect_http?, false
 
 # Bamboo config for emails


### PR DESCRIPTION
This appears to be a relic of a previous approach to managing the flow of creating a subscription. The string `temp_state_key` appears nowhere else in the current codebase.