### PR TITLE
Fix integration test failing on weekends

### DIFF
--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1204,11 +1204,16 @@ defmodule AlertProcessor.Integration.MatchingTest do
     end
   end
 
-  # NOTE: The following tests use a specific trip ID that must have schedules present in the API
-  # at the time the tests are run. The trip must depart from Fairmount station outbound and the
-  # time it departs must be specified here. The current test trip has schedules as of 2020-03-25.
+  # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
+  # trip for the current day of the week must have schedules present in the API. All trips must
+  # depart from Fairmount station outbound and the time must be specified here. These test trips
+  # are active as of 2020-03-25.
 
-  @test_trip_id "CR-Weekday-StormB-19-1769C0"
+  @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
+                   day when day in 1..5 -> "CR-Weekday-StormB-19-1769C0"
+                   6 -> "CR-Saturday-FranklinPTC-20-1769C0"
+                   7 -> "CR-Sunday-FranklinPTC-20-2769C0"
+                 end)
   @test_trip_departs_fairmount_at ~T[16:13:00]
 
   describe "informed_entity's trip matching" do


### PR DESCRIPTION
Because these tests rely on the chosen trip having schedules on the current day, they would fail on weekends because Saturdays and Sundays have distinct sets of trips. To fix this, we can specify a complete set of trips, and use the one corresponding to the current day.