### PR TITLE
Fix test failures and subscriptions page crash

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -317,6 +317,10 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
              ServiceInfoCache.get_route(pid, filter)
   end
 
+  test "get_route/2 returns an error with a nonexistent route ID", %{pid: pid} do
+    assert {:error, :not_found} = ServiceInfoCache.get_route(pid, "no-such-route-id")
+  end
+
   test "get_routes/1 returns all the routes", %{pid: pid} do
     {:ok, routes} = ServiceInfoCache.get_routes(pid)
     assert Enum.all?(routes, fn route -> route.__struct__ == Route end)

--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1207,14 +1207,17 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
   # trip for the current day of the week must have schedules present in the API. All trips must
   # depart from Fairmount station outbound and the time must be specified here. These test trips
-  # are active as of 2020-12-17.
+  # are active as of 2021-04-05.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-Weekday-Winter-21-1907"
-                   6 -> "CR-Saturday-Winter-21-2905"
-                   7 -> "CR-Sunday-Winter-21-2905"
+                   day when day in 1..5 -> "CR-Weekday-Spring-21-909"
+                   6 -> "CR-Saturday-Spring-21-2907"
+                   7 -> "CR-Sunday-Spring-21-2907"
                  end)
-  @test_trip_departs_fairmount_at ~T[10:13:00]
+  @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
+                                     day when day in 1..5 -> ~T[08:25:00]
+                                     day when day in 6..7 -> ~T[11:43:00]
+                                   end)
 
   describe "informed_entity's trip matching" do
     test "with origin scheduled time after subscription's start time" do

--- a/apps/concierge_site/lib/views/stop_select_helper.ex
+++ b/apps/concierge_site/lib/views/stop_select_helper.ex
@@ -120,8 +120,10 @@ defmodule ConciergeSite.StopSelectHelper do
     |> Enum.uniq_by(& &1)
   end
 
-  defp get_stop_list(route_id, _),
-    do: with({:ok, %{stop_list: stops}} = ServiceInfoCache.get_route(route_id), do: stops)
+  defp get_stop_list(route_id, _) do
+    {:ok, %{stop_list: stops}} = ServiceInfoCache.get_route(route_id)
+    stops
+  end
 
   @spec attributes(atom, atom, String.t(), keyword) :: keyword(String.t())
   defp attributes(input_name, field, route_id, attrs) do

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -45,10 +45,10 @@ defmodule ConciergeSite.ScheduleTest do
     assert Enum.all?(result[{"cr", "CR-Newburyport"}], &Map.has_key?(&1, :weekend?))
 
     assert List.first(result[{"cr", "CR-Newburyport"}]) == %TripInfo{
-             arrival_time: ~T[09:20:00],
-             departure_time: ~T[08:30:00],
-             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[09:20:00]},
-             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[08:30:00]},
+             arrival_time: ~T[07:26:00],
+             departure_time: ~T[06:35:00],
+             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[07:26:00]},
+             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[06:35:00]},
              destination: {"Manchester", "place-GB-0254", {42.573687, -70.77009}, 1},
              direction_id: 0,
              origin: {"North Station", "place-north", {42.365577, -71.06129}, 1},
@@ -83,7 +83,7 @@ defmodule ConciergeSite.ScheduleTest do
                direction_destinations: ["Newburyport or Rockport", "North Station"]
              },
              selected: false,
-             trip_number: "1101",
+             trip_number: "101",
              weekend?: false
            }
 
@@ -159,18 +159,18 @@ defmodule ConciergeSite.ScheduleTest do
              %AlertProcessor.Model.TripInfo{
                arrival_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[08:10:00]
+                 time: ~T[06:20:00]
                },
-               arrival_time: ~T[08:10:00],
+               arrival_time: ~T[06:20:00],
                departure_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[07:31:00]
+                 time: ~T[05:40:00]
                },
-               departure_time: ~T[07:31:00],
+               departure_time: ~T[05:40:00],
                destination: {"Worcester", "place-WML-0442", {42.261461, -71.794888}, 1},
                direction_id: 0,
                selected: false,
-               trip_number: "1501",
+               trip_number: "501",
                weekend?: false,
                origin: {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
                route: %AlertProcessor.Model.Route{
@@ -194,9 +194,11 @@ defmodule ConciergeSite.ScheduleTest do
                    {"Wellesley Square", "place-WML-0147", {42.297526, -71.294173}, 2},
                    {"Wellesley Hills", "place-WML-0135", {42.31037, -71.277044}, 2},
                    {"Wellesley Farms", "place-WML-0125", {42.323608, -71.272288}, 2},
+                   {"Riverside", "place-river", {42.337352, -71.252685}, 1},
                    {"Auburndale", "place-WML-0102", {42.345725, -71.250826}, 2},
                    {"West Newton", "place-WML-0091", {42.347878, -71.230528}, 2},
                    {"Newtonville", "place-WML-0081", {42.351702, -71.205408}, 2},
+                   {"Newton Highlands", "place-newtn", {42.322381, -71.205509}, 1},
                    {"Boston Landing", "place-WML-0035", {42.357293, -71.139883}, 1},
                    {"Lansdowne", "place-WML-0025", {42.347581, -71.099974}, 1},
                    {"Back Bay", "place-bbsta", {42.34735, -71.075727}, 1},
@@ -205,7 +207,7 @@ defmodule ConciergeSite.ScheduleTest do
                }
              }
 
-    assert Enum.find_index(first_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 1
+    assert Enum.find_index(first_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 3
 
     assert is_map(return_trip_result)
     assert Map.keys(return_trip_result) == [{"cr", "CR-Worcester"}]
@@ -216,18 +218,18 @@ defmodule ConciergeSite.ScheduleTest do
              %AlertProcessor.Model.TripInfo{
                arrival_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[06:10:00]
+                 time: ~T[04:55:00]
                },
-               arrival_time: ~T[06:10:00],
+               arrival_time: ~T[04:55:00],
                departure_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[05:30:00]
+                 time: ~T[04:15:00]
                },
-               departure_time: ~T[05:30:00],
+               departure_time: ~T[04:15:00],
                direction_id: 1,
                origin: {"Worcester", "place-WML-0442", {42.261461, -71.794888}, 1},
                selected: false,
-               trip_number: "7500",
+               trip_number: "500",
                weekend?: false,
                destination: {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
                route: %AlertProcessor.Model.Route{
@@ -251,9 +253,11 @@ defmodule ConciergeSite.ScheduleTest do
                    {"Wellesley Square", "place-WML-0147", {42.297526, -71.294173}, 2},
                    {"Wellesley Hills", "place-WML-0135", {42.31037, -71.277044}, 2},
                    {"Wellesley Farms", "place-WML-0125", {42.323608, -71.272288}, 2},
+                   {"Riverside", "place-river", {42.337352, -71.252685}, 1},
                    {"Auburndale", "place-WML-0102", {42.345725, -71.250826}, 2},
                    {"West Newton", "place-WML-0091", {42.347878, -71.230528}, 2},
                    {"Newtonville", "place-WML-0081", {42.351702, -71.205408}, 2},
+                   {"Newton Highlands", "place-newtn", {42.322381, -71.205509}, 1},
                    {"Boston Landing", "place-WML-0035", {42.357293, -71.139883}, 1},
                    {"Lansdowne", "place-WML-0025", {42.347581, -71.099974}, 1},
                    {"Back Bay", "place-bbsta", {42.34735, -71.075727}, 1},
@@ -262,7 +266,7 @@ defmodule ConciergeSite.ScheduleTest do
                }
              }
 
-    assert Enum.find_index(return_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 2
+    assert Enum.find_index(return_trip_result[{"cr", "CR-Worcester"}], & &1.weekend?) == 4
   end
 
   defp is_trip_info(%TripInfo{}), do: true

--- a/apps/concierge_site/test/web/views/trip_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_card_helper_test.exs
@@ -67,7 +67,7 @@ defmodule ConciergeSite.TripCardHelperTest do
               direction_id: 0,
               rank: 5
             }),
-            add_subscription_for_trip(trip, %{type: :bus, route: "57A", direction_id: 0, rank: 6}),
+            add_subscription_for_trip(trip, %{type: :bus, route: "57", direction_id: 0, rank: 6}),
             add_subscription_for_trip(trip, %{type: :bus, route: "741", direction_id: 0, rank: 6}),
             add_subscription_for_trip(trip, %{
               type: :cr,
@@ -87,7 +87,7 @@ defmodule ConciergeSite.TripCardHelperTest do
             }),
             add_subscription_for_trip(trip, %{
               type: :cr,
-              route: "CR-Lowell",
+              route: "route-that-was-eliminated",
               origin: "place-north",
               destination: "stop-with-no-service-anymore",
               direction_id: 0,
@@ -102,10 +102,11 @@ defmodule ConciergeSite.TripCardHelperTest do
       assert html =~ "Green Line"
       assert html =~ "Blue Line"
       assert html =~ "Mattapan Trolley"
-      assert html =~ "57A"
+      assert html =~ "Route 57"
       assert html =~ "Silver Line SL1"
       assert html =~ "Haverhill Line"
       assert html =~ "Hingham/Hull Ferry"
+      assert html =~ "Unknown Route"
       assert html =~ "Unknown Stop"
       assert html =~ "One-way"
       refute html =~ "Round-trip"

--- a/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
+++ b/apps/concierge_site/test/web/views/trip_review_card_helper_test.exs
@@ -102,7 +102,7 @@ defmodule ConciergeSite.TripReviewCardHelperTest do
               direction_id: 0,
               rank: 5
             }),
-            add_subscription_for_trip(trip, %{type: :bus, route: "57A", direction_id: 0, rank: 6}),
+            add_subscription_for_trip(trip, %{type: :bus, route: "57", direction_id: 0, rank: 6}),
             add_subscription_for_trip(trip, %{type: :bus, route: "741", direction_id: 0, rank: 6}),
             add_subscription_for_trip(trip, %{
               type: :cr,


### PR DESCRIPTION
If a user had any subscriptions involving a route that didn't exist anymore, the subscriptions page would crash on render, preventing any further managing of subscriptions. This also blocked the test suite from passing, as the recently eliminated bus route 57A was used in a few test cases.

This fixes the immediate issue by displaying "Unknown Route" as the route name. For now attempting to edit such a subscription will still cause a crash, but it can be deleted, and will otherwise not cause any harm.