### PR TITLE
deps: Update patch-level versions of Erlang & Elixir

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.13.3-otp-24
-erlang 24.3.4.5
+elixir 1.13.4-otp-24
+erlang 24.3.4.6
 nodejs 14.21.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Set up Elixir build ---
-FROM hexpm/elixir:1.13.3-erlang-24.3.4.5-debian-bullseye-20220801-slim as elixir-builder
+FROM hexpm/elixir:1.13.4-erlang-24.3.4.6-debian-bullseye-20220801-slim as elixir-builder
 
 ENV LANG=C.UTF-8 MIX_ENV=prod
 


### PR DESCRIPTION
No ticket

- erlang from 24.3.4.5 to 24.3.4.6
- elixir from 1.13.3 to 1.13.4

[Successful build and deploy](https://github.com/mbta/alerts_concierge/actions/runs/3464596137/jobs/5786307545)