### PR TITLE
chore: upgrade to Postgres 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     needs: setup
     services:
       postgres:
-        image: postgres:10
+        image: postgres:13
         ports:
           - 5432:5432
         env:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ subscribe to notifications for service disruptions.
 
 - MBTA API key (get one [here](https://dev.api.mbtace.com))
   - **Note:** This key must have its version set to `2019-04-05`
-- PostgreSQL 10 (using Homebrew: `brew install postgresql@10`)
+- PostgreSQL 13 (using Homebrew: `brew install postgresql@13`)
 - Chromedriver (using Homebrew: `brew cask install chromedriver`)
 - Erlang, Elixir, and Node.js versions specified in `.tool_versions`
   - Use [`asdf`](https://github.com/asdf-vm/asdf) to install automatically

--- a/apps/alert_processor/priv/repo/structure.sql
+++ b/apps/alert_processor/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.17
--- Dumped by pg_dump version 13.3
+-- Dumped from database version 13.4
+-- Dumped by pg_dump version 14.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -31,6 +31,8 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
 
 
 SET default_tablespace = '';
+
+SET default_table_access_method = heap;
 
 --
 -- Name: alerts; Type: TABLE; Schema: public; Owner: -

--- a/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/text_replacement_test.exs
@@ -48,10 +48,10 @@ defmodule AlertProcessor.TextReplacementTest do
         informed_entities: [
           %AlertProcessor.Model.InformedEntity{
             activities: ["BOARD"],
-            stop: "place-ER-0046"
+            stop: "place-chels"
           }
         ],
-        origin: "place-ER-0046"
+        origin: "place-chels"
       }
 
       alert = %Alert{
@@ -72,7 +72,7 @@ defmodule AlertProcessor.TextReplacementTest do
               },
               %{
                 departure_time: "2017-10-30T22:17:00-04:00",
-                stop_id: "place-ER-0046",
+                stop_id: "place-chels",
                 trip_id: "CR-Weekday-Aug14th-17-NR-180"
               },
               %{

--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -258,9 +258,9 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
              ServiceInfoCache.get_headsign(pid, "place-davis", "place-pktrm", 0)
 
     assert {:ok, "Alewife"} == ServiceInfoCache.get_headsign(pid, "place-pktrm", "place-davis", 1)
-    assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-north", "place-clmnl", 0)
-    assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-clmnl", "place-north", 1)
-    assert {:ok, "C or E"} == ServiceInfoCache.get_headsign(pid, "place-gover", "place-haecl", 0)
+    assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-gover", "place-clmnl", 0)
+    assert {:ok, "C"} == ServiceInfoCache.get_headsign(pid, "place-clmnl", "place-gover", 1)
+    assert {:ok, "D or E"} == ServiceInfoCache.get_headsign(pid, "place-gover", "place-haecl", 0)
     assert :error == ServiceInfoCache.get_headsign(pid, "garbage", "more garbage", 1)
   end
 
@@ -412,7 +412,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
     assert stops_with_icons["1154"] == [modes: MapSet.new([:bus]), accessible: false]
 
     assert stops_with_icons["place-north"] == [
-             modes: MapSet.new([:cr, :"green-c", :"green-e", :orange]),
+             modes: MapSet.new([:cr, :"green-d", :"green-e", :orange]),
              accessible: true
            ]
 

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -77,7 +77,7 @@ defmodule ConciergeSite.ScheduleTest do
                  {"Swampscott", "place-ER-0128", {42.473743, -70.922537}, 1},
                  {"Lynn", "place-ER-0115", {42.462953, -70.945421}, 1},
                  {"River Works", "place-ER-0099", {42.449927, -70.969848}, 2},
-                 {"Chelsea", "place-ER-0046", {42.395689, -71.034281}, 2},
+                 {"Chelsea", "place-chels", {42.397024, -71.041314}, 1},
                  {"North Station", "place-north", {42.365577, -71.06129}, 1}
                ],
                direction_destinations: ["Newburyport or Rockport", "North Station"]


### PR DESCRIPTION
All deployed environments other than `prod` have already been upgraded without incident, and `prod` will likely be upgraded this week. ✨