### PR TITLE
Delete Mailchimp data when account is deleted

### DIFF
--- a/apps/concierge_site/lib/controllers/account_controller.ex
+++ b/apps/concierge_site/lib/controllers/account_controller.ex
@@ -85,9 +85,8 @@ defmodule ConciergeSite.AccountController do
   end
 
   def delete(conn, _params, user, _claims) do
-    {:ok, user} = User.update_account(user, %{digest_opt_in: false}, user)
-    Mailchimp.update_member(user)
-    {:ok, _} = Repo.delete(user)
+    Mailchimp.delete_member(user)
+    Repo.delete!(user)
     redirect(conn, to: page_path(conn, :account_deleted))
   end
 

--- a/apps/concierge_site/lib/mailchimp/mailchimp_fake_client.ex
+++ b/apps/concierge_site/lib/mailchimp/mailchimp_fake_client.ex
@@ -1,23 +1,13 @@
 defmodule ConciergeSite.Mailchimp.FakeClient do
-  @moduledoc """
-  module used in testing mailchimp
-  """
+  @moduledoc "Fake version of `HTTPoison` used for testing `Mailchimp`."
 
-  def post(_endpoint, data, _headers) do
-    data = Poison.decode!(data)
-
-    if data["email_address"] == "success@test.com" do
-      {:ok, %{status_code: 200}}
-    else
-      {:error, %{status_code: 500}}
-    end
+  def put("/3.0/lists/abc123/members/0CF242BFA32139E06B25456DA90D29D1", data, _headers) do
+    %{"email_address" => "error@example.com"} = Poison.decode!(data)
+    {:error, %{status_code: 500}}
   end
 
-  def patch(endpoint, _data, _headers) do
-    if endpoint == "/3.0/lists/abc123/members/DC0C46B79F1514132B01F751B9B8AA54" do
-      {:ok, %{status_code: 200}}
-    else
-      {:error, %{status_code: 500}}
-    end
+  def put("/3.0/lists/abc123/members/" <> _, data, _headers) do
+    %{"email_address" => _, "status" => _, "status_if_new" => _} = Poison.decode!(data)
+    {:ok, %{status_code: 200}}
   end
 end

--- a/apps/concierge_site/lib/mailchimp/mailchimp_fake_client.ex
+++ b/apps/concierge_site/lib/mailchimp/mailchimp_fake_client.ex
@@ -6,8 +6,24 @@ defmodule ConciergeSite.Mailchimp.FakeClient do
     {:error, %{status_code: 500}}
   end
 
-  def put("/3.0/lists/abc123/members/" <> _, data, _headers) do
+  def put("/3.0/lists/abc123/members/" <> <<_::binary-size(32)>>, data, _headers) do
     %{"email_address" => _, "status" => _, "status_if_new" => _} = Poison.decode!(data)
     {:ok, %{status_code: 200}}
+  end
+
+  def post(
+        "/3.0/lists/abc123/members/0CF242BFA32139E06B25456DA90D29D1/actions/delete-permanent",
+        _data,
+        _headers
+      ) do
+    {:error, %{status_code: 500}}
+  end
+
+  def post(
+        "/3.0/lists/abc123/members/" <> <<_::binary-size(32)>> <> "/actions/delete-permanent",
+        _data,
+        _headers
+      ) do
+    {:ok, %{status_code: 204}}
   end
 end

--- a/apps/concierge_site/test/lib/mailchimp_test.exs
+++ b/apps/concierge_site/test/lib/mailchimp_test.exs
@@ -21,4 +21,18 @@ defmodule ConciergeSite.MailchimpTest do
       assert logs =~ "Mailchimp event=update_failed user_id=fakeid"
     end
   end
+
+  describe "delete_member/1" do
+    test "success" do
+      assert :ok == Mailchimp.delete_member(%User{email: "success@example.com"})
+    end
+
+    test "error" do
+      user = %User{id: "fakeid", email: "error@example.com"}
+
+      logs = capture_log(fn -> assert :error == Mailchimp.delete_member(user) end)
+
+      assert logs =~ "Mailchimp event=delete_failed user_id=fakeid"
+    end
+  end
 end

--- a/apps/concierge_site/test/lib/mailchimp_test.exs
+++ b/apps/concierge_site/test/lib/mailchimp_test.exs
@@ -4,33 +4,21 @@ defmodule ConciergeSite.MailchimpTest do
 
   alias AlertProcessor.Model.User
   alias ConciergeSite.Mailchimp
+  import ExUnit.CaptureLog
 
-  describe "add_member/3" do
-    test "success subscribe" do
-      user = %User{email: "success@test.com", id: "abc123", digest_opt_in: true}
-      assert :ok == Mailchimp.add_member(user)
-    end
-
-    test "success ignore" do
-      user = %User{email: "ignore@test.com", id: "abc123", digest_opt_in: false}
-      assert :ok == Mailchimp.add_member(user)
-    end
-
-    test "error" do
-      user = %User{email: "error@test.com", id: "abc123", digest_opt_in: true}
-      assert :error == Mailchimp.add_member(user)
-    end
-  end
-
-  describe "send_member_status_update/2" do
+  describe "update_member/1" do
     test "success" do
-      user = %User{email: "success@test.com", id: "abc123", digest_opt_in: true}
-      assert :ok == Mailchimp.send_member_status_update(user)
+      user = %User{email: "success@example.com", digest_opt_in: true}
+
+      assert :ok == Mailchimp.update_member(user)
     end
 
     test "error" do
-      user = %User{email: "error@test.com", id: "abc123", digest_opt_in: true}
-      assert :error == Mailchimp.send_member_status_update(user)
+      user = %User{id: "fakeid", email: "error@example.com", digest_opt_in: true}
+
+      logs = capture_log(fn -> assert :error == Mailchimp.update_member(user) end)
+
+      assert logs =~ "Mailchimp event=update_failed user_id=fakeid"
     end
   end
 end


### PR DESCRIPTION
This was a request from the team drafting new MBTA privacy policies. Currently when a user self-service deletes their account, we permanently delete all data connected to them _except_ their membership on the weekly digest in Mailchimp, where we only mark them as unsubscribed. It will simplify the privacy policy (and also better reflect the intent of the action) if deleting your account truly deletes everything, including Mailchimp data.

This change is deployed to dev-green, where I tested that existing functionality still works and that the new delete request goes through.