### PR TITLE
fix: reversed route icon order in stop selectors

### DIFF
--- a/apps/concierge_site/assets/js/select-stop-choices.js
+++ b/apps/concierge_site/assets/js/select-stop-choices.js
@@ -71,7 +71,9 @@ const getStopChoices = optionEls =>
   }));
 
 const renderIcons = stopId =>
-  stopData[stopId].reduce(
+  // with float-right, the first element in the markup will be the one furthest
+  // to the right, so we need to reverse the icon list to get the correct order
+  stopData[stopId].slice().reverse().reduce(
     (accumulator, iconId) =>
       `${accumulator}${getIcon(iconId)("float-right route__select--icon")}`,
     ""


### PR DESCRIPTION
Changes to attribute ordering due to the Phoenix upgrade in fe6c785c introduced a bug where route icons in stop selectors would display in the opposite of the intended order (see below). Since the reversed ordering is a consequence of using `float: right`, we can un-reverse it in the same place we apply this style.

![Screen Shot 2022-03-10 at 11 55 02 AM](https://user-images.githubusercontent.com/394835/157717708-3ab7a0a9-0b1e-466a-9fb4-15f6c47ae127.png)

