### PR TITLE
Fix logging of courtesy emails

### DIFF
--- a/apps/alert_processor/lib/alert_parsing/alert_parser.ex
+++ b/apps/alert_processor/lib/alert_parsing/alert_parser.ex
@@ -63,7 +63,8 @@ defmodule AlertProcessor.AlertParser do
         alert_filter_duration_type
       )
 
-      AlertCourtesyEmail.send_courtesy_emails(saved_alerts, parsed_alerts)
+      courtesy_alerts = add_tracking_fields(parsed_alerts, started_at, :courtesy)
+      AlertCourtesyEmail.send_courtesy_emails(saved_alerts, courtesy_alerts)
 
       {alerts, api_alerts, updated_alerts}
     end


### PR DESCRIPTION
The version of the alert list passed to the courtesy email code did not include the tracking fields, so the `NotificationSender` would later be unable to log the sending correctly. This fixes that, while ensuring we can filter courtesy emails out of the stats if needed, by giving them a distinct "duration type". (courtesy emails ignore the alert processor's current duration type and are sent for all alerts in the feed)