### PR TITLE
ci: add no-op deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  push:
+    branches: master
+  workflow_dispatch:
+    inputs:
+      env:
+        default: "dev"
+        description: "Environment"
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.env || 'dev' }}
+    concurrency: ${{ github.event.inputs.env || 'dev' }}
+
+    steps:
+      - run: echo "Workflow not implemented yet!"


### PR DESCRIPTION
`workflow_dispatch` workflows need to exist in some form on the repo's main branch to be available, so this adds a "deploy" workflow that does nothing, to enable testing of the real deploy workflow on a branch.