### PR TITLE
Only print "(bad time)" when the time is negative

### DIFF
--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -30,7 +30,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
 
     Logger.info(fn ->
       time = Time.diff(end_time, start_time, :millisecond)
-      alert_type = if time > 0, do: "alert matching", else: "alert matching (bad time)"
+      alert_type = if time >= 0, do: "alert matching", else: "alert matching (bad time)"
       "#{alert_type} #{alert_filter_duration_type}, time=#{time} alert_count=#{length(alerts)}"
     end)
 


### PR DESCRIPTION
Don't print it if the time is 0.

No ticket, this came up [in Slack](https://mbta.slack.com/archives/C01B0577NH4/p1601651706029300) this morning.