### PR TITLE
feat: Script to dump the DB, sanitize, and upload to S3

### DIFF
--- a/scripts/db_dump_sanitize.sh
+++ b/scripts/db_dump_sanitize.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Run like PGHOST=ACTUAL_HOST PGPASSWORD=ACTUAL_PASSWORD BUCKET==ACTUAL_BUCKET ./scripts/db_dump_sanitize.sh
+
+timestamp=$(TZ=UTC date +%Y-%m-%dT%H_%M_%SZ)
+
+# Skipping the table:
+# - guardian_tokens
+# - metadata
+# - password_resets
+# - versions
+pg_dump \
+--port=5432 \
+--username=alerts_concierge \
+--dbname=alerts_concierge_prod \
+--table=alerts \
+--table=informed_entities \
+--table=notification_subscriptions \
+--table=notifications \
+--table=schema_migrations \
+--table=subscriptions \
+--table=trips \
+--table=users \
+--no-owner \
+--data-only \
+| elixir ./scripts/sanitize_db_dump.exs \
+| gzip \
+| aws s3 cp - s3://${BUCKET}/alerts-concierge/prod-db-scrubbed-${timestamp}.sql.gz


### PR DESCRIPTION
Asana ticket: [Set up reusable pipeline](https://app.asana.com/0/1167196461144361/1203573682044259)

This script makes it easier to run the existing sanitize script we had, and codifies dumping the DB and writing to S3. This is intended to be run in the `app-alerts-concierge-etl` instance, introduced in https://github.com/mbta/devops/pull/754.