### PR TITLE
Validate email addresses more strictly

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -162,7 +162,12 @@ defmodule AlertProcessor.Model.User do
 
   defp validate_email(changeset) do
     changeset
-    |> validate_format(:email, ~r/@/, message: "Please enter a valid email address.")
+    |> validate_format(
+      :email,
+      # The same validation used by the `mail` library
+      ~r/[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}/,
+      message: "Please enter a valid email address."
+    )
     |> unique_constraint(:email, message: "Sorry, that email has already been taken.")
   end
 


### PR DESCRIPTION
The previous validation only checked for an `@` somewhere in the string, and since we perform no confirmation of email addresses, this allowed a number of users to register despite common typos like forgetting the TLD or inserting whitespace somewhere. This meant they would not receive any alerts, if their preferred communication mode was email.

With this change we use the same regex used by the `mail` library, which is itself based on RFC2822.