### PR TITLE
feat(admin): add column to users report

### DIFF
--- a/apps/alert_processor/lib/model/query.ex
+++ b/apps/alert_processor/lib/model/query.ex
@@ -68,11 +68,11 @@ defmodule AlertProcessor.Model.Query do
         query: """
         SELECT communication_mode,
           COUNT(DISTINCT users.id) AS users,
-          COUNT(DISTINCT CASE WHEN subscriptions.id IS NOT NULL THEN users.id END) AS active_users
+          COUNT(DISTINCT CASE WHEN subscriptions.id IS NOT NULL THEN users.id END) AS subscribed_users,
+          COUNT(DISTINCT CASE WHEN subscriptions.id IS NOT NULL AND subscriptions.paused IS NOT TRUE THEN users.id END) AS active_users
         FROM users
         LEFT JOIN subscriptions
           ON users.id = subscriptions.user_id
-            AND subscriptions.paused IS NOT TRUE
         GROUP BY communication_mode
         """
       }

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -83,7 +83,7 @@ defmodule ConciergeSite.ScheduleTest do
                direction_destinations: ["Newburyport or Rockport", "North Station"]
              },
              selected: false,
-             trip_number: "2101",
+             trip_number: "1101",
              weekend?: true
            }
   end


### PR DESCRIPTION
This adds a column `subscribed_users` which is the count of users who have any subscriptions, regardless of paused status.