### PR TITLE
Update tests for Fall 2020 CR rating

### DIFF
--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1207,14 +1207,14 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
   # trip for the current day of the week must have schedules present in the API. All trips must
   # depart from Fairmount station outbound and the time must be specified here. These test trips
-  # are active as of 2020-03-25.
+  # are active as of 2020-11-02.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-Weekday-Summer-20-7751"
-                   6 -> "CR-Saturday-FranklinPTC-20-1769C0"
-                   7 -> "CR-Sunday-FranklinPTC-20-2769C0"
+                   day when day in 1..5 -> "CR-Weekday-Fall-20-911"
+                   6 -> "CR-Saturday-Fall-20-1905"
+                   7 -> "CR-Sunday-Fall-20-2905"
                  end)
-  @test_trip_departs_fairmount_at ~T[16:35:00]
+  @test_trip_departs_fairmount_at ~T[09:10:00]
 
   describe "informed_entity's trip matching" do
     test "with origin scheduled time after subscription's start time" do
@@ -1305,13 +1305,7 @@ defmodule AlertProcessor.Integration.MatchingTest do
         }
       ]
 
-      refute_notify(
-        alert_from_parsed_data(
-          informed_entity_data,
-          ~N[2018-01-01 06:00:00],
-          ~N[2018-01-01 09:00:00]
-        )
-      )
+      refute_notify(alert_from_parsed_data(informed_entity_data))
     end
   end
 
@@ -1516,7 +1510,7 @@ defmodule AlertProcessor.Integration.MatchingTest do
 
   defp alert_from_parsed_data(
          informed_entity_data,
-         period_start \\ ~N[2018-01-01 21:00:00],
+         period_start \\ ~N[2018-01-01 05:00:00],
          period_end \\ ~N[2018-01-01 23:00:00]
        ) do
     # Monday, January 1, 2018 12:00:00 AM GMT-05:00 (EST)

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -32,7 +32,7 @@ defmodule ConciergeSite.ScheduleTest do
   test "get_schedules_for_input/4" do
     legs = ["CR-Newburyport"]
     origins = ["place-north"]
-    destinations = ["place-GB-0316"]
+    destinations = ["place-GB-0254"]
     modes = ["cr"]
 
     result = Schedule.get_schedules_for_input(legs, origins, destinations, modes)
@@ -45,11 +45,11 @@ defmodule ConciergeSite.ScheduleTest do
     assert Enum.all?(result[{"cr", "CR-Newburyport"}], &Map.has_key?(&1, :weekend?))
 
     assert List.first(result[{"cr", "CR-Newburyport"}]) == %TripInfo{
-             arrival_time: ~T[07:46:00],
-             departure_time: ~T[06:35:00],
-             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[07:46:00]},
-             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[06:35:00]},
-             destination: {"Gloucester", "place-GB-0316", {42.616799, -70.668345}, 1},
+             arrival_time: ~T[05:53:00],
+             departure_time: ~T[05:04:00],
+             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[05:53:00]},
+             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[05:04:00]},
+             destination: {"Manchester", "place-GB-0254", {42.573687, -70.77009}, 1},
              direction_id: 0,
              origin: {"North Station", "place-north", {42.365577, -71.06129}, 1},
              route: %Route{
@@ -84,11 +84,11 @@ defmodule ConciergeSite.ScheduleTest do
                direction_destinations: ["Newburyport or Rockport", "North Station"]
              },
              selected: false,
-             trip_number: "7101",
+             trip_number: "101",
              weekend?: false
            }
 
-    assert Enum.find_index(result[{"cr", "CR-Newburyport"}], & &1.weekend?) == 2
+    assert Enum.find_index(result[{"cr", "CR-Newburyport"}], & &1.weekend?) == 3
   end
 
   test "get_schedules_for_trip/2" do
@@ -159,14 +159,14 @@ defmodule ConciergeSite.ScheduleTest do
              %AlertProcessor.Model.TripInfo{
                arrival_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[06:02:00]
+                 time: ~T[05:49:00]
                },
-               arrival_time: ~T[06:02:00],
+               arrival_time: ~T[05:49:00],
                departure_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[05:26:00]
+                 time: ~T[05:11:00]
                },
-               departure_time: ~T[05:26:00],
+               departure_time: ~T[05:11:00],
                destination: {"Worcester", "place-WML-0442", {42.261461, -71.794888}, 1},
                direction_id: 0,
                selected: false,
@@ -216,14 +216,14 @@ defmodule ConciergeSite.ScheduleTest do
              %AlertProcessor.Model.TripInfo{
                arrival_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[05:26:00]
+                 time: ~T[04:40:00]
                },
-               arrival_time: ~T[05:26:00],
+               arrival_time: ~T[04:40:00],
                departure_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[04:45:00]
+                 time: ~T[04:00:00]
                },
-               departure_time: ~T[04:45:00],
+               departure_time: ~T[04:00:00],
                direction_id: 1,
                origin: {"Worcester", "place-WML-0442", {42.261461, -71.794888}, 1},
                selected: false,
@@ -262,7 +262,7 @@ defmodule ConciergeSite.ScheduleTest do
                }
              }
 
-    assert Enum.find_index(return_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 5
+    assert Enum.find_index(return_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 6
   end
 
   defp is_trip_info(%TripInfo{}), do: true


### PR DESCRIPTION
A different destination is now required for the `concierge_site` tests that deal with the Newburyport line, since due to Gloucester Drawbridge work there are no longer any single trips that go from North Station to Gloucester (until summer 2021). The destination is now Manchester.