### PR TITLE
Restore "list enqueue" function of sending queue

### DIFF
--- a/apps/alert_processor/lib/dissemination/mass_notifier.ex
+++ b/apps/alert_processor/lib/dissemination/mass_notifier.ex
@@ -35,7 +35,7 @@ defmodule AlertProcessor.Dissemination.MassNotifier do
     log("event=commit time=#{now() - commit_start}")
 
     enqueue_start = now()
-    Enum.each(saved_notifications, &SendingQueue.push/1)
+    SendingQueue.push_list(saved_notifications)
     log("event=enqueue time=#{now() - enqueue_start}")
   end
 

--- a/apps/alert_processor/lib/dissemination/sending_queue.ex
+++ b/apps/alert_processor/lib/dissemination/sending_queue.ex
@@ -28,6 +28,12 @@ defmodule AlertProcessor.SendingQueue do
     GenServer.call(name, {:push, notification})
   end
 
+  @doc "Add a list of notifications to the queue in list order."
+  @spec push_list([Notification.t()]) :: :ok
+  def push_list(name \\ __MODULE__, notifications) when is_list(notifications) do
+    GenServer.call(name, {:push_list, notifications})
+  end
+
   @doc "Drop all notifications from the queue."
   @spec reset() :: :ok
   def reset(name \\ __MODULE__) do
@@ -47,6 +53,10 @@ defmodule AlertProcessor.SendingQueue do
 
   def handle_call({:push, notification}, _from, queue) do
     {:reply, :ok, :queue.in(notification, queue)}
+  end
+
+  def handle_call({:push_list, notifications}, _from, queue) do
+    {:reply, :ok, Enum.reduce(notifications, queue, &:queue.in(&1, &2))}
   end
 
   def handle_call(:reset, _from, _notifications) do


### PR DESCRIPTION
In production we found the "enqueue" stage of the pipeline was taking a non-trivial amount of time (up to 12ms per batch). One possible reason is that each individual notification was being enqueued with a separate GenServer call, creating many opportunities for contention with the pop calls from the sending workers.

The previous "stack" version of the sending queue had a function to enqueue a list of notifications in a single call. This restores it.