### PR TITLE
test: fix intermittent `SendingQueue` failures

### DIFF
--- a/apps/alert_processor/test/alert_processor/dissemination/mass_notifier_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/mass_notifier_test.exs
@@ -1,5 +1,5 @@
 defmodule AlertProcessor.Dissemination.MassNotifierTest do
-  use AlertProcessor.DataCase, async: true
+  use AlertProcessor.DataCase
   import AlertProcessor.Factory
   alias AlertProcessor.Dissemination.MassNotifier
   alias AlertProcessor.{Model.Alert, NotificationBuilder, Repo, SendingQueue}
@@ -14,6 +14,10 @@ defmodule AlertProcessor.Dissemination.MassNotifierTest do
     service_effect: "test",
     last_push_notification: DateTime.utc_now() |> DateTime.truncate(:second)
   }
+
+  setup do
+    SendingQueue.reset()
+  end
 
   describe "save_and_enqueue/1" do
     defp insert_user_and_build_notification(user_attrs \\ %{}) do

--- a/apps/alert_processor/test/alert_processor/reminders/processor/processor_test.exs
+++ b/apps/alert_processor/test/alert_processor/reminders/processor/processor_test.exs
@@ -1,6 +1,6 @@
 defmodule AlertProcessor.Reminders.ProcessorTest do
   @moduledoc false
-  use AlertProcessor.DataCase, async: true
+  use AlertProcessor.DataCase
   import AlertProcessor.Factory
   alias AlertProcessor.Reminders.Processor
   alias AlertProcessor.Model.{Alert, Notification}


### PR DESCRIPTION
The queue is a global resource, so tests that use it cannot be `async`. We also need to make sure we `reset` it before such tests.