### PR TITLE
Fix missing favicon

### DIFF
--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1210,9 +1210,9 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # are active as of 2021-06-28.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-483969-909"
-                   6 -> "CR-485400-1907"
-                   7 -> "CR-485902-2907"
+                   day when day in 1..5 -> "CR-501108-909"
+                   6 -> "CR-501497-1907"
+                   7 -> "CR-501301-2907"
                  end)
   @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
                                      day when day in 1..5 -> ~T[08:25:00]

--- a/apps/concierge_site/assets/static/analytics.txt
+++ b/apps/concierge_site/assets/static/analytics.txt
@@ -1,1 +1,0 @@
-GooGhywoiu9839t543j0s7543uw1. Please add gshkolnik@gmail.com to GA account UA-120513192 with "Manage Users and Edit" permissions - date 04/09/2019.

--- a/apps/concierge_site/assets/static/robots.txt
+++ b/apps/concierge_site/assets/static/robots.txt
@@ -1,5 +1,1 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+# See http://www.robotstxt.org/robotstxt.html for how to use this file

--- a/apps/concierge_site/lib/endpoint.ex
+++ b/apps/concierge_site/lib/endpoint.ex
@@ -17,7 +17,7 @@ defmodule ConciergeSite.Endpoint do
     at: "/",
     from: :concierge_site,
     gzip: true,
-    only: ~w(css fonts images js favicon.ico robots.txt analytics.txt)
+    only: ~w(css fonts images js favicon.ico robots.txt)
   )
 
   # Code reloading can be explicitly enabled under the

--- a/apps/concierge_site/lib/endpoint.ex
+++ b/apps/concierge_site/lib/endpoint.ex
@@ -17,7 +17,7 @@ defmodule ConciergeSite.Endpoint do
     at: "/",
     from: :concierge_site,
     gzip: true,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only_matching: ~w(css fonts images js favicon robots)
   )
 
   # Code reloading can be explicitly enabled under the


### PR DESCRIPTION
This occurred because the `<link rel="icon">` in the HTML used the "digested" filename in production, but following this link would give a 404, since the site was only configured to serve the un-digested `favicon.ico`. Depending on whether the browser "preferred" the `<link>` or the file at `/favicon.ico`, it sometimes wouldn't show the icon.

Using `only_matching` instead of `only` in `Plug.Static` allows serving digested files at the root, since strings specified here only need to be a prefix of the first path component instead of matching it exactly.