### PR TITLE
build: Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,59 @@
-FROM erlang:22.3.4.14 as builder
+# --- Set up Elixir build ---
+FROM hexpm/elixir:1.8.2-erlang-22.3.4.14-debian-bullseye-20210902-slim as elixir-builder
 
-# elixir expects utf8.
-ENV ELIXIR_VERSION=1.8.2 \
-	ELIXIR_SHA1=62265bb3660bfc17a1ad209be9ca9304ae9d3035 \
-	LANG=C.UTF-8
+ENV LANG=C.UTF-8 MIX_ENV=prod
 
-RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" \
-	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
-	&& echo "$ELIXIR_SHA1 elixir-src.tar.gz" | sha1sum -c - \
-	&& mkdir -p /usr/local/src/elixir \
-	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
-	&& rm elixir-src.tar.gz \
-	&& cd /usr/local/src/elixir \
-	&& make install clean
-
-ENV MIX_ENV=prod
+RUN apt-get update --allow-releaseinfo-change
+RUN apt-get install --no-install-recommends --yes \
+  build-essential ca-certificates git
+RUN mix local.hex --force
+RUN mix local.rebar --force
 
 WORKDIR /root
 ADD . .
+RUN mix deps.get --only prod
 
-# Configure Git to use HTTPS in order to avoid issues with the internal MBTA network
-RUN git config --global url.https://github.com/.insteadOf git://github.com/
 
-# Install hex and rebar
-RUN mix local.hex --force && \
-	mix local.rebar --force && \
-	mix do deps.get --only prod, compile --force
+# --- Build frontend assets ---
+FROM node:14.17.6-bullseye-slim as asset-builder
 
-WORKDIR /root/apps/concierge_site/assets/
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get update --allow-releaseinfo-change
+RUN apt-get install --no-install-recommends --yes ca-certificates git
+
+# Allow asset build to reference files provided by Elixir dependencies
+WORKDIR /root
+COPY --from=elixir-builder /root/deps ./deps
+
+WORKDIR /root/apps/concierge_site/assets
+ADD apps/concierge_site/assets .
 RUN npm install
 RUN npm run deploy
 
-WORKDIR /root/apps/concierge_site/
-RUN mix phx.digest
+
+# --- Build Elixir release ---
+FROM elixir-builder as app-builder
+
+WORKDIR /root/apps/concierge_site/priv/static
+COPY --from=asset-builder /root/apps/concierge_site/priv/static .
 
 WORKDIR /root
+RUN mix compile
+RUN mix phx.digest
 RUN mix release --verbose
 
-# the one the elixir image was built with
-FROM debian:buster
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	libssl1.1 libsctp1 libtinfo6 curl \
-	&& rm -rf /var/lib/apt/lists/*
+# --- Set up runtime container ---
+FROM debian:bullseye-slim
+
+ENV LANG=C.UTF-8 MIX_ENV=prod REPLACE_OS_VARS=true
+
+RUN apt-get update --allow-releaseinfo-change \
+  && apt-get install --no-install-recommends --yes dumb-init \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
-EXPOSE 4000
-ENV MIX_ENV=prod TERM=xterm LANG="C.UTF-8" REPLACE_OS_VARS=true
+COPY --from=app-builder /root/_build/prod/rel/alerts_concierge .
 
-COPY --from=builder /root/_build/prod/rel/alerts_concierge/releases/current/alerts_concierge.tar.gz .
-RUN mkdir gtfs
-RUN tar -xzf alerts_concierge.tar.gz
+EXPOSE 4000
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["bin/alerts_concierge", "foreground"]


### PR DESCRIPTION
* Use pre-built `hexpm/elixir` image instead of starting from an Erlang image and manually installing Elixir
* Use `node` image to build assets instead of installing Node in the Elixir image (allows specifying exact version)
* Upgrade to current stable Debian release ("Bullseye")
* Use `slim` Debian images to omit unneeded packages where possible
* Use `dumb-init` as entrypoint to ensure signals are handled correctly

Overall, these improvements reduce our deploy time by about 2 minutes, and better align with how we're currently doing Docker builds on other projects like Dotcom and Arrow.