### PR TITLE
refactor: Delete unused `pause_count` function

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -441,17 +441,6 @@ defmodule AlertProcessor.Model.Subscription do
     |> Repo.preload(:user)
   end
 
-  @spec paused_count() :: number
-  def paused_count do
-    Repo.one(
-      from(
-        s in __MODULE__,
-        where: s.paused == true,
-        select: count(s.id)
-      )
-    )
-  end
-
   defp subscribers_match_query(
          route_ids: _,
          routes: _,

--- a/apps/alert_processor/test/alert_processor/model/subscription_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/subscription_test.exs
@@ -660,15 +660,6 @@ defmodule AlertProcessor.Model.SubscriptionTest do
     end
   end
 
-  test "paused_count returns the number of paused subscriptions" do
-    user = insert(:user)
-    insert(:subscription, user: user, route: "Red", paused: true)
-    insert(:subscription, user: user, route: "Orange")
-    insert(:subscription, user: user, route: "Blue", paused: true)
-
-    assert Subscription.paused_count() == 2
-  end
-
   defp map_subscription(%{"routes" => routes} = params) do
     params = Map.delete(params, "routes")
 


### PR DESCRIPTION
No ticket, came across this orphan code while working in the file.