### PR TITLE
Improve UI and explanations when alerts are disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         id: asdf-cache
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
       - uses: asdf-vm/actions/install@v1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - uses: mbta/actions/reshim-asdf@v1
@@ -53,7 +53,7 @@ jobs:
           path: |
             _build
             deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
       - name: Elixir dependencies
         if: steps.ex-deps-cache.outputs.cache-hit != 'true'
         run: |
@@ -66,7 +66,7 @@ jobs:
         id: js-deps-cache
         with:
           path: apps/concierge_site/assets/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ secrets.CACHE_UUID }}-node-${{ hashFiles('**/package-lock.json') }}
       - name: JS dependencies
         if: steps.js-deps-cache.outputs.cache-hit != 'true'
         run: npm install --prefix apps/concierge_site/assets
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
       - uses: mbta/actions/reshim-asdf@v1
       - run: mix format --check-formatted
 
@@ -97,14 +97,14 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: |
             _build
             deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
       - run: mix credo
 
 
@@ -133,18 +133,18 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: |
             _build
             deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
       - uses: actions/cache@v2
         with:
           path: apps/concierge_site/assets/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ secrets.CACHE_UUID }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - run: mix test --cover
 
@@ -175,12 +175,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: |
             _build
             deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
       - uses: mbta/actions/dialyzer@v1

--- a/apps/concierge_site/lib/controllers/trip_controller.ex
+++ b/apps/concierge_site/lib/controllers/trip_controller.ex
@@ -17,9 +17,20 @@ defmodule ConciergeSite.TripController do
   @valid_facility_types ~w(bike_storage elevator escalator parking_area)
 
   def index(conn, _params, user, _claims) do
-    trips = Trip.get_trips_by_user(user.id)
-    render(conn, "index.html", trips: trips, user_id: user.id)
+    conn
+    |> communication_mode_flash(user)
+    |> render("index.html", trips: Trip.get_trips_by_user(user.id), user_id: user.id)
   end
+
+  defp communication_mode_flash(conn, %User{communication_mode: "none"}) do
+    put_flash(
+      conn,
+      :warning,
+      "Alerts are disabled for your account. To resume alerts, check your account Settings."
+    )
+  end
+
+  defp communication_mode_flash(conn, _user), do: conn
 
   def new(conn, _params, user, _claims) do
     trip_count = Trip.get_trip_count_by_user(user.id)

--- a/apps/concierge_site/lib/templates/account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit.html.eex
@@ -1,5 +1,6 @@
 <h1 class="heading__title">Settings</h1>
 <%= flash_error(@conn) %>
+<%= flash_warning(@conn) %>
 
 <% communication_mode = fetch_field!(@changeset, :communication_mode) %>
 

--- a/apps/concierge_site/lib/templates/account/edit.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit.html.eex
@@ -1,16 +1,7 @@
-<% alias AlertProcessor.Model.User %>
-
 <h1 class="heading__title">Settings</h1>
 <%= flash_error(@conn) %>
 
-<%
-  communication_mode = if @changeset.data.phone_number == nil && Map.get(@changeset.changes, :communication_mode, @changeset.data.communication_mode) != "sms" do
-    "email"
-  else
-    "sms"
-  end
-%>
-
+<% communication_mode = fetch_field!(@changeset, :communication_mode) %>
 
 <div class="container container__inner">
   <div class="row justify-content-md-center">
@@ -19,14 +10,20 @@
         <div class="form-group form__section--top">
           <%= label form, :sms_toggle, "I’d like to receive alert notifications by:", class: "form__label" %>
           <div class="btn-group btn-group-toggle btn__radio--toggle-container" data-toggle="buttons" role="radiogroup">
-            <label data-id="email" role="radio" aria-checked="<%= if communication_mode == "email", do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if communication_mode == "email", do: "active" %>" tabindex="0">
+            <label data-id="email" role="radio" tabindex="0"
+                aria-checked="<%= if communication_mode == "email", do: "true", else: "false" %>"
+                class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if communication_mode == "email", do: "active" %>">
               <%= render ConciergeSite.LayoutView, "_icon_email.html" %>
-              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: @changeset.data.phone_number == nil %>
+              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: communication_mode == "email" %>
               <div>Email me</div>
             </label>
-            <label data-id="sms" role="radio" aria-checked="<%= if communication_mode == "sms", do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}), do: "disabled" %> <%= if !User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) and communication_mode == "sms", do: "active" %>" tabindex="0">
+            <label data-id="sms" role="radio" tabindex="0"
+                aria-checked="<%= if communication_mode == "sms", do: "true", else: "false" %>"
+                class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item
+                <%= if sms_frozen?(@changeset), do: "disabled" %>
+                <%= if !sms_frozen?(@changeset) and communication_mode == "sms", do: "active" %>">
               <%= render ConciergeSite.LayoutView, "_icon_sms.html" %>
-              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: @changeset.data.phone_number != nil, disabled: User.inside_opt_out_freeze_window?(%User{sms_opted_out_at: @changeset.data.sms_opted_out_at}) %>
+              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: communication_mode == "sms", disabled: sms_frozen?(@changeset) %>
               <div>Text me</div>
             </label>
           </div>

--- a/apps/concierge_site/lib/templates/account/options_new.html.eex
+++ b/apps/concierge_site/lib/templates/account/options_new.html.eex
@@ -1,35 +1,34 @@
 <h1 class="heading__title">Customize my settings</h1>
 <%= flash_error(@conn) %>
-<%
-  communication_mode = if @changeset.data.phone_number == nil && Map.get(@changeset.changes, :communication_mode, @changeset.data.communication_mode) != "sms" do
-    "email"
-  else
-    "sms"
-  end
-%>
+
+<% communication_mode = fetch_field!(@changeset, :communication_mode) %>
+
 <div class="container container__inner">
   <div class="row justify-content-md-center">
     <div class="col-md-10 col-sm-12">
       <%= form_for @changeset, account_path(@conn, :options_create), [as: :user, method: :post], fn form -> %>
-        <% phone_number = @changeset.data.phone_number || form.params["phone_number"] %>
         <div class="form-group form__section--top">
           <%= label form, :sms_toggle, "How would you like to receive alerts?", class: "form__label" %>
           <div class="btn-group btn-group-toggle btn__radio--toggle-container" data-toggle="buttons" role="radiogroup">
-            <label data-id="email" role="radio" aria-checked="<%= if @changeset.data.phone_number == nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if phone_number == nil, do: "active" %>" tabindex="0">
+            <label data-id="email" role="radio" tabindex="0"
+                aria-checked="<%= if communication_mode == "email", do: "true", else: "false" %>"
+                class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if communication_mode == "email", do: "active" %>">
               <%= render ConciergeSite.LayoutView, "_icon_email.html" %>
-              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: phone_number == nil %>
+              <%= radio_button form, :sms_toggle, "false", tabindex: "-1", required: true, checked: communication_mode == "email" %>
               <div>Email me</div>
             </label>
-            <label data-id="sms" role="radio" aria-checked="<%= if phone_number != nil, do: "true", else: "false" %>" class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if phone_number != nil, do: "active" %>" tabindex="0">
+            <label data-id="sms" role="radio" tabindex="0"
+                aria-checked="<%= if communication_mode == "sms", do: "true", else: "false" %>"
+                class="btn btn-outline-primary btn__radio--toggle btn__radio--toggle-item <%= if communication_mode == "sms", do: "active" %>">
               <%= render ConciergeSite.LayoutView, "_icon_sms.html" %>
-              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: phone_number != nil %>
+              <%= radio_button form, :sms_toggle, "true", tabindex: "-1", required: true, checked: communication_mode == "sms" %>
               <div>Text me</div>
             </label>
           </div>
           <%= hidden_input form, :communication_mode, value: communication_mode  %>
         </div>
 
-        <div class="form-group my-4 <%= if phone_number == nil, do: "d-none", else: "" %>" data-phone="input">
+        <div class="form-group my-4 <%= if communication_mode != "sms", do: "d-none", else: "" %>" data-phone="input">
           <%= label form, :phone_number, "What’s your mobile phone number?", class: "form__label d-block" %>
           <%= telephone_input form, :phone_number, autocomplete: "off", placeholder: "###-###-####", class: "form-control d-inline-block form__phone--input", data: [toggle: "input"] %>
           <%= error_tag form, :phone_number %>
@@ -38,7 +37,7 @@
 
         <div class="form-group form__section form-check">
           <%= checkbox form, :digest_opt_in, class: "form-check-input" %>
-          <%= label form, :digest_opt_in, "Yes, send me a weekly email about planned service disruptions across the MBTA", class: "form__label--radio" %>
+          <%= label form, :digest_opt_in, "Yes, send me a weekly email about planned service disruptions across the MBTA.", class: "form__label--radio" %>
           Even if you receive text alerts, this will be sent to the email address you signed up with.
         </div>
 

--- a/apps/concierge_site/lib/templates/trip/index.html.eex
+++ b/apps/concierge_site/lib/templates/trip/index.html.eex
@@ -1,5 +1,6 @@
 <h1 class="heading__title">My subscriptions</h1>
 <%= flash_error(@conn) %>
+<%= flash_warning(@conn) %>
 <%= flash_info(@conn) %>
 
 <div class="container container__inner">

--- a/apps/concierge_site/lib/views/account_view.ex
+++ b/apps/concierge_site/lib/views/account_view.ex
@@ -1,4 +1,13 @@
 defmodule ConciergeSite.AccountView do
   use ConciergeSite.Web, :view
   import ConciergeSite.PasswordHelper, only: [password_regex_string: 0]
+  alias AlertProcessor.Model.User
+  alias Ecto.Changeset
+
+  defp fetch_field!(changeset, field) do
+    {_, value} = Changeset.fetch_field(changeset, field)
+    value
+  end
+
+  defp sms_frozen?(%{data: user}), do: User.inside_opt_out_freeze_window?(user)
 end

--- a/apps/concierge_site/test/web/controllers/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/trip_controller_test.exs
@@ -10,13 +10,23 @@ defmodule ConciergeSite.TripControllerTest do
     {:ok, user: user}
   end
 
-  test "GET /trips", %{conn: conn, user: user} do
-    conn =
-      user
-      |> guardian_login(conn)
-      |> get(trip_path(conn, :index))
+  describe "GET /trips" do
+    test "explains alerts are disabled", %{conn: conn} do
+      user = insert(:user, communication_mode: "none")
 
-    assert html_response(conn, 200) =~ "My subscriptions"
+      conn = user |> guardian_login(conn) |> get(trip_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "Alerts are disabled for your account"
+    end
+
+    test "has no message if alerts are not disabled", %{conn: conn, user: user} do
+      conn = user |> guardian_login(conn) |> get(trip_path(conn, :index))
+
+      response = html_response(conn, 200)
+
+      assert response =~ "My subscriptions"
+      refute response =~ "Alerts are disabled for your account"
+    end
   end
 
   describe "GET /trips/:id/edit" do


### PR DESCRIPTION
Currently a `none` communication mode is displayed the same as `email`, making it appear email delivery is enabled when in fact it isn't. There's no other indication in the UI that alerts are disabled, or explanation as to why, except when the reason is SMS opt-out and the user is still inside the opt-out freeze period.

With these changes, if a user's communication mode is `none`:

* their Settings page correctly has neither of the delivery options selected

* a flash appears on their Settings page explaining how this happened and what they can do to resolve it (for all circumstances, not just when inside the SMS freeze period)

* a flash appears on their Subscriptions page, which is the "home page" when signed in, explaining that alerts are disabled and to access the Settings page to resolve this