### PR TITLE
deps: Update node to the latest LTS version 18.12.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.13.4-otp-24
 erlang 24.3.4.6
-nodejs 14.21.1
+nodejs 18.12.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix deps.get --only prod
 
 
 # --- Build frontend assets ---
-FROM node:14.21.1-bullseye-slim as asset-builder
+FROM node:18.12.1-bullseye-slim as asset-builder
 
 RUN apt-get update --allow-releaseinfo-change
 RUN apt-get install --no-install-recommends --yes ca-certificates git

--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -37,7 +37,7 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "1.6.6",
+      "version": "1.6.15",
       "license": "MIT"
     },
     "../../../deps/phoenix_html": {


### PR DESCRIPTION
No ticket

Also sneaking in:
fix: Update phoenix version in lockfile

[Successful build and deploy](https://github.com/mbta/alerts_concierge/actions/runs/3525266952/jobs/5911771651)