### PR TITLE
deps: Configure Dependabot to keep dependencies up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "09:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
+  - package-ecosystem: npm
+    directory: "/apps/concierge_site/assets"
+    schedule:
+      interval: daily
+      time: "09:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Asana ticket: [Configure Dependabot to keep dependencies up-to-date automatically](https://app.asana.com/0/1167196461144361/1203413849690490)

Maintain both mix and npm dependencies. Follow the version upgrade rules in the respective lockfiles.