### PR TITLE
Fix crash when all service to a stop is suspended

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -411,7 +411,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
              accessible: true
            ]
 
-    assert stops_with_icons["place-FR-0098"] == [modes: MapSet.new([:cr]), accessible: true]
+    assert stops_with_icons["place-NHRML-0254"] == [modes: MapSet.new([:cr]), accessible: true]
     assert stops_with_icons["Boat-Hingham"] == [modes: MapSet.new([:ferry]), accessible: true]
   end
 end

--- a/apps/concierge_site/lib/views/route_helper.ex
+++ b/apps/concierge_site/lib/views/route_helper.ex
@@ -41,15 +41,19 @@ defmodule ConciergeSite.RouteHelper do
   end
 
   @doc """
-  Get the name of a stop.
+  Get the name of a stop, with a fallback name if the stop isn't in the service info cache.
 
     iex> ConciergeSite.RouteHelper.stop_name("place-davis")
     "Davis"
+    iex> ConciergeSite.RouteHelper.stop_name("does-not-exist")
+    "Unknown Stop"
   """
   @spec stop_name(String.t()) :: String.t()
   def stop_name(stop_id) do
-    {:ok, {name, _, _, _}} = ServiceInfoCache.get_stop(stop_id)
-    name
+    case ServiceInfoCache.get_stop(stop_id) do
+      {:ok, {name, _, _, _}} -> name
+      {:ok, nil} -> "Unknown Stop"
+    end
   end
 
   @spec collapse_duplicate_green_legs([Subscription.t()]) :: [Subscription.t()]

--- a/apps/concierge_site/test/web/views/stop_select_helper_test.exs
+++ b/apps/concierge_site/test/web/views/stop_select_helper_test.exs
@@ -39,9 +39,9 @@ defmodule ConciergeSite.StopSelectHelperTest do
   end
 
   test "render/3 Ferry" do
-    html = Phoenix.HTML.safe_to_string(StopSelectHelper.render("Boat-F4", :foo, :bar))
+    html = Phoenix.HTML.safe_to_string(StopSelectHelper.render("Boat-F1", :foo, :bar))
 
-    assert html =~ "<option data-ferry=\"true\" value=\"Boat-Charlestown\">Charlestown</option>"
+    assert html =~ "<option data-ferry=\"true\" value=\"Boat-Hingham\">Hingham</option>"
   end
 
   test "render/3 Green-B" do

--- a/apps/concierge_site/test/web/views/trip_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_card_helper_test.exs
@@ -79,11 +79,19 @@ defmodule ConciergeSite.TripCardHelperTest do
             }),
             add_subscription_for_trip(trip, %{
               type: :ferry,
-              route: "Boat-F4",
+              route: "Boat-F1",
               origin: "Boat-Long",
-              destination: "Boat-Charlestown",
+              destination: "Boat-Hingham",
               direction_id: 0,
               rank: 8
+            }),
+            add_subscription_for_trip(trip, %{
+              type: :cr,
+              route: "CR-Lowell",
+              origin: "place-north",
+              destination: "stop-with-no-service-anymore",
+              direction_id: 0,
+              rank: 9
             })
           ]
       }
@@ -97,7 +105,8 @@ defmodule ConciergeSite.TripCardHelperTest do
       assert html =~ "57A"
       assert html =~ "Silver Line SL1"
       assert html =~ "Haverhill Line"
-      assert html =~ "Charlestown Ferry"
+      assert html =~ "Hingham/Hull Ferry"
+      assert html =~ "Unknown Stop"
       assert html =~ "One-way"
       refute html =~ "Round-trip"
       assert html =~ "Mon"

--- a/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
@@ -114,9 +114,9 @@ defmodule ConciergeSite.TripReviewCardHelperTest do
             }),
             add_subscription_for_trip(trip, %{
               type: :ferry,
-              route: "Boat-F4",
+              route: "Boat-F1",
               origin: "Boat-Long",
-              destination: "Boat-Charlestown",
+              destination: "Boat-Hingham",
               direction_id: 0,
               rank: 8
             })


### PR DESCRIPTION
We noticed this because all service is currently suspended on `Boat-F4`, causing its stops to no longer be considered "on" the route in the API, but it would have already been affecting users since (at least) the closure of Winchester Center on the Lowell line.

This is a quick fix — it's theoretically possible for us to display the correct stop name in these cases instead of "Unknown Stop", since affected stops still exist in the API in general, but under the current ServiceInfoCache model stops only exist if they're "on" a route.

This also adjusts some tests to otherwise avoid using `Boat-F4`, and tweaks one test to avoid running into the temporary shuttle-related change where stations on the Fitchburg line now incorporate nearby bus stops as child stops.