### PR TITLE
Remove unneeded "bad time" distinction in logging

### DIFF
--- a/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
+++ b/apps/alert_processor/lib/rules_engine/subscription_filter_engine.ex
@@ -30,8 +30,7 @@ defmodule AlertProcessor.SubscriptionFilterEngine do
 
     Logger.info(fn ->
       time = Time.diff(end_time, start_time, :millisecond)
-      alert_type = if time >= 0, do: "alert matching", else: "alert matching (bad time)"
-      "#{alert_type} #{alert_filter_duration_type}, time=#{time} alert_count=#{length(alerts)}"
+      "alert matching #{alert_filter_duration_type}, time=#{time} alert_count=#{length(alerts)}"
     end)
 
     :ok


### PR DESCRIPTION
Since the only criterion for whether we log this is that the `time` is less than 0, but we also log the time itself, anyone wanting to filter out "bad times" can easily do so without the added label. I ensured our Splunk dashboard still works with this change.