### PR TITLE
fix: Sobelow was not accessible to CI

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule AlertsConcierge.Mixfile do
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:distillery, "~> 1.5", runtime: false},
       {:lcov_ex, "~> 0.2", only: [:dev, :test], runtime: false},
-      {:sobelow, "~> 0.11.0", only: [:dev], runtime: false}
+      {:sobelow, "~> 0.11.0", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
Since CI always runs in `MIX_ENV=test` and Sobelow was only listed as a `dev` dependency, it failed with a "task could not be found" error. Unclear how the change that added Sobelow passed CI in the first place before being merged.