### PR TITLE
chore: clean up unnecessary email handling code

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_sender.ex
+++ b/apps/alert_processor/lib/dissemination/notification_sender.ex
@@ -27,10 +27,6 @@ defmodule AlertProcessor.Dissemination.NotificationSender do
         log(notification, :email, :error, error)
         {:error, error}
     end
-  rescue
-    error in ArgumentError ->
-      Logger.error("invalid email for #{notification.user_id}")
-      {:error, error}
   end
 
   def send(%Notification{phone_number: phone_number} = notification)

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_sender_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_sender_test.exs
@@ -2,7 +2,6 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
   @moduledoc false
   use ExUnit.Case
 
-  import ExUnit.CaptureLog
   alias AlertProcessor.Dissemination.NotificationSender
   alias AlertProcessor.Model.Notification
 
@@ -20,19 +19,6 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
       notification = %Notification{email: "mailer_error@example.com", header: "This is a test"}
 
       assert {:error, %{message: "error requested"}} = NotificationSender.send(notification)
-    end
-
-    test "catches bad email addresses and logs them (instead of crashing)" do
-      function = fn ->
-        NotificationSender.send(%Notification{
-          email: "bad_email",
-          header: "This is a test",
-          user_id: 1
-        })
-      end
-
-      assert {:error, %{message: "invalid email"}} = function.()
-      assert capture_log(function) =~ "invalid email for 1"
     end
   end
 

--- a/apps/alert_processor/test/support/mocks/mailer_mock.ex
+++ b/apps/alert_processor/test/support/mocks/mailer_mock.ex
@@ -3,7 +3,6 @@ defmodule AlertProcessor.MailerMock do
 
   def deliver_now(email, _options \\ [])
 
-  def deliver_now(%{to: "bad_email"}, _), do: raise(ArgumentError, message: "invalid email")
   def deliver_now(%{to: "mailer_error" <> _}, _), do: {:error, %{message: "error requested"}}
 
   def deliver_now(email, _) do


### PR DESCRIPTION
Following some clean up work done recently, all of our emails should be "valid" now (in the sense that the should at least be well-formed, not necessarily real).

Once this merges in, I'll keep my eye on Sentry for any new errors that pop up
