### PR TITLE
decrease worker count to check if improves errors

### DIFF
--- a/apps/alert_processor/config/config.exs
+++ b/apps/alert_processor/config/config.exs
@@ -54,7 +54,7 @@ config :alert_processor,
      "postgresql://postgres:postgres@localhost:5432/alert_concierge_dev"}
 
 # Number of workers for sending notifications
-config :alert_processor, notification_workers: 50
+config :alert_processor, notification_workers: 40
 
 # Config for db migration function
 config :alert_processor, :migration_task, AlertProcessor.ReleaseTasks.Dev


### PR DESCRIPTION
[Reduce the number of T-Alerts sending workers](https://app.asana.com/0/385363666817452/1182365642948861/f
)

I'm going to raise this issue w/ AWS, but in the meantime, I want to see if reducing the number of workers prevents the message.