### PR TITLE
Add Docker Hub login to build-push script

### DIFF
--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -x -u
+set -e -u
 
 # bash script should be called with aws environment (dev / dev-green / prod)
 # other required configuration:
@@ -7,6 +7,11 @@ set -e -x -u
 # * DOCKER_REPO
 
 awsenv=$1
+
+# log into docker hub if credentials are in the environment
+if [ -n "$DOCKER_USERNAME" ]; then
+  echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+fi
 
 # build docker image and tag it with git hash and aws environment
 githash=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Docker Hub has instituted rate limits for anonymous pulls, so we need to authenticate our connections on Semaphore to avoid hitting them.