### PR TITLE
Fix password resets with non-lowercase emails

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -301,7 +301,7 @@ defmodule AlertProcessor.Model.User do
 
   @spec for_email(String.t()) :: t | nil
   def for_email(email) do
-    Repo.get_by(__MODULE__, email: email)
+    Repo.get_by(__MODULE__, email: String.downcase(email))
   end
 
   @spec find_by_email_search(String.t()) :: [t]

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -241,6 +241,11 @@ defmodule AlertProcessor.Model.UserTest do
       assert user == User.for_email(user.email)
     end
 
+    test "disregards the case of the email" do
+      user = insert(:user, email: "testemail@example.com")
+      assert user == User.for_email("TestEmail@example.com")
+    end
+
     test "returns nil if no matching user" do
       assert nil == User.for_email("test@nonexistent.com")
     end

--- a/apps/concierge_site/lib/controllers/password_reset_controller.ex
+++ b/apps/concierge_site/lib/controllers/password_reset_controller.ex
@@ -11,7 +11,7 @@ defmodule ConciergeSite.PasswordResetController do
   end
 
   def create(conn, %{"password_reset" => %{"email" => email}}) do
-    case email |> String.downcase() |> User.for_email() do
+    case User.for_email(email) do
       nil ->
         conn
         |> put_flash(:error, "Could not find that email address.")

--- a/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/password_reset_controller_test.exs
@@ -43,8 +43,9 @@ defmodule ConciergeSite.PasswordResetControllerTest do
 
   describe "update/2" do
     test "with valid reset token and password", %{conn: conn} do
-      user = insert(:user)
-      reset_token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", user.email)
+      # case shouldn't matter, as it doesn't matter when looking up the user to send the email
+      insert(:user, email: "abcd@example.com")
+      token = Phoenix.Token.sign(ConciergeSite.Endpoint, "password_reset", "AbCd@example.com")
       valid_password = "password1!"
 
       params = %{
@@ -54,7 +55,7 @@ defmodule ConciergeSite.PasswordResetControllerTest do
         }
       }
 
-      conn = patch(conn, password_reset_path(conn, :update, reset_token), params)
+      conn = patch(conn, password_reset_path(conn, :update, token), params)
       assert get_flash(conn)["info"] == "Your password has been updated."
     end
 


### PR DESCRIPTION
Although we allowed any casing of a user's email to be entered in the password reset form, the resulting link would only work if the email was entered in all lowercase, and would otherwise give a confusing 404 error page when the new-password form was submitted.

Since we downcase user emails whenever they enter the database via user create or update, it makes sense that we'd also want to downcase the input whenever we look up a user by email, so this implements the change within `User.for_email`.