### PR TITLE
Add "T-Alerts - " prefix to all SMS messages

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_sender.ex
+++ b/apps/alert_processor/lib/dissemination/notification_sender.ex
@@ -34,12 +34,15 @@ defmodule AlertProcessor.Dissemination.NotificationSender do
     {result, response} =
       notification
       |> sms_message()
+      |> with_t_alerts_prefix()
       |> ExAws.SNS.publish(phone_number: "+1#{phone_number}")
       |> AwsClient.request()
 
     log(notification, :sms, result, response)
     {result, response}
   end
+
+  defp with_t_alerts_prefix(str), do: "T-Alerts - #{str}"
 
   @spec sms_message(Notification.t()) :: String.t()
   defp sms_message(%{type: :all_clear, header: header}), do: "All clear (re: #{header})"

--- a/apps/alert_processor/test/alert_processor/dissemination/notification_sender_test.exs
+++ b/apps/alert_processor/test/alert_processor/dissemination/notification_sender_test.exs
@@ -32,7 +32,8 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
 
       {:ok, _} = NotificationSender.send(notification)
 
-      assert_receive {:publish, %{"Message" => "This is a test", "PhoneNumber" => "+15555551234"}}
+      assert_receive {:publish,
+                      %{"Message" => "T-Alerts - This is a test", "PhoneNumber" => "+15555551234"}}
     end
 
     test "sends SMS and not email when both are possible" do
@@ -58,7 +59,7 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
 
       {:ok, _} = NotificationSender.send(notification)
 
-      assert_receive {:publish, %{"Message" => "All clear (re: This is a test)"}}
+      assert_receive {:publish, %{"Message" => "T-Alerts - All clear (re: This is a test)"}}
     end
 
     test "formats a reminder notification" do
@@ -70,7 +71,7 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
 
       {:ok, _} = NotificationSender.send(notification)
 
-      assert_receive {:publish, %{"Message" => "Reminder: This is a test"}}
+      assert_receive {:publish, %{"Message" => "T-Alerts - Reminder: This is a test"}}
     end
 
     test "formats an update notification" do
@@ -82,7 +83,7 @@ defmodule AlertProcessor.Dissemination.NotificationSenderTest do
 
       {:ok, _} = NotificationSender.send(notification)
 
-      assert_receive {:publish, %{"Message" => "Update: This is a test"}}
+      assert_receive {:publish, %{"Message" => "T-Alerts - Update: This is a test"}}
     end
   end
 end

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -45,10 +45,10 @@ defmodule ConciergeSite.ScheduleTest do
     assert Enum.all?(result[{"cr", "CR-Newburyport"}], &Map.has_key?(&1, :weekend?))
 
     assert List.first(result[{"cr", "CR-Newburyport"}]) == %TripInfo{
-             arrival_time: ~T[07:20:00],
-             departure_time: ~T[06:30:00],
-             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[07:20:00]},
-             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[06:30:00]},
+             arrival_time: ~T[07:26:00],
+             departure_time: ~T[06:35:00],
+             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[07:26:00]},
+             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[06:35:00]},
              destination: {"Manchester", "place-GB-0254", {42.573687, -70.77009}, 1},
              direction_id: 0,
              origin: {"North Station", "place-north", {42.365577, -71.06129}, 1},
@@ -76,7 +76,6 @@ defmodule ConciergeSite.ScheduleTest do
                  {"Salem", "place-ER-0168", {42.524792, -70.895876}, 1},
                  {"Swampscott", "place-ER-0128", {42.473743, -70.922537}, 1},
                  {"Lynn", "place-ER-0115", {42.462953, -70.945421}, 1},
-                 {"Wellington", "place-welln", {42.40237, -71.077082}, 1},
                  {"River Works", "place-ER-0099", {42.449927, -70.969848}, 2},
                  {"Chelsea", "place-chels", {42.397024, -71.041314}, 1},
                  {"North Station", "place-north", {42.365577, -71.06129}, 1}
@@ -84,8 +83,8 @@ defmodule ConciergeSite.ScheduleTest do
                direction_destinations: ["Newburyport or Rockport", "North Station"]
              },
              selected: false,
-             trip_number: "1101",
-             weekend?: true
+             trip_number: "101",
+             weekend?: false
            }
   end
 


### PR DESCRIPTION
This is required to comply with SMS regulations. See https://app.asana.com/0/1113179098808463/1202332063233179/f for more context