### PR TITLE
Fix "email" option of notification test script

### DIFF
--- a/scripts/send_notifications.exs
+++ b/scripts/send_notifications.exs
@@ -86,7 +86,7 @@ defmodule SendNotifications do
     attributes = %{
       email: @user_email,
       password: "Password1",
-      phone_number: @user_phone,
+      phone_number: if(mode == :sms, do: @user_phone, else: nil),
       communication_mode: mode
     }
 


### PR DESCRIPTION
Using `-m email` would still send via SMS, because the mode to use when sending a notification is determined solely from whether the user has a phone number or not. (saving a user record with `communication_mode` set to "email" has the side effect of nulling their phone number)