### PR TITLE
ci: use `environment` input in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
         default: "dev"
         description: "Environment"
         required: true
+        type: environment
 
 jobs:
   deploy:


### PR DESCRIPTION
This allows selecting an environment from those defined on the repo, instead of having to type in an environment name. Reference: https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/