### PR TITLE
fix: add overload to catch missing query params

### DIFF
--- a/apps/concierge_site/lib/controllers/email_opened_controller.ex
+++ b/apps/concierge_site/lib/controllers/email_opened_controller.ex
@@ -3,7 +3,10 @@ defmodule ConciergeSite.EmailOpenedController do
   require Logger
 
   def notification(conn, %{"alert_id" => alert_id, "notification_id" => notification_id}) do
-    Logger.info("email_opened alert_id=#{alert_id} notification_id=#{notification_id}")
+    Logger.info(
+      "email_opened=notification alert_id=#{alert_id} notification_id=#{notification_id}"
+    )
+
     conn = put_resp_content_type(conn, "image/gif", nil)
     send_resp(conn, 200, "")
   end

--- a/apps/concierge_site/lib/helpers/mail_helper.ex
+++ b/apps/concierge_site/lib/helpers/mail_helper.ex
@@ -51,11 +51,6 @@ defmodule ConciergeSite.Helpers.MailHelper do
 
   @spec track_open_url(Notification.t()) :: String.t()
   def track_open_url(%Notification{id: notification_id, alert_id: alert_id}) do
-    Helpers.email_opened_url(
-      ConciergeSite.Endpoint,
-      :notification,
-      alert_id: alert_id,
-      notification_id: notification_id
-    )
+    Helpers.email_opened_url(ConciergeSite.Endpoint, :notification, alert_id, notification_id)
   end
 end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -52,7 +52,13 @@ defmodule ConciergeSite.Router do
     get("/login", SessionController, :login_redirect)
     get("/deleted", PageController, :account_deleted)
     get("/feedback", FeedbackController, :feedback)
-    get("/notification_email_opened", EmailOpenedController, :notification)
+
+    get(
+      "/email_opened/notification/:alert_id/:notification_id/img.gif",
+      EmailOpenedController,
+      :notification
+    )
+
     post("/api/feedback", FeedbackController, :new)
     get("/digest/feedback", DigestFeedbackController, :feedback)
     post("/api/digest/feedback", DigestFeedbackController, :new)

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -77,8 +77,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     assert body =~ "feedback?alert_id=123&user_id=456&rating=yes"
     assert body =~ "feedback?alert_id=123&user_id=456&rating=no"
 
-    assert body =~
-             "notification_email_opened?alert_id=123&notification_id=a7722510-6a27-44ee-808e-b242312abb6d"
+    assert body =~ "/email_opened/notification/123/a7722510-6a27-44ee-808e-b242312abb6d/img.gif"
   end
 
   test "html_email/1 includes content for closed alerts" do

--- a/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
+++ b/apps/concierge_site/test/lib/helpers/mail_helper_test.exs
@@ -35,9 +35,7 @@ defmodule ConcerigeSite.Helpers.MailHelperTest do
         })
 
       assert url =~ "http"
-      assert url =~ "notification_email_opened?"
-      assert url =~ "alert_id=foo"
-      assert url =~ "notification_id=bar"
+      assert url =~ "/email_opened/notification/foo/bar/img.gif"
     end
   end
 end

--- a/apps/concierge_site/test/web/controllers/email_opened_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/email_opened_controller_test.exs
@@ -5,10 +5,15 @@ defmodule ConciergeSite.EmailOpenedControllerTest do
   describe "/notification_email_opened" do
     test "returns empty image/gif successfully", %{conn: conn} do
       resp =
-        get(conn, "/notification_email_opened", %{
-          "notification_id" => "test",
-          "alert_id" => "test"
-        })
+        get(
+          conn,
+          ConciergeSite.Router.Helpers.email_opened_path(
+            ConciergeSite.Endpoint,
+            :notification,
+            "alert_id",
+            "notification_id"
+          )
+        )
 
       assert %{status: 200, resp_body: ""} = resp
       assert ["image/gif"] = get_resp_header(resp, "content-type")


### PR DESCRIPTION
Forgot to consider that the endpoint could potentially be hit without the query params set 🥲 

currently this just swallows the request, but do we want to log anything in this case? I think maybe this could have been originally caused by email clients scrubbing out query parameters on images 🤔 could be an interesting stat to track