### PR TITLE
Reset production log level to info

### DIFF
--- a/apps/concierge_site/config/prod.exs
+++ b/apps/concierge_site/config/prod.exs
@@ -25,12 +25,12 @@ config :concierge_site, ConciergeSite.Endpoint,
 config :concierge_site, :redirect_http?, true
 
 config :logger,
-  level: :debug,
+  level: :info,
   truncate: :infinity,
   backends: [:console]
 
 config :logger, :console,
-  level: :debug,
+  level: :info,
   format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
   metadata: [:request_id, :ip]
 


### PR DESCRIPTION
This was set to `debug` primarily for the purpose of getting ExAWS debug logs, to see if we were hitting the backoff logic. However, it doesn't appear we ever have — all logged requests have gone through on the first attempt.