### PR TITLE
fix: alert processing crash in `get_route`

### DIFF
--- a/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
+++ b/apps/alert_processor/lib/rules_engine/informed_entity_filter.ex
@@ -175,7 +175,7 @@ defmodule AlertProcessor.InformedEntityFilter do
     MapSet.subset?(origin_and_destination, scheduled_stops)
   end
 
-  defp in_between_stop_match?(%{type: "accessibility"}, _), do: false
+  defp in_between_stop_match?(%{type: :accessibility}, _), do: false
 
   defp in_between_stop_match?(subscription, %{activities: activities, stop: stop}) do
     stop in stops_in_between(subscription, activities)

--- a/apps/alert_processor/lib/service_info/service_info_cache.ex
+++ b/apps/alert_processor/lib/service_info/service_info_cache.ex
@@ -78,7 +78,7 @@ defmodule AlertProcessor.ServiceInfoCache do
   @spec get_route(
           GenServer.server(),
           String.t() | %{route_id: String.t(), stop_ids: [String.t()]}
-        ) :: {:ok, Route.t()} | {:error, any}
+        ) :: {:ok, Route.t()} | {:error, atom}
   def get_route(name \\ __MODULE__, route)
 
   def get_route(name, route) when is_binary(route) do
@@ -101,6 +101,8 @@ defmodule AlertProcessor.ServiceInfoCache do
   end
 
   def get_route(name, %{route_id: route}), do: get_route(name, route)
+
+  def get_route(_, _), do: {:error, :invalid_argument}
 
   def get_routes(name \\ __MODULE__) do
     GenServer.call(name, :get_routes, @timeout)

--- a/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/informed_entity_filter_test.exs
@@ -1349,6 +1349,30 @@ defmodule AlertProcessor.InformedEntityFilterTest do
       refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
     end
 
+    test "returns false with a 'stop subscription' (activities: ['RIDE'] with different stop)" do
+      subscription_details = [
+        route_type: nil,
+        direction_id: nil,
+        route: nil,
+        origin: "some stop",
+        destination: "some stop",
+        facility_types: [:elevator]
+      ]
+
+      subscription = build(:subscription, subscription_details)
+
+      informed_entity_details = [
+        route_type: 1,
+        direction_id: nil,
+        route: nil,
+        stop: "some other stop",
+        activities: ["RIDE"]
+      ]
+
+      informed_entity = build(:informed_entity, informed_entity_details)
+      refute InformedEntityFilter.subscription_match?(subscription, informed_entity)
+    end
+
     test "returns true for accessibility subscription route-stop match" do
       # With an "accessibility" type subscription with no origin or destination
       # we want to infer the stops from the route. In the scenario below the

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -321,6 +321,10 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     assert {:error, :not_found} = ServiceInfoCache.get_route(pid, "no-such-route-id")
   end
 
+  test "get_route/2 returns an error with an invalid argument", %{pid: pid} do
+    assert {:error, :invalid_argument} = ServiceInfoCache.get_route(pid, nil)
+  end
+
   test "get_routes/1 returns all the routes", %{pid: pid} do
     {:ok, routes} = ServiceInfoCache.get_routes(pid)
     assert Enum.all?(routes, fn route -> route.__struct__ == Route end)


### PR DESCRIPTION
In c4914b5 we removed a seemingly unused clause of `get_route` that allowed passing `nil` as the route ID. Though this was not covered by any tests, it turned out to be used when an uncommon set of conditions occurred, and this caused processing of the "oldest" group of alerts to always crash in production.

This adds two tests that both fail in the presence of this bug: one for `ServiceInfoCache` that explicitly tests passing `nil` as the route ID, and one for `InformedEntityFilter` replicating the conditions that cause `nil` to be passed as the route ID.

This also fixes an incorrect pattern in `InformedEntityFilter` that never would have matched, because it was matching a subscription `type` (which only has atom values) against a string.