### PR TITLE
chore: track notification batches

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_sender.ex
+++ b/apps/alert_processor/lib/dissemination/notification_sender.ex
@@ -57,7 +57,8 @@ defmodule AlertProcessor.Dissemination.NotificationSender do
              last_push_notification: alert_updated_at,
              severity: alert_severity,
              tracking_duration_type: alert_duration_type,
-             tracking_fetched_at: alert_fetched_at
+             tracking_fetched_at: alert_fetched_at,
+             tracking_batch_id: batch_id
            }
          },
          communication_mode,
@@ -79,6 +80,7 @@ defmodule AlertProcessor.Dissemination.NotificationSender do
         alert_duration_type: alert_duration_type,
         seconds_processing: DateTime.diff(now, alert_fetched_at, :millisecond) / 1000,
         seconds_since_alert_update: DateTime.diff(now, alert_updated_at),
+        batch_id: batch_id,
         response: inspect(response)
       }
       |> Enum.map_join(" ", fn {key, value} -> "#{key}=#{value}" end)

--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -28,7 +28,8 @@ defmodule AlertProcessor.Model.Alert do
     :closed_timestamp,
     :reminder_times,
     :tracking_duration_type,
-    :tracking_fetched_at
+    :tracking_fetched_at,
+    :tracking_batch_id
   ]
 
   @type informed_entity :: [
@@ -60,7 +61,8 @@ defmodule AlertProcessor.Model.Alert do
           closed_timestamp: DateTime.t() | nil,
           reminder_times: [DateTime.t()] | nil,
           tracking_duration_type: AlertFilters.duration_type() | nil,
-          tracking_fetched_at: DateTime.t() | nil
+          tracking_fetched_at: DateTime.t() | nil,
+          tracking_batch_id: Ecto.UUID.t() | nil
         }
 
   @doc """


### PR DESCRIPTION
We want to track some operational performance metrics in Splunk. One thing that we want to track is the total time taken to send all notifications for an alert. However, since alerts can persist over longer periods of time, tracking just the `alert_id` is insufficient. Thus, with this PR we want to add a concept of a `batch_id`. This will allow us to see how long it takes for us to send all notifications for an alert _in a given batch_ rather than over the entire lifetime of the alert.