### PR TITLE
Revert increase of notification workers

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -50,7 +50,7 @@ config :alert_processor,
      "postgresql://postgres:postgres@localhost:5432/alert_concierge_dev"}
 
 # Number of workers for sending notifications
-config :alert_processor, notification_workers: 40
+config :alert_processor, notification_workers: 20
 
 # Config for db migration function
 config :alert_processor, :migration_task, AlertProcessor.ReleaseTasks.Dev

--- a/apps/alert_processor/lib/alert_processor.ex
+++ b/apps/alert_processor/lib/alert_processor.ex
@@ -6,7 +6,6 @@ defmodule AlertProcessor do
   def start(_type, _args) do
     link = AlertProcessor.Supervisor.start_link()
     Application.get_env(:alert_processor, :migration_task).migrate()
-    :hackney_trace.enable(:max, :io)
     link
   end
 end

--- a/apps/alert_processor/test/test_helper.exs
+++ b/apps/alert_processor/test/test_helper.exs
@@ -1,5 +1,4 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
-:hackney_trace.disable()
 
 ExUnit.configure(exclude: [pending: true])
 ExUnit.start()


### PR DESCRIPTION
This reverts the earlier increase from 20 to 40, as we discovered a bottleneck elsewhere in the app that needs to be addressed first, and it's causing GenServer timeouts that result in emails being lost.

This also reverts the Hackney tracing change, as the multi-line format proved almost impossible to analyze using Splunk.