### PR TITLE
feat(admin): report for subscription count by stop

### DIFF
--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -83,7 +83,7 @@ defmodule ConciergeSite.ScheduleTest do
                direction_destinations: ["Newburyport or Rockport", "North Station"]
              },
              selected: false,
-             trip_number: "1101",
+             trip_number: "2101",
              weekend?: true
            }
   end


### PR DESCRIPTION
Temporarily deployed to production to ensure this is reasonably optimized — the query completes in less than a second.