### PR TITLE
Add sql queries for 2 common reports we need to run

### DIFF
--- a/report_queries/subscriptions_by_cr_line.sql
+++ b/report_queries/subscriptions_by_cr_line.sql
@@ -1,0 +1,6 @@
+-- Get the number of subscriptions for each Commuter Rail line
+SELECT route,
+  count(distinct(user_id))
+FROM subscriptions
+WHERE type = 'cr'
+GROUP BY route;

--- a/report_queries/subscriptions_by_type.sql
+++ b/report_queries/subscriptions_by_type.sql
@@ -1,0 +1,5 @@
+-- Get the number of subscriptions for each mode and accessibility
+SELECT type,
+  count(distinct(user_id))
+FROM subscriptions
+GROUP BY type;


### PR DESCRIPTION
• Subscriptions by type
• Subscriptions by CR line

Inspired by: [Run a report of CR rail riders from T-Alerts](https://app.asana.com/0/555089885850811/1195669804685944). If we need to run these same queries periodically, it seems worth saving them for quick reference.