### PR TITLE
build: remove "app version" generation

### DIFF
--- a/apps/alert_processor/mix.exs
+++ b/apps/alert_processor/mix.exs
@@ -4,7 +4,7 @@ defmodule AlertProcessor.Mixfile do
   def project do
     [
       app: :alert_processor,
-      version: "0.0.59",
+      version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/concierge_site/mix.exs
+++ b/apps/concierge_site/mix.exs
@@ -4,7 +4,7 @@ defmodule ConciergeSite.Mixfile do
   def project do
     [
       app: :concierge_site,
-      version: app_version("0.0.59"),
+      version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -78,18 +78,6 @@ defmodule ConciergeSite.Mixfile do
       {:hammer_plug, "~> 2.0"},
       {:sentry, "~> 7.0"}
     ]
-  end
-
-  defp app_version(base) do
-    # get git version
-    try do
-      case System.cmd("git", ~w[rev-parse HEAD]) do
-        {hash, 0} -> "#{base}+#{String.trim(hash)}"
-        _ -> base
-      end
-    rescue
-      _ -> base
-    end
   end
 
   # Aliases are shortcuts or tasks specific to the current project.


### PR DESCRIPTION
It's unclear whether this still worked, and in any case we don't use it for anything.