### PR TITLE
test: fix rare failure in `Lock` test

### DIFF
--- a/apps/alert_processor/test/alert_processor/lock_test.exs
+++ b/apps/alert_processor/test/alert_processor/lock_test.exs
@@ -36,8 +36,10 @@ defmodule AlertProcessor.LockTest do
 
     test "releases the lock if the calling process dies" do
       pid = acquire_and_sleep(&spawn/1)
+      Process.monitor(pid)
 
       Process.exit(pid, :test_reason)
+      assert_receive {:DOWN, _, _, ^pid, :test_reason}
 
       assert Lock.acquire(fn :ok -> true end)
     end


### PR DESCRIPTION
Noticed this failure for the first time in the CI run for #1152, so it's pretty rare, but possible.

`Process.exit` is not synchronous, and this test did not wait for the process to exit before continuing, so occasionally it would fail because the lock was not released by the time the test tried to acquire it.