### PR TITLE
refactor: remove unused "header note" feature

### DIFF
--- a/apps/concierge_site/assets/css/_header.scss
+++ b/apps/concierge_site/assets/css/_header.scss
@@ -44,13 +44,6 @@
   border-bottom: 1px solid $pale-grey;
 }
 
-.header__sub--container_note {
-  background-color: #fbce0e;
-  font-size: 0.875rem;
-  line-height: 1.3125rem;
-  padding: 0.8rem 0;
-}
-
 a[data-menu-toggle="up"] {
   .fa-angle-down {
     display: none;

--- a/apps/concierge_site/assets/css/_landing_page.scss
+++ b/apps/concierge_site/assets/css/_landing_page.scss
@@ -170,7 +170,6 @@ body.landing-page {
   }
 
   .header__sub--container,
-  .header__sub--container_note,
   .landing-page.row,
   .footer__container {
     display:none\9;

--- a/apps/concierge_site/lib/templates/layout/app.html.eex
+++ b/apps/concierge_site/lib/templates/layout/app.html.eex
@@ -57,13 +57,6 @@
         </div>
       </header>
     <% end %>
-    <%= if assigns[:header_note] do %>
-    <header class="header__sub--container_note">
-      <div class="container">
-        <%= raw assigns[:header_note] %>
-      </div>
-    </header>
-    <% end %>
     <div class="container page__content">
       <div class="row justify-content-md-center">
         <% cols = if (assigns[:wide_layout]), do: "col-md-12", else: "col-md-8" %>


### PR DESCRIPTION
This was previously used to display a warning about the govDelivery version of T-Alerts being turned off. It is not referenced anywhere in the code since September 2018.