### PR TITLE
deps: update and clean up frontend packages

### DIFF
--- a/apps/concierge_site/assets/js/admin/api/index.ts
+++ b/apps/concierge_site/assets/js/admin/api/index.ts
@@ -1,5 +1,3 @@
-import 'whatwg-fetch';
-
 interface UserResponse {
   id: string;
   email: string;

--- a/apps/concierge_site/assets/js/schedule/process-schedule.js
+++ b/apps/concierge_site/assets/js/schedule/process-schedule.js
@@ -1,4 +1,3 @@
-import elemDataset from "elem-dataset";
 import { checkItem, unCheckItem } from "./handle-trip-change";
 
 const makeDate = timeString => new Date(`1/1/2000 ${timeString}`);
@@ -40,9 +39,8 @@ function processTrip(
   travelStartTime,
   travelEndTime
 ) {
-  const dataset = elemDataset(tripEl);
-  const tripTime = dataset.time;
-  const dayType = dataset.weekend === "true" ? "weekend" : "weekday";
+  const tripTime = tripEl.dataset.time;
+  const dayType = tripEl.dataset.weekend === "true" ? "weekend" : "weekday";
   const matched =
     isTimeMatched(tripTime, startTime, endTime) &&
     isDayMatched(dayType, weekday, weekend);
@@ -119,15 +117,13 @@ const timeForTrip = (tripType) => {
 export function processSchedule(scheduleEl, showDefaultTravelTimes) {
   const weekdaySelected = checkdDays(weekdays);
   const weekendSelected = checkdDays(weekends);
-  const scheduleDataset = elemDataset(scheduleEl);
-  const startTime = timeForTrip(scheduleDataset.start);
-  const endTime = timeForTrip(scheduleDataset.end);
+  const startTime = timeForTrip(scheduleEl.dataset.start);
+  const endTime = timeForTrip(scheduleEl.dataset.end);
   const legs = [
     ...scheduleEl.querySelectorAll("div[data-type='schedule-leg']")
   ];
   legs.forEach(legEl => {
-    const legDataset =
-      showDefaultTravelTimes === true ? elemDataset(legEl) : {};
+    const legDataset = showDefaultTravelTimes === true ? legEl.dataset : {};
     const trips = [...legEl.getElementsByClassName("schedules__trips--item")];
     trips.forEach((tripEl, index) =>
       tripEl.setAttribute("data-position", index)

--- a/apps/concierge_site/assets/js/select-route-choices.js
+++ b/apps/concierge_site/assets/js/select-route-choices.js
@@ -1,5 +1,4 @@
 import Choices from "choices.js";
-import elemDataset from "elem-dataset";
 import getIcon from "./route-icons";
 import { say } from "./speak-to-screenreader";
 
@@ -185,8 +184,7 @@ const handleHighlightChoice = event => {
 const getIconMap = el => {
   return [...el.querySelectorAll("option")].reduce((accumulator, option) => {
     const id = option.getAttribute("value");
-    const dataset = elemDataset(option);
-    const icon = dataset.icon;
+    const icon = option.dataset.icon;
     if (id && icon) {
       accumulator[id] = icon;
     }
@@ -198,8 +196,7 @@ const getIconMap = el => {
 export const toggleVisibleSelector = inputValue => {
   [...document.querySelectorAll("[data-type='mode-select']")].forEach(el => {
     const selectEl = el.querySelector("select");
-    const dataset = elemDataset(el);
-    if (dataset.id == inputValue) {
+    if (el.dataset.id == inputValue) {
       el.classList.remove("d-none");
       selectEl.setAttribute("name", "trip[route]");
       applyChoicesJSToRoute(selectEl, {

--- a/apps/concierge_site/assets/js/select-stop-choices.js
+++ b/apps/concierge_site/assets/js/select-stop-choices.js
@@ -1,5 +1,4 @@
 import Choices from "choices.js";
-import elemDataset from 'elem-dataset';
 import getIcon from "./route-icons";
 import { say } from "./speak-to-screenreader";
 
@@ -30,8 +29,7 @@ const cacheStopData = optionEls => {
     if (!stopId) {
       return;
     }
-    const dataset = elemDataset(optionEl);
-    stopData[stopId] = Object.keys(Object.assign({}, dataset));
+    stopData[stopId] = Object.keys(Object.assign({}, optionEl.dataset));
   });
 };
 
@@ -121,8 +119,7 @@ const handleChoice = event => {
   const selectEl = event.target;
   const selectId = selectEl.getAttribute("id");
   const otherSelectId = flipId(selectId);
-  const dataset = elemDataset(selectEl);
-  const selectData = Object.assign({}, dataset);
+  const selectData = Object.assign({}, selectEl.dataset);
   const selectedStopId = event.detail.choice.value || null;
   let availableChoices;
 

--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.14.5"
@@ -18,20 +18,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
-      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+      "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
+        "@babel/code-frame": "^7.15.8",
+        "@babel/generator": "^7.15.8",
         "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.8",
         "@babel/helpers": "^7.15.4",
-        "@babel/parser": "^7.15.5",
+        "@babel/parser": "^7.15.8",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -64,12 +64,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -79,22 +73,16 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
-      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -132,39 +120,6 @@
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -220,12 +175,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -287,9 +236,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
-      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+      "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.15.4",
@@ -413,47 +362,18 @@
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
     "@babel/parser": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
-      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -468,9 +388,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
-      "integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+      "integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -802,14 +722,6 @@
         "@babel/helper-replace-supers": "^7.15.4",
         "@babel/helper-split-export-declaration": "^7.15.4",
         "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -1016,13 +928,13 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+      "integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -1072,9 +984,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
-      "integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+      "integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -1082,7 +994,7 @@
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.15.8",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.15.4",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -1137,7 +1049,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.6",
+        "@babel/plugin-transform-spread": "^7.15.8",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -1146,18 +1058,10 @@
         "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.15.6",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "core-js-compat": "^3.16.0",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "@babel/preset-modules": {
@@ -1177,7 +1081,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
       "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1185,8 +1088,7 @@
         "regenerator-runtime": {
           "version": "0.13.9",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-          "dev": true
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
       }
     },
@@ -1227,12 +1129,6 @@
             "ms": "2.1.2"
           }
         },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1249,14 +1145,6 @@
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
       }
     },
     "@discoveryjs/json-ext": {
@@ -1298,9 +1186,9 @@
       "dev": true
     },
     "@types/eslint": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-      "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
+      "integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -1520,24 +1408,24 @@
       }
     },
     "@webpack-cli/configtest": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-      "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
       "dev": true
     },
     "@webpack-cli/info": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-      "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
       }
     },
     "@webpack-cli/serve": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-      "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
       "dev": true
     },
     "@xtuc/ieee754": {
@@ -1553,9 +1441,9 @@
       "dev": true
     },
     "PubSub": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/PubSub/-/PubSub-3.6.2.tgz",
-      "integrity": "sha512-9X62/xZ76z+hp5t7aM/066D5T97yYmKyYAZDWdIY1Y2D8kmCE+l3vlQk6l4HFhsQgO6pdYOdsgTAKwc5YkwsLw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/PubSub/-/PubSub-4.0.0.tgz",
+      "integrity": "sha512-3YKlKutT8DC6/XNq++XK/aRoyr1kyv9WOAdANwjL1GeBjkF1eI4CylzhqFvxhrstkOSRebZwQ/PNQgkz1N5mvg=="
     },
     "acorn": {
       "version": "8.5.0",
@@ -1564,9 +1452,9 @@
       "dev": true
     },
     "acorn-import-assertions": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
-      "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true
     },
     "ajv": {
@@ -1592,6 +1480,15 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "anymatch": {
       "version": "3.1.2",
@@ -1727,24 +1624,16 @@
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.2.2",
         "semver": "^6.1.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+      "integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "core-js-compat": "^3.16.2"
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -1927,60 +1816,33 @@
         "caniuse-lite": "^1.0.0",
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001259",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-              "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-              "dev": true
-            }
-          }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001265",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
       "dev": true
     },
-    "choices.js": {
-      "version": "git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5",
-      "from": "choices.js@git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5",
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
-        "classnames": "^2.2.5",
-        "core-js": "^2.5.6",
-        "custom-event-polyfill": "^0.3.0",
-        "fuse.js": "^3.1.0",
-        "opn": "^5.1.0",
-        "redux": "^3.3.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        }
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "choices.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-9.0.1.tgz",
+      "integrity": "sha512-JgpeDY0Tmg7tqY6jaW/druSklJSt7W68tXFJIw0GSGWmO37SDAL8o60eICNGbzIODjj02VNNtf5h6TgoHDtCsA==",
+      "requires": {
+        "deepmerge": "^4.2.0",
+        "fuse.js": "^3.4.5",
+        "redux": "^4.0.4"
       }
     },
     "chokidar": {
@@ -2072,11 +1934,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -2114,9 +1971,9 @@
       "dev": true
     },
     "colord": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
-      "integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
+      "integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA==",
       "dev": true
     },
     "colorette": {
@@ -2196,20 +2053,45 @@
       }
     },
     "core-js": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
-      "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w=="
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+      "integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ=="
     },
     "core-js-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.0.tgz",
-      "integrity": "sha512-tRVjOJu4PxdXjRMEgbP7lqWy1TWJu9a01oBkn8d+dNrhgmBwdTkzhHZpVJnEmhISLdoJI1lX08rcBcHi3TZIWg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.2.tgz",
+      "integrity": "sha512-25VJYCJtGjZwLguj7d66oiHfmnVw3TMOZ0zV8DyMJp/aeQ3OjR519iOOeck08HMyVVRAqXxafc2Hl+5QstJrsQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.17.0",
+        "browserslist": "^4.17.3",
         "semver": "7.0.0"
       },
       "dependencies": {
+        "browserslist": {
+          "version": "4.17.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+          "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001264",
+            "electron-to-chromium": "^1.3.857",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.77",
+            "picocolors": "^0.2.1"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.862",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.862.tgz",
+          "integrity": "sha512-o+FMbCD+hAUJ9S8bfz/FaqA0gE8OpCCm58KhhGogOEqiA1BLFSoVYLi+tW+S/ZavnqBn++n0XZm7HQiBVPs8Jg==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.77",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+          "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+          "dev": true
+        },
         "semver": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -2233,38 +2115,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "css-color-names": {
@@ -2327,16 +2177,16 @@
       }
     },
     "css-minimizer-webpack-plugin": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.0.2.tgz",
-      "integrity": "sha512-B3I5e17RwvKPJwsxjjWcdgpU/zqylzK1bPVghcmpFHRL48DXiBgrtqz1BJsn68+t/zzaLp9kYAaEDvQ7GyanFQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.1.1.tgz",
+      "integrity": "sha512-KlB8l5uoNcf9F7i5kXnkxoqJGd2BXH4f0+Lj2vSWSmuvMLYO1kNsJ1KHSzeDW8e45/whgSOPcKVT/3JopkT8dg==",
       "dev": true,
       "requires": {
         "cssnano": "^5.0.6",
         "jest-worker": "^27.0.2",
         "p-limit": "^3.0.2",
         "postcss": "^8.3.5",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^3.1.0",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1"
       },
@@ -2468,11 +2318,6 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
       "dev": true
     },
-    "custom-event-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz",
-      "integrity": "sha1-mYB4Ob5i7bRGtkWDLg2A6tb6GIg="
-    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -2497,6 +2342,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2605,11 +2455,6 @@
       "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
       "dev": true
     },
-    "elem-dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/elem-dataset/-/elem-dataset-1.1.1.tgz",
-      "integrity": "sha1-GPB/p/xx69SbD59jgZywPIJ2V3o="
-    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -2649,9 +2494,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-      "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
       "dev": true
     },
     "es5-ext": {
@@ -3145,6 +2990,12 @@
         "process": "^0.11.10"
       }
     },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
     "globby": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -3245,9 +3096,9 @@
       "dev": true
     },
     "import-local": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
       "dev": true,
       "requires": {
         "pkg-dir": "^4.2.0",
@@ -3428,11 +3279,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3490,9 +3336,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -3563,12 +3409,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -3745,18 +3587,18 @@
       }
     },
     "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
       "dev": true,
       "requires": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.50.0"
       }
     },
     "mimic-fn": {
@@ -3774,9 +3616,9 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.3.0.tgz",
-      "integrity": "sha512-uzWaOwC+gJrnKbr23J1ZRWx/Wd9W9Ce1mKPlsBGBV/r8zG7/G7oKMxGmxbI65pVGbae2cR7CUx9Ulk0HQt8BfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.2.tgz",
+      "integrity": "sha512-ZmqShkn79D36uerdED+9qdo1ZYG8C1YsWvXu0UMJxurZnSdgz7gQKO2EGv8T55MhDqG3DYmGtizZNpM/UbTlcA==",
       "dev": true,
       "requires": {
         "schema-utils": "^3.1.0"
@@ -3835,6 +3677,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
       "dev": true
     },
     "nanoid": {
@@ -3991,14 +3839,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -4058,6 +3898,12 @@
     "phoenix_html": {
       "version": "file:../../../deps/phoenix_html"
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4085,14 +3931,22 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
         "source-map-js": "^0.6.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.1.29",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+          "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
+          "dev": true
+        }
       }
     },
     "postcss-calc": {
@@ -4115,33 +3969,6 @@
         "caniuse-api": "^3.0.0",
         "colord": "^2.0.1",
         "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "postcss-convert-values": {
@@ -4199,33 +4026,6 @@
         "cssnano-utils": "^2.0.1",
         "postcss-selector-parser": "^6.0.5",
         "vendors": "^1.0.3"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "postcss-minify-font-values": {
@@ -4259,33 +4059,6 @@
         "cssnano-utils": "^2.0.1",
         "postcss-value-parser": "^4.1.0",
         "uniqs": "^2.0.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "postcss-minify-selectors": {
@@ -4403,33 +4176,6 @@
       "requires": {
         "browserslist": "^4.16.0",
         "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "postcss-normalize-url": {
@@ -4470,33 +4216,6 @@
       "requires": {
         "browserslist": "^4.16.0",
         "caniuse-api": "^3.0.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
       }
     },
     "postcss-reduce-transforms": {
@@ -4662,14 +4381,11 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "regenerate": {
@@ -4733,6 +4449,14 @@
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "repeat-element": {
@@ -4815,9 +4539,9 @@
       }
     },
     "sass": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.0.tgz",
-      "integrity": "sha512-kcjxsemgaOnfl43oZgO/IePLvXQI0ZKzo0/xbCt6uyrg3FY/FF8hVK9YoO8GiZBcEG2Ebl79EKnUc+aiE4f2Vw==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -4852,6 +4576,12 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -4899,10 +4629,25 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "signal-exit": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
-      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
     "snapdragon": {
@@ -5118,56 +4863,32 @@
       "requires": {
         "browserslist": "^4.16.0",
         "postcss-selector-parser": "^6.0.4"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
       }
     },
     "svgo": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.6.1.tgz",
-      "integrity": "sha512-SDo274ymyG1jJ3HtCr3hkfwS8NqWdF0fMr6xPlrJ5y2QMofsQxIEFWgR1epwb197teKGgnZbzozxvJyIeJpE2Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.7.0.tgz",
+      "integrity": "sha512-aDLsGkre4fTDCWvolyW+fs8ZJFABpzLXbtdK1y71CKnHzAnpDxKXPj2mNKj+pyOXUCzFHzuxRJ94XOFygOWV3w==",
       "dev": true,
       "requires": {
         "@trysound/sax": "0.2.0",
-        "colorette": "^1.4.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
+        "nanocolors": "^0.1.12",
         "stable": "^0.1.8"
       },
       "dependencies": {
-        "colorette": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-          "dev": true
-        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -5175,11 +4896,6 @@
           "dev": true
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tapable": {
       "version": "1.1.3",
@@ -5269,6 +4985,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
@@ -5467,9 +5189,9 @@
       }
     },
     "webpack": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-      "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+      "version": "5.58.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.1.tgz",
+      "integrity": "sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -5481,8 +5203,8 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.0",
-        "es-module-lexer": "^0.7.1",
+        "enhanced-resolve": "^5.8.3",
+        "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -5498,31 +5220,6 @@
         "webpack-sources": "^3.2.0"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-          "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001254",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.830",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001259",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
-          "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.845",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-          "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
-          "dev": true
-        },
         "enhanced-resolve": {
           "version": "5.8.3",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
@@ -5549,26 +5246,20 @@
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
           "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
           "dev": true
-        },
-        "webpack-sources": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-          "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
-          "dev": true
         }
       }
     },
     "webpack-cli": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-      "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
+      "integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.0.4",
-        "@webpack-cli/info": "^1.3.0",
-        "@webpack-cli/serve": "^1.5.2",
-        "colorette": "^1.2.1",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
@@ -5579,6 +5270,12 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -5640,10 +5337,20 @@
         "wildcard": "^2.0.0"
       }
     },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    "webpack-sources": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
+      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "wildcard": {
       "version": "2.0.0",

--- a/apps/concierge_site/assets/package.json
+++ b/apps/concierge_site/assets/package.json
@@ -8,11 +8,10 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "PubSub": "^3.4.0",
+    "PubSub": "^4.0.0",
     "bootstrap": "^4.1.0",
-    "choices.js": "git+https://git@github.com/jshjohnson/Choices.git#8dedc6f1e032bf9891e7ec6564daed058d61ead5",
-    "core-js": "^3.18.0",
-    "elem-dataset": "^1.1.1",
+    "choices.js": "^9.0.1",
+    "core-js": "^3.18.2",
     "font-awesome": "^4.7.0",
     "form-serialize": "^0.7.2",
     "jquery": "^3.2.1",
@@ -25,12 +24,11 @@
     "react-dom": "^16.4.2",
     "set-manipulator": "^0.3.1",
     "time-number": "^1.1.0",
-    "whatwg-fetch": "^2.0.4",
     "xhr": "^2.5.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.15.5",
-    "@babel/preset-env": "^7.15.6",
+    "@babel/core": "^7.15.8",
+    "@babel/preset-env": "^7.15.8",
     "@types/promise": "^7.1.30",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
@@ -38,12 +36,12 @@
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.3.0",
-    "css-minimizer-webpack-plugin": "^3.0.2",
-    "mini-css-extract-plugin": "^2.3.0",
-    "sass": "^1.42.0",
+    "css-minimizer-webpack-plugin": "^3.1.1",
+    "mini-css-extract-plugin": "^2.4.2",
+    "sass": "^1.42.1",
     "sass-loader": "^12.1.0",
     "typescript": "^3.0.1",
-    "webpack": "^5.53.0",
-    "webpack-cli": "^4.8.0"
+    "webpack": "^5.58.1",
+    "webpack-cli": "^4.9.0"
   }
 }

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -156,9 +156,9 @@ defmodule ConciergeSite.ScheduleTest do
              %AlertProcessor.Model.TripInfo{
                arrival_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
-                 time: ~T[06:20:00]
+                 time: ~T[06:21:00]
                },
-               arrival_time: ~T[06:20:00],
+               arrival_time: ~T[06:21:00],
                departure_extended_time: %AlertProcessor.ExtendedTime{
                  relative_day: 1,
                  time: ~T[05:40:00]


### PR DESCRIPTION
* `elem-dataset` is replaced with native `dataset` since all browsers now support it, even IE11
* `whatwg-fetch` polyfill is removed as all browsers other than IE11 support `fetch` natively, and this function is only used in the admin interface
* All package updates otherwise had no breaking changes for us

Packages that remain outdated:

* `react`, `react-dom`, and `typescript`: these are used only in the admin interface, and we're not yet sure whether we will keep this
* `bootstrap`: this is already at the latest release of Bootstrap 4, and migrating to Bootstrap 5 is pretty far out of scope for this task