### PR TITLE
ci: add cancel-in-progress concurrency option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ on:
       - "*.md"
       - LICENSE
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   API_KEY: ${{ secrets.API_KEY }}
   MIX_ENV: test

--- a/apps/alert_processor/test/alert_processor/api/api_client_test.exs
+++ b/apps/alert_processor/test/alert_processor/api/api_client_test.exs
@@ -26,8 +26,7 @@ defmodule AlertProcessor.ApiClientTest do
                "id" => "Red",
                "links" => %{"self" => "/routes/Red"},
                "relationships" => %{
-                 "line" => %{"data" => %{"id" => "line-Red", "type" => "line"}},
-                 "route_patterns" => %{}
+                 "line" => %{"data" => %{"id" => "line-Red", "type" => "line"}}
                },
                "type" => "route"
              }
@@ -47,8 +46,7 @@ defmodule AlertProcessor.ApiClientTest do
                "id" => "CR-Fairmount",
                "links" => %{"self" => "/routes/CR-Fairmount"},
                "relationships" => %{
-                 "line" => %{"data" => %{"id" => "line-Fairmount", "type" => "line"}},
-                 "route_patterns" => %{}
+                 "line" => %{"data" => %{"id" => "line-Fairmount", "type" => "line"}}
                },
                "type" => "route"
              }

--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1207,12 +1207,12 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
   # trip for the current day of the week must have schedules present in the API. All trips must
   # depart from Fairmount station outbound and the time must be specified here. These test trips
-  # are active as of 2021-04-05.
+  # are active as of 2021-06-28.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-483257-909"
-                   6 -> "CR-478237-2907"
-                   7 -> "CR-478184-2907"
+                   day when day in 1..5 -> "CR-483969-909"
+                   6 -> "CR-485400-1907"
+                   7 -> "CR-485902-2907"
                  end)
   @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
                                      day when day in 1..5 -> ~T[08:25:00]


### PR DESCRIPTION
`github.ref` here is a branch or tag name (not a commit hash), so this means if we push new commits to a branch that already has an ongoing CI job, it will be cancelled in favor of the new one.