### PR TITLE
fix: 500 error when auth token expired

### DIFF
--- a/apps/concierge_site/lib/guardian/auth_error_handler.ex
+++ b/apps/concierge_site/lib/guardian/auth_error_handler.ex
@@ -2,15 +2,16 @@ defmodule ConciergeSite.Guardian.AuthErrorHandler do
   @moduledoc false
   use ConciergeSite.Web, :controller
 
-  def auth_error(conn, {:unauthenticated, _reason}, _opts) do
-    conn
-    |> put_flash(:info, "Please log in.")
-    |> redirect(to: session_path(conn, :new))
-  end
-
   def auth_error(conn, {:unauthorized, _reason}, _opts) do
     conn
     |> put_flash(:error, "You are not authorized to view that page.")
-    |> redirect(to: "/")
+    |> redirect(to: trip_path(conn, :index))
+  end
+
+  def auth_error(conn, {_failure, _reason}, _opts) do
+    conn
+    |> configure_session(drop: true)
+    |> put_flash(:info, "Please log in.")
+    |> redirect(to: session_path(conn, :new))
   end
 end


### PR DESCRIPTION
Sentry report: https://sentry.io/organizations/mbtace/issues/2930926732/?environment=prod&project=5583106

Guardian 0.14.x had a default set of error handlers it would fall back to if you didn't handle a particular type of error. This is no longer the case in Guardian 1.x due to the error handler API changing to use different clauses of a single callback, instead of multiple callbacks. This means we need to include a fallback clause ourselves.