### PR TITLE
fix: temporarily skip spurious test failure

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -332,11 +332,9 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     assert {:ok, nil} = ServiceInfoCache.get_parent_stop_id(pid, "garbage")
   end
 
-  # Skipped: This function exists only to support ferry routes, and the test fails when the
-  # specified Charlestown ferry trip is not running on the current day. All ferry service is
-  # canceled as of 2020-03-16 due to COVID-19 service changes, but even during regular service,
-  # this fails when the current day is not a weekday.
-  @tag :skip
+  # TODO: address these tests having a dependency on live data that changes frequently
+
+  @tag skip: "fails when the current day is not a weekday"
   test "get_generalized_trip_id", %{pid: pid} do
     assert {:ok, "Boat-F4-Boat-Charlestown-11:45:00-weekday-1"} ==
              ServiceInfoCache.get_generalized_trip_id(pid, "Boat-F4-1145-Charlestown-Weekday")
@@ -344,6 +342,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     assert {:ok, nil} = ServiceInfoCache.get_generalized_trip_id(pid, "garbage")
   end
 
+  @tag skip: "fails every time commuter rail trips change"
   test "get_trip_name", %{pid: pid} do
     assert {:ok, "1801"} = ServiceInfoCache.get_trip_name(pid, "CR-Weekday-Winter-21-1801")
   end


### PR DESCRIPTION
We have a task in the queue to address the various test failures caused by live data changing, and in the meantime this frequently blocks other tasks for no good reason.