### PR TITLE
docs: prepare to make repo public

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <developer@mbta.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Massachusetts Bay Transportation Authority
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Alerts Concierge
 
-[![Build Status](https://semaphoreci.com/api/v1/projects/de013d4d-9f29-4afd-83d4-85f13e0699e6/1892610/badge.svg)](https://semaphoreci.com/mbta/alerts_concierge)
-[![codecov](https://codecov.io/gh/mbta/alerts_concierge/branch/master/graph/badge.svg?token=yvAzhPtUcf)](https://codecov.io/gh/mbta/alerts_concierge)
+[![Build status](https://semaphoreci.com/api/v1/projects/de013d4d-9f29-4afd-83d4-85f13e0699e6/1892610/badge.svg)](https://semaphoreci.com/mbta/alerts_concierge)
+[![Code coverage](https://codecov.io/gh/mbta/alerts_concierge/branch/master/graph/badge.svg?token=yvAzhPtUcf)](https://codecov.io/gh/mbta/alerts_concierge)
 
-Subscription and dissemination system which allows MBTA customers to easily
-subscribe to and receive relevant service alerts for desired
-itineraries/services, while ensuring MBTA’s costs for providing this
-functionality remain low and that MBTA can manage and improve the system.
+a.k.a. **[T-Alerts](https://alerts.mbta.com/)**. Enables MBTA riders to
+subscribe to notifications for service disruptions.
 
 ## Setup
 
@@ -19,12 +17,10 @@ functionality remain low and that MBTA can manage and improve the system.
 - Erlang, Elixir, and Node.js versions specified in `.tool_versions`
   - Use [`asdf`](https://github.com/asdf-vm/asdf) to install automatically
     - Note [these extra install steps][nodejs-reqs] for NodeJS plugin
-    - Use [this workaround][erlang-fix] to compile Erlang on Mac OS Catalina
 - Yarn (`npm install -g yarn`; may require `asdf reshim` after)
 - [direnv](https://github.com/direnv/direnv) _(optional, but convenient)_
 
 [nodejs-reqs]: https://github.com/asdf-vm/asdf-nodejs#requirements
-[erlang-fix]: https://github.com/kerl/kerl/issues/320#issuecomment-556565250
 
 ### Instructions
 
@@ -35,8 +31,6 @@ functionality remain low and that MBTA can manage and improve the system.
 - `direnv allow`
 - `mix ecto.setup`
 - `MIX_ENV=test mix ecto.setup`
-
-#### Notes
 
 The above assumes you have a PostgreSQL user with the same name as your OS user
 (`logname`), which should be the default with a Homebrew install. Otherwise, you
@@ -55,40 +49,6 @@ B) it will persist _through_ the session, even if you change directories.
 - `mix phx.server`
 - Visit <http://localhost:4005/>
 
-### More information
+## Deployment
 
-For more information about setup and use of the application, see the
-[Wiki](https://github.com/mbta/alerts_concierge/wiki).
-
-## Querying historical data
-
-We occasionally get one-off questions about how T-Alerts behaved in the past, for example, whether a certain notification was sent out and when. In order to answer such questions we generally need to query the production database. The production database is not directly accessible, but we can be accessed by connecting through the [Bastion Host Gateway](https://github.com/mbta/wiki/blob/master/devops/bastion-host.md). Obviously the production database should only be interacted with _very carefully_.
-
-## AWS
-
-The Alerts Concierge application lives on AWS in three environments, `alerts-concierge-prod`, `alerts-concierge-dev`, and `alerts-concierge-dev-green`. The app runs as a release in a docker container. The docker images are hosted on AWS ECR, and the containers are run on Fargate.
-
-### Deployment
-
-Deployment to the environments is done via SemaphoreCI.
-
-Deploying to `alerts-concierge-prod` is done manually, by choosing a branch (usually `master`), choosing the desired build, clicking "Deploy manually", choosing "Production", and pressing the "Deploy" button. Before deploying to production, note what build of `master` is currently deployed in case you need to rollback (i.e.: re-deploy that earlier build using the steps above.)
-
-Every merge to master automatically deploys the newest version to `alerts-concierge-dev`.
-
-`alerts-concierge-dev-green` is used to test branches in a production-esque environment. It can be deployed to in a similar way as to Production, but choose "Dev Green" instead. Ask in the slack channel if anyone is using that environment before doing so.
-
-### Changing ENV variables
-
-Here's how to change them on AWS:
-
-1. Go to Elastic Container Service AWS page (https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters)
-1. Click "Task Definitions" in the sidebar
-1. Check the box next to the environment that you want to make the change to (e.g. alerts-concierge-dev-green).
-1. This should enable the "Create new revision" button along the top. Click it. This clones the most recent settings so you can make the changes you want.
-1. In the "Container Definitions" section 2/3 of the way down, click the link in the table under Container Name (e.g. alerts-concierge-dev-green). A panel should slide in from the side.
-1. In this panel, there's an "Env Variables" section. You can create, delete, or update environment variables there.
-1. Click the "Update" button on the bottom. The panel slides away.
-1. Click the "Create" button on the bottom. There should be a green "Created new revision of Task Defintion foo:# successfully" at the top.
-
-At this point, the newest task definition has the desired environment variables. However, the alerts-concierge app will still be running the old task definition. To make the app restart, picking up the new changes, it needs to be re-deployed from semaphore.
+We run the app on AWS: see [`docs/aws.md`](docs/aws.md) for deployment guides.

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,0 +1,54 @@
+# Deploying
+
+The app lives on AWS in three environments, `alerts-concierge-prod`,
+`alerts-concierge-dev`, and `alerts-concierge-dev-green`. The app runs as an
+Elixir release in a Docker container. The Docker images are hosted on AWS ECR,
+and the containers are run on Fargate.
+
+Deploying to the environments is done via [Semaphore]:
+
+* `prod` is deployed manually, by choosing a desired build (normally the latest
+  build of `master`), clicking "Deploy manually", choosing "Production", and
+  pressing the "Deploy" button. Before deploying to production, note which build
+  is currently deployed in case you need to roll back (i.e. re-deploy that build
+  using these same steps).
+
+* Any new commits on `master` are automatically deployed to `dev`.
+
+* `dev-green` is used to test unmerged branches. It can be deployed to in a
+  similar way as to Production, but choose "Dev Green" instead. Ask in the Slack
+  channel if anyone is using that environment before doing so.
+
+[Semaphore]: https://semaphoreci.com/mbta/alerts_concierge
+
+## Environment variables
+
+Here's how to change them on AWS:
+
+1. Go to the [ECS dashboard]
+
+1. Click "Task Definitions" in the sidebar
+
+1. Check the box next to the environment that you want to make the change to
+
+1. This should enable the "Create new revision" button along the top. Click it.
+   This clones the most recent settings so you can make the changes you want.
+
+1. In the "Container Definitions" section 2/3 of the way down, click the link in
+   the table under Container Name (e.g. alerts-concierge-dev-green). A panel
+   should slide in from the side.
+
+1. In this panel, there's an "Env Variables" section. You can create, delete, or
+   update environment variables there.
+
+1. Click the "Update" button on the bottom. The panel slides away.
+
+1. Click the "Create" button on the bottom. There should be a green "Created new
+   revision of Task Defintion foo:# successfully" at the top.
+
+At this point, the newest task definition has the desired environment variables.
+However, the alerts-concierge app will still be running the old task definition.
+To make the app restart, picking up the new changes, it needs to be re-deployed
+from Semaphore.
+
+[ECS dashboard]: https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters

--- a/report_queries/README.md
+++ b/report_queries/README.md
@@ -1,0 +1,4 @@
+These queries are intended to be run against the production database by
+connecting through the [Bastion Host Gateway][bastion].
+
+[bastion]: https://github.com/mbta/wiki/blob/master/devops/bastion-host.md


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1167196461144361/1199901902013076

This adds our standard open-source license and Code of Conduct, and cleans up the README, moving some materials into their own docs. Also removes reference to an Erlang compilation workaround that is no longer required, since 36cf757.

[truffleHog](https://github.com/dxa4481/truffleHog) was used to search the repo history for potential sensitive data. With the exception of the key mentioned in #1123, which @ryan-mahoney confirmed has been deleted from the API, it did not find anything.