### PR TITLE
feat(admin): filter inactive users out of reports

### DIFF
--- a/apps/concierge_site/test/web/controllers/admin/queries_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/queries_controller_test.exs
@@ -25,7 +25,7 @@ defmodule ConciergeSite.Admin.QueriesControllerTest do
       resp = conn |> get(admin_queries_path(conn, :show, id)) |> html_response(200)
 
       assert resp =~ label
-      assert resp =~ sql
+      assert resp =~ sql |> String.split("\n") |> hd()
       refute resp =~ "rows returned"
     end
 

--- a/apps/concierge_site/test/web/controllers/session_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/session_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule ConciergeSite.SessionControllerTest do
   @moduledoc false
-  use ConciergeSite.ConnCase, async: true
+  use ConciergeSite.ConnCase
   import AlertProcessor.Factory
   alias AlertProcessor.{Model.User, Model.Trip, Repo}
   alias Hammer
@@ -61,7 +61,7 @@ defmodule ConciergeSite.SessionControllerTest do
   end
 
   test "POST /login rate-limited", %{conn: conn} do
-    on_exit(fn -> Hammer.delete_buckets("127.0.0.1") end)
+    on_exit(fn -> true = :ets.delete_all_objects(:hammer_ets_buckets) end)
     params = %{"user" => %{"email" => "test2@email.com", "password" => "11111111111"}}
 
     [first_attempt, _, _, _, next_to_last_attempt, last_attempt] =


### PR DESCRIPTION
Following a vulnerability scan that created a massive number of fake accounts, complete with fake subscriptions, the numbers in our reports were a bit skewed. We can compensate for this by ignoring accounts where alerts are disabled, which happens when either their email address bounces (which we saw with these accounts, since they made up non-existent addresses) or they opt out via SMS. In cases where this occurs "naturally", it should still be okay to not include those accounts in the reports, since we are primarily interested in subscription stats for users where those subscriptions are actually generating notifications.