### PR TITLE
ci: enable deployment with Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy
 
 on:
-  push:
-    branches: master
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [master]
   workflow_dispatch:
     inputs:
       env:
@@ -14,8 +16,34 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      }}
     environment: ${{ github.event.inputs.env || 'dev' }}
     concurrency: ${{ github.event.inputs.env || 'dev' }}
+    env:
+      TARGET: ${{ github.event.inputs.env || 'dev' }}
 
     steps:
-      - run: echo "Workflow not implemented yet!"
+      - uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+      - uses: mbta/actions/deploy-ecs@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: alerts-concierge
+          ecs-service: alerts-concierge-${{ env.TARGET }}-a
+          ecs-task-definition: alerts-concierge-${{ env.TARGET }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}


### PR DESCRIPTION
See [successful dev-green deploy](https://github.com/mbta/alerts_concierge/runs/2898382424?check_suite_focus=true) from this branch!

Some notable "innovations" I'd like to backport or at least socialize:

* This allows manually deploying to any environment, and auto-deploying the main branch to `dev`, using a common workflow. The UI isn't great in that you have to [type in the name of the environment](https://user-images.githubusercontent.com/394835/123157928-2857d000-d439-11eb-8df5-8ce5b2ed76d0.png) instead of selecting it from a list — but if you typo, nothing terrible happens (it does pollute the list of "Environments" in the repo settings).

* The auto-deploy only happens after CI finishes, and only if it passed... at least, it _should_ work this way, but it doesn't appear there's any way to test it until the new config is committed to the main branch. So, we'll see. 🤞