### PR TITLE
fix(test): Update tests to work with the current schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ subscribe to notifications for service disruptions.
   - You will need Postgres client tools in your PATH; if using Homebrew and you
     get an error about missing tools, use `brew link postgresql@13`
 - [Google Chrome](https://www.google.com/chrome/)
-- Chromedriver (using Homebrew: `brew cask install chromedriver`)
+- Chromedriver (using Homebrew: `brew install --cask chromedriver`)
 - [`asdf`](https://asdf-vm.com/) with plugins: `elixir`, `erlang`, `nodejs`
 - [`direnv`](https://direnv.net/) _(optional, for auto-loading env vars)_
 
@@ -51,4 +51,5 @@ export of the environment variables into your current shell session.
 We run the app on AWS: see [`docs/aws.md`](docs/aws.md) for deployment guides.
 
 ## Scrubbing the Production Database for Local Usage
+
 See [`scripts/sanitize_db_dump/README.md`](scripts/sanitize_db_dump/README.md)

--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1201,16 +1201,16 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
   # trip for the current day of the week must have schedules present in the API. All trips must
   # depart from Fairmount station outbound and the time must be specified here. These test trips
-  # are active as of 2022-06-13.
+  # are active as of 2022-11-09.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-524779-911"
-                   6 -> "CR-525227-1905"
-                   7 -> "CR-524550-2905"
+                   day when day in 1..5 -> "CR-551379-908"
+                   6 -> "CR-550937-1906"
+                   7 -> "CR-551129-2906"
                  end)
   @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
-                                     day when day in 1..5 -> ~T[08:55:00]
-                                     day when day in 6..7 -> ~T[08:28:00]
+                                     day when day in 1..5 -> ~T[08:04:00]
+                                     day when day in 6..7 -> ~T[09:03:00]
                                    end)
 
   describe "informed_entity's trip matching" do

--- a/apps/concierge_site/test/lib/schedule_test.exs
+++ b/apps/concierge_site/test/lib/schedule_test.exs
@@ -3,8 +3,7 @@ defmodule ConciergeSite.ScheduleTest do
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
   use ExUnit.Case
   alias ConciergeSite.Schedule
-  alias AlertProcessor.ExtendedTime
-  alias AlertProcessor.Model.{Route, Subscription, TripInfo}
+  alias AlertProcessor.Model.{Subscription, TripInfo}
 
   doctest Schedule
 
@@ -43,49 +42,6 @@ defmodule ConciergeSite.ScheduleTest do
     assert is_list(result[{"cr", "CR-Newburyport"}])
     assert Enum.all?(result[{"cr", "CR-Newburyport"}], &is_trip_info(&1))
     assert Enum.all?(result[{"cr", "CR-Newburyport"}], &Map.has_key?(&1, :weekend?))
-
-    assert List.first(result[{"cr", "CR-Newburyport"}]) == %TripInfo{
-             arrival_time: ~T[07:20:00],
-             departure_time: ~T[06:30:00],
-             arrival_extended_time: %ExtendedTime{relative_day: 1, time: ~T[07:20:00]},
-             departure_extended_time: %ExtendedTime{relative_day: 1, time: ~T[06:30:00]},
-             destination: {"Manchester", "place-GB-0254", {42.573687, -70.77009}, 1},
-             direction_id: 0,
-             origin: {"North Station", "place-north", {42.365577, -71.06129}, 1},
-             route: %Route{
-               direction_names: ["Outbound", "Inbound"],
-               headsigns: nil,
-               route_id: "CR-Newburyport",
-               route_type: 2,
-               short_name: "",
-               long_name: "Newburyport/Rockport Line",
-               order: 10,
-               stop_list: [
-                 {"Rockport", "place-GB-0353", {42.655491, -70.627055}, 1},
-                 {"Gloucester", "place-GB-0316", {42.616799, -70.668345}, 1},
-                 {"West Gloucester", "place-GB-0296", {42.611933, -70.705417}, 1},
-                 {"Manchester", "place-GB-0254", {42.573687, -70.77009}, 1},
-                 {"Beverly Farms", "place-GB-0229", {42.561651, -70.811405}, 1},
-                 {"Montserrat", "place-GB-0198", {42.562171, -70.869254}, 1},
-                 {"Newburyport", "place-ER-0362", {42.797837, -70.87797}, 1},
-                 {"Rowley", "place-ER-0312", {42.726845, -70.859034}, 1},
-                 {"Ipswich", "place-ER-0276", {42.676921, -70.840589}, 1},
-                 {"Hamilton/Wenham", "place-ER-0227", {42.609212, -70.874801}, 1},
-                 {"North Beverly", "place-ER-0208", {42.583779, -70.883851}, 1},
-                 {"Beverly", "place-ER-0183", {42.547276, -70.885432}, 1},
-                 {"Salem", "place-ER-0168", {42.524792, -70.895876}, 1},
-                 {"Swampscott", "place-ER-0128", {42.473743, -70.922537}, 1},
-                 {"Lynn", "place-ER-0115", {42.462953, -70.945421}, 1},
-                 {"River Works", "place-ER-0099", {42.449927, -70.969848}, 2},
-                 {"Chelsea", "place-chels", {42.397024, -71.041314}, 1},
-                 {"North Station", "place-north", {42.365577, -71.06129}, 1}
-               ],
-               direction_destinations: ["Newburyport or Rockport", "North Station"]
-             },
-             selected: false,
-             trip_number: "1101",
-             weekend?: true
-           }
   end
 
   test "get_schedules_for_trip/2" do
@@ -152,110 +108,10 @@ defmodule ConciergeSite.ScheduleTest do
     assert is_list(first_trip_result[{"cr", "CR-Worcester"}])
     assert Enum.all?(first_trip_result[{"cr", "CR-Worcester"}], &is_trip_info(&1))
 
-    assert List.first(first_trip_result[{"cr", "CR-Worcester"}]) ==
-             %AlertProcessor.Model.TripInfo{
-               arrival_extended_time: %AlertProcessor.ExtendedTime{
-                 relative_day: 1,
-                 time: ~T[06:15:00]
-               },
-               arrival_time: ~T[06:15:00],
-               departure_extended_time: %AlertProcessor.ExtendedTime{
-                 relative_day: 1,
-                 time: ~T[05:30:00]
-               },
-               departure_time: ~T[05:30:00],
-               destination: {"Worcester", "place-WML-0442", {42.261835, -71.791806}, 1},
-               direction_id: 0,
-               selected: false,
-               trip_number: "501",
-               weekend?: false,
-               origin: {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
-               route: %AlertProcessor.Model.Route{
-                 direction_destinations: ["Worcester", "South Station"],
-                 direction_names: ["Outbound", "Inbound"],
-                 headsigns: nil,
-                 long_name: "Framingham/Worcester Line",
-                 order: 2,
-                 route_id: "CR-Worcester",
-                 route_type: 2,
-                 short_name: "",
-                 stop_list: [
-                   {"Worcester", "place-WML-0442", {42.261835, -71.791806}, 1},
-                   {"Grafton", "place-WML-0364", {42.2466, -71.685325}, 1},
-                   {"Westborough", "place-WML-0340", {42.269644, -71.647076}, 1},
-                   {"Southborough", "place-WML-0274", {42.267024, -71.524371}, 1},
-                   {"Ashland", "place-WML-0252", {42.26149, -71.482161}, 1},
-                   {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
-                   {"West Natick", "place-WML-0199", {42.283064, -71.391797}, 1},
-                   {"Natick Center", "place-WML-0177", {42.285719, -71.347133}, 2},
-                   {"Wellesley Square", "place-WML-0147", {42.297526, -71.294173}, 2},
-                   {"Wellesley Hills", "place-WML-0135", {42.31037, -71.277044}, 2},
-                   {"Wellesley Farms", "place-WML-0125", {42.323608, -71.272288}, 2},
-                   {"Auburndale", "place-WML-0102", {42.345833, -71.250373}, 2},
-                   {"West Newton", "place-WML-0091", {42.347878, -71.230528}, 2},
-                   {"Newtonville", "place-WML-0081", {42.351702, -71.205408}, 2},
-                   {"Boston Landing", "place-WML-0035", {42.357293, -71.139883}, 1},
-                   {"Lansdowne", "place-WML-0025", {42.347581, -71.099974}, 1},
-                   {"Back Bay", "place-bbsta", {42.34735, -71.075727}, 1},
-                   {"South Station", "place-sstat", {42.352271, -71.055242}, 1}
-                 ]
-               }
-             }
-
     assert is_map(return_trip_result)
     assert Map.keys(return_trip_result) == [{"cr", "CR-Worcester"}]
     assert is_list(return_trip_result[{"cr", "CR-Worcester"}])
     assert Enum.all?(return_trip_result[{"cr", "CR-Worcester"}], &is_trip_info(&1))
-
-    assert List.first(return_trip_result[{"cr", "CR-Worcester"}]) ==
-             %AlertProcessor.Model.TripInfo{
-               arrival_extended_time: %AlertProcessor.ExtendedTime{
-                 relative_day: 1,
-                 time: ~T[04:55:00]
-               },
-               arrival_time: ~T[04:55:00],
-               departure_extended_time: %AlertProcessor.ExtendedTime{
-                 relative_day: 1,
-                 time: ~T[04:15:00]
-               },
-               departure_time: ~T[04:15:00],
-               direction_id: 1,
-               origin: {"Worcester", "place-WML-0442", {42.261835, -71.791806}, 1},
-               selected: false,
-               trip_number: "500",
-               weekend?: false,
-               destination: {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
-               route: %AlertProcessor.Model.Route{
-                 direction_destinations: ["Worcester", "South Station"],
-                 direction_names: ["Outbound", "Inbound"],
-                 headsigns: nil,
-                 long_name: "Framingham/Worcester Line",
-                 order: 2,
-                 route_id: "CR-Worcester",
-                 route_type: 2,
-                 short_name: "",
-                 stop_list: [
-                   {"Worcester", "place-WML-0442", {42.261835, -71.791806}, 1},
-                   {"Grafton", "place-WML-0364", {42.2466, -71.685325}, 1},
-                   {"Westborough", "place-WML-0340", {42.269644, -71.647076}, 1},
-                   {"Southborough", "place-WML-0274", {42.267024, -71.524371}, 1},
-                   {"Ashland", "place-WML-0252", {42.26149, -71.482161}, 1},
-                   {"Framingham", "place-WML-0214", {42.276108, -71.420055}, 1},
-                   {"West Natick", "place-WML-0199", {42.283064, -71.391797}, 1},
-                   {"Natick Center", "place-WML-0177", {42.285719, -71.347133}, 2},
-                   {"Wellesley Square", "place-WML-0147", {42.297526, -71.294173}, 2},
-                   {"Wellesley Hills", "place-WML-0135", {42.31037, -71.277044}, 2},
-                   {"Wellesley Farms", "place-WML-0125", {42.323608, -71.272288}, 2},
-                   {"Auburndale", "place-WML-0102", {42.345833, -71.250373}, 2},
-                   {"West Newton", "place-WML-0091", {42.347878, -71.230528}, 2},
-                   {"Newtonville", "place-WML-0081", {42.351702, -71.205408}, 2},
-                   {"Boston Landing", "place-WML-0035", {42.357293, -71.139883}, 1},
-                   {"Lansdowne", "place-WML-0025", {42.347581, -71.099974}, 1},
-                   {"Back Bay", "place-bbsta", {42.34735, -71.075727}, 1},
-                   {"South Station", "place-sstat", {42.352271, -71.055242}, 1}
-                 ]
-               }
-             }
   end
 
   defp is_trip_info(%TripInfo{}), do: true


### PR DESCRIPTION
No ticket, some of the tests are just tied to schedule data so need to be updated periodically when the rating changes and they fail. (Side note, there's a [ticket](https://app.asana.com/0/1167196461144361/1199513856779936) in the backlog to improve this situation).

- docs: Update the chromedriver installation command

- fix(test): Remove schedule-specific test conditions
These conditions would break when the schedule changed, and don't add
anything meaningful to the tests.

- fix(test): Update test data to use current schedule
Background: These tests use a set of specific trip IDs. At the time the
tests are run, the trip for the current day of the week must have
schedules present in the API.

[Passing test run](https://github.com/mbta/alerts_concierge/actions/runs/3431182352)