### PR TITLE
Send notifications in queue order

### DIFF
--- a/apps/alert_processor/lib/dissemination/mass_notifier.ex
+++ b/apps/alert_processor/lib/dissemination/mass_notifier.ex
@@ -64,7 +64,7 @@ defmodule AlertProcessor.Dissemination.MassNotifier do
 
   defp enqueue_batch(notifications) do
     enqueue_start = now()
-    :ok = SendingQueue.list_enqueue(notifications)
+    for n <- notifications, do: SendingQueue.push(n)
     log("event=enqueue time=#{now() - enqueue_start}")
     notifications
   end

--- a/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
+++ b/apps/alert_processor/test/alert_processor/alert_parsing/alert_parser_test.exs
@@ -9,6 +9,7 @@ defmodule AlertProcessor.AlertParserTest do
 
   setup_all do
     {:ok, _} = Application.ensure_all_started(:alert_processor)
+    SendingQueue.reset()
     HTTPoison.start()
     :ok
   end

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_worker_test.exs
@@ -27,7 +27,7 @@ defmodule AlertProcessor.NotificationWorkerTest do
     {:ok, pid} = start_supervised(NotificationWorker)
     :erlang.trace(pid, true, [:receive])
 
-    SendingQueue.enqueue(@notification)
+    SendingQueue.push(@notification)
 
     assert_receive {:trace, ^pid, :receive, {:sent_email, _}}
   end

--- a/apps/alert_processor/test/alert_processor/dissemination/sending_queue_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/sending_queue_test.exs
@@ -3,52 +3,51 @@ defmodule AlertProcessor.SendingQueueTest do
   use ExUnit.Case
   alias AlertProcessor.{SendingQueue, Model.Notification}
 
-  setup_all do
+  setup %{test: test} do
+    {:ok, _} = SendingQueue.start_link(name: test)
     {:ok, notification: %Notification{send_after: DateTime.utc_now()}}
   end
 
-  test "Instantiates empty queue by default", %{test: test} do
-    SendingQueue.start_link(name: test)
+  test "starts empty", %{test: test} do
+    assert SendingQueue.length(test) == 0
     assert SendingQueue.pop(test) == :error
   end
 
-  test "Alert can be added to the queue", %{test: test, notification: notification} do
-    SendingQueue.start_link(name: test)
-    :ok = SendingQueue.enqueue(test, notification)
-    assert SendingQueue.pop(test) == {:ok, notification}
-  end
-
-  test "Alert can be removed from the queue", %{test: test, notification: notification} do
-    SendingQueue.start_link(name: test)
-    :ok = SendingQueue.enqueue(test, notification)
+  test "can push and pop notifications", %{test: test, notification: notification} do
+    :ok = SendingQueue.push(test, notification)
 
     assert SendingQueue.pop(test) == {:ok, notification}
     assert SendingQueue.pop(test) == :error
   end
 
-  test "Multiple alerts can be added to the queue", %{test: test} do
+  test "pops notifications in the order they were pushed", %{test: test} do
     notification1 = %Notification{alert_id: "1"}
     notification2 = %Notification{alert_id: "2"}
     notification3 = %Notification{alert_id: "3"}
-    SendingQueue.start_link(name: test)
-    SendingQueue.list_enqueue(test, [notification1])
-    SendingQueue.list_enqueue(test, [notification2, notification3])
 
+    SendingQueue.push(test, notification1)
+    SendingQueue.push(test, notification2)
+    SendingQueue.push(test, notification3)
+
+    assert SendingQueue.pop(test) == {:ok, notification1}
     assert SendingQueue.pop(test) == {:ok, notification2}
     assert SendingQueue.pop(test) == {:ok, notification3}
-    assert SendingQueue.pop(test) == {:ok, notification1}
   end
 
-  test "We can get the number of items in the queue", %{test: test} do
-    notification1 = %Notification{alert_id: "1"}
-    notification2 = %Notification{alert_id: "2"}
-    SendingQueue.start_link(name: test)
-    SendingQueue.enqueue(test, notification1)
-    SendingQueue.enqueue(test, notification2)
+  test "can get the number of notifications in the queue", %{test: test} do
+    SendingQueue.push(test, %Notification{alert_id: "a"})
+    SendingQueue.push(test, %Notification{alert_id: "b"})
+    SendingQueue.push(test, %Notification{alert_id: "c"})
+    SendingQueue.pop(test)
 
-    assert {:ok, 2} = SendingQueue.queue_length(test)
-    SendingQueue.pop(test)
-    SendingQueue.pop(test)
-    assert {:ok, 0} = SendingQueue.queue_length(test)
+    assert SendingQueue.length(test) == 2
+  end
+
+  test "can reset the queue to empty", %{test: test, notification: notification} do
+    SendingQueue.push(test, notification)
+
+    SendingQueue.reset()
+
+    assert SendingQueue.pop() == :error
   end
 end

--- a/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/subscription_filter_engine_test.exs
@@ -7,7 +7,6 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
   alias AlertProcessor.{
     Model.Alert,
     Model.InformedEntity,
-    Model.Notification,
     Model.Subscription,
     SendingQueue,
     SubscriptionFilterEngine
@@ -32,6 +31,10 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
     }
 
     {:ok, alert: alert}
+  end
+
+  setup do
+    :ok = SendingQueue.reset()
   end
 
   describe "determine_recipients/1" do
@@ -235,12 +238,9 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
       |> weekday_subscription
       |> insert
 
-      {:ok, beginning_queue_length} = SendingQueue.queue_length()
-      assert SubscriptionFilterEngine.schedule_all_notifications([alert])
-      {:ok, ending_queue_length} = SendingQueue.queue_length()
+      :ok = SubscriptionFilterEngine.schedule_all_notifications([alert])
 
-      assert ending_queue_length - beginning_queue_length == 1
-      assert {:ok, %Notification{}} = SendingQueue.pop()
+      assert SendingQueue.length() == 1
     end
   end
 
@@ -270,11 +270,8 @@ defmodule AlertProcessor.SubscriptionFilterEngineTest do
     |> weekday_subscription
     |> insert
 
-    {:ok, beginning_queue_length} = SendingQueue.queue_length()
-    assert SubscriptionFilterEngine.schedule_all_notifications([alert])
-    {:ok, ending_queue_length} = SendingQueue.queue_length()
+    :ok = SubscriptionFilterEngine.schedule_all_notifications([alert])
 
-    assert ending_queue_length - beginning_queue_length == 1
-    assert {:ok, %Notification{}} = SendingQueue.pop()
+    assert SendingQueue.length() == 1
   end
 end

--- a/scripts/send_notifications.exs
+++ b/scripts/send_notifications.exs
@@ -79,9 +79,7 @@ defmodule SendNotifications do
   end
 
   defp await_notifications_sent do
-    {:ok, length} = SendingQueue.queue_length()
-
-    if length > 0 do
+    if SendingQueue.length() > 0 do
       :timer.sleep(100)
       await_notifications_sent()
     end


### PR DESCRIPTION
This is more of a proposal-as-PR, so feel free to reject if there's a good reason for the current design, but it's been bugging me how the "SendingQueue" behaves more like a stack than a queue — causing notifications to be sent first-in-last-out. The order of notifications within a given "run" of the alert processor is not meaningful, but this could have odd user-facing effects over consecutive runs that involve large notification counts, such as getting an "update" for an alert prior to getting the alert itself.