### PR TITLE
Increase number of sending workers to 50

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -54,7 +54,7 @@ config :alert_processor,
      "postgresql://postgres:postgres@localhost:5432/alert_concierge_dev"}
 
 # Number of workers for sending notifications
-config :alert_processor, notification_workers: 20
+config :alert_processor, notification_workers: 50
 
 # Config for db migration function
 config :alert_processor, :migration_task, AlertProcessor.ReleaseTasks.Dev

--- a/apps/alert_processor/config/test.exs
+++ b/apps/alert_processor/config/test.exs
@@ -29,7 +29,7 @@ config :alert_processor, database_url: {:system, "DATABASE_URL_TEST"}
 
 config :alert_processor, :notification_window_filter, AlertProcessor.NotificationWindowFilterMock
 
-config :alert_processor, notification_workers: 0
+config :alert_processor, notification_workers: 0, notification_worker_idle_wait: 50
 
 config :exvcr,
   vcr_cassette_library_dir: "test/fixture/vcr_cassettes",


### PR DESCRIPTION
Based on production metrics, this will be needed to send emails for large alerts in a timely fashion, as the average time for a single SES call is ~150ms. With 50 workers, this gives a send rate of 333/s.

To avoid excessive idle load on the sending queue process, which could slow down the "enqueue" calls that make the work available, this also increases the amount of time a worker will "back off" if the queue is found to be empty. Originally, with 2 workers and a delay of 100ms, the queue would get 20 calls/s at idle. Now with 50 workers and a 1s delay, the queue will get 50 calls/s.