### PR TITLE
Fix more tests to account for CR service changes

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -189,8 +189,6 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
              route_type: 2,
              short_name: "",
              stop_list: [
-               {"Foxboro", "place-FS-0049", {42.0951, -71.26151}, 1},
-               {"Dedham Corp Center", "place-FB-0118", {42.227079, -71.174254}, 1},
                {"Readville", "place-DB-0095", {42.238405, -71.133246}, 1},
                {"Fairmount", "place-DB-2205", {42.253638, -71.11927}, 1},
                {"Blue Hill Avenue", "place-DB-2222", {42.271466, -71.095782}, 1},
@@ -347,8 +345,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
   end
 
   test "get_trip_name", %{pid: pid} do
-    assert {:ok, "7515"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Summer-20-7515")
-    assert {:ok, "288"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Summer-20-288")
+    assert {:ok, "206"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Fall-20-206")
   end
 
   test "get_facility_map", %{pid: pid} do


### PR DESCRIPTION
**Asana:** [🔧 Fix test failure involving summer trips](https://app.asana.com/0/1167196461144361/1199158942990533)

* A test used a specific trip ID that no longer exists in the Fall.

* A test encoded the expected list of stops on the Fairmount line, which has changed due to the shutdown of the Foxboro pilot.