### PR TITLE
ci: use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           key: ${{ secrets.CACHE_UUID }}-node-${{ hashFiles('**/package-lock.json') }}
       - name: JS dependencies
         if: steps.js-deps-cache.outputs.cache-hit != 'true'
-        run: npm install --prefix apps/concierge_site/assets
+        run: npm ci --prefix apps/concierge_site/assets
 
 
   format:


### PR DESCRIPTION
This installs dependencies exactly as specified in the lockfile, and always exits with an error in cases where `npm install` would update `package.json` and/or the lockfile (e.g. if the lockfile did not match the version constraints in `package.json`). Also, it's faster. ⚡️

Previously we didn't use this because our NodeJS version was too old for the included version of NPM to support this command.

Ref: https://docs.npmjs.com/cli/v6/commands/npm-ci

**Note:** [Tested](https://github.com/mbta/alerts_concierge/runs/6083937006?check_suite_focus=true) by temporarily commenting out the cache-hit condition on this step, since otherwise it would have been skipped.