### PR TITLE
fix: Break apart database query with many ors

### DIFF
--- a/apps/alert_processor/lib/model/subscription.ex
+++ b/apps/alert_processor/lib/model/subscription.ex
@@ -501,29 +501,6 @@ defmodule AlertProcessor.Model.Subscription do
     |> Repo.preload(:user)
   end
 
-  # defp subscribers_match_query(
-  #        route_ids: _,
-  #        routes: _,
-  #        stops: _,
-  #        wildcard: true
-  #      ),
-  #      do: from(s in __MODULE__)
-
-  # defp subscribers_match_query(
-  #        route_ids: route_ids,
-  #        routes: routes,
-  #        stops: stops,
-  #        wildcard: false
-  #      ) do
-  #   # group (route_type ANY(..) OR route ANY(..) OR origin ANY(..) OR destination ANY (...)) together
-  #   from(
-  #     s in __MODULE__,
-  #     where:
-  #       s.is_admin == true or s.route_type in ^route_ids or s.route in ^routes or
-  #         s.origin in ^stops or s.destination in ^stops
-  #   )
-  # end
-
   defp where_subscription_not_paused(query), do: from(s in query, where: s.paused == false)
 
   defp where_not_yet_notified(query, %Alert{id: alert_id}),


### PR DESCRIPTION
Allow the pieces to use indexes. The old query had to run a sequential scan.

Even if the cumulative time doesn't decrease drastically, hopefully individual queries will be much shorter than the timeout we are currently sometimes seeing.


Before:

```
explain SELECT s0."id", s0."user_id", s0."trip_id", s0."relevant_days", s0."start_time", s0."end_time", s0."travel_start_time", s0."travel_end_time", s0."origin", s0."destination", s0."type", s0."route", s0."route_type", s0."direction_id", s0."origin_lat", s0."origin_long", s0."destination_lat", s0."destination_long", s0."rank", s0."return_trip", s0."facility_types", s0."paused", s0."parent_id", s0."is_admin", s0."inserted_at", s0."updated_at" FROM "subscriptions" AS s0 WHERE ( ( ( ( ( s0."is_admin" = true ) OR s0."route_type" = ANY ( '{0, 1, 2, 3, 4}' ) ) OR s0."route" = ANY ( '{Red}' ) ) OR s0."origin" = ANY ( '{}' ) ) OR s0."destination" = ANY ( '{}' ) ) AND ( s0."paused" = false ) AND ( NOT ( s0."user_id" = ANY ((SELECT DISTINCT ON (n.user_id) n.user_id FROM notifications AS n WHERE  n.alert_id = '133483' AND n.status = 'sent')) ) );
                                                                                                                       QUERY PLAN                                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Seq Scan on subscriptions s0  (cost=400.24..14755.30 rows=114671 width=299)
   Filter: ((NOT paused) AND (NOT (hashed SubPlan 1)) AND (is_admin OR (route_type = ANY ('{0,1,2,3,4}'::integer[])) OR ((route)::text = ANY ('{Red}'::text[])) OR ((origin)::text = ANY ('{}'::text[])) OR ((destination)::text = ANY ('{}'::text[]))))
   SubPlan 1
     ->  Unique  (cost=378.97..393.34 rows=2758 width=16)
           ->  Sort  (cost=378.97..386.16 rows=2874 width=16)
                 Sort Key: n.user_id
                 ->  Index Scan using notifications_alert_id_index on notifications n  (cost=0.56..213.88 rows=2874 width=16)
                       Index Cond: ((alert_id)::text = '133483'::text)
                       Filter: ((status)::text = 'sent'::text)
```

After:

```
explain SELECT s0."id", s0."user_id", s0."trip_id", s0."relevant_days", s0."start_time", s0."end_time", s0."travel_start_time", s0."travel_end_time", s0."origin", s0."destination", s0."type", s0."route", s0."route_type", s0."direction_id", s0."origin_lat", s0."origin_long", s0."destination_lat", s0."destination_long", s0."rank", s0."return_trip", s0."facility_types", s0."paused", s0."parent_id", s0."is_admin", s0."inserted_at", s0."updated_at" FROM "subscriptions" AS s0 WHERE (s0."route" = ANY(array['Red'])) AND (s0."paused" = FALSE) AND (NOT (s0."user_id" = ANY((select distinct on (n.user_id) n.user_id from notifications as n where n.alert_id = '133483' and n.status = 'sent'))));
                                                          QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on subscriptions s0  (cost=863.79..10877.05 rows=20664 width=299)
   Recheck Cond: (((route)::text = ANY ('{Red}'::text[])) AND (NOT paused))
   Filter: (NOT (hashed SubPlan 1))
   ->  Bitmap Index Scan on subscriptions_route_ix  (cost=0.00..458.38 rows=41328 width=0)
         Index Cond: ((route)::text = ANY ('{Red}'::text[]))
   SubPlan 1
     ->  Unique  (cost=378.97..393.34 rows=2758 width=16)
           ->  Sort  (cost=378.97..386.16 rows=2874 width=16)
                 Sort Key: n.user_id
                 ->  Index Scan using notifications_alert_id_index on notifications n  (cost=0.56..213.88 rows=2874 width=16)
                       Index Cond: ((alert_id)::text = '133483'::text)
                       Filter: ((status)::text = 'sent'::text)
```