### PR TITLE
build(deps): Collected npm updates

### DIFF
--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -2577,9 +2577,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -7352,9 +7352,9 @@
       }
     },
     "core-js": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w=="
     },
     "core-js-compat": {
       "version": "3.26.1",

--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -3619,9 +3619,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -8094,9 +8094,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -2626,13 +2626,13 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.2.tgz",
-      "integrity": "sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
+      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.19",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
@@ -7384,13 +7384,13 @@
       "requires": {}
     },
     "css-loader": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.2.tgz",
-      "integrity": "sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
+      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
       "dev": true,
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.19",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",

--- a/apps/concierge_site/assets/package-lock.json
+++ b/apps/concierge_site/assets/package-lock.json
@@ -4776,9 +4776,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
-      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.0.tgz",
+      "integrity": "sha512-PiMJcP33DdKtZ/1jSjjqVIKihoDc6yWmYr9K/4r3fVVIEDAluD0q7XZiRKrNJcPK3qkLRF/79DND1H5q1LBjgg==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -8882,9 +8882,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
-      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.0.tgz",
+      "integrity": "sha512-PiMJcP33DdKtZ/1jSjjqVIKihoDc6yWmYr9K/4r3fVVIEDAluD0q7XZiRKrNJcPK3qkLRF/79DND1H5q1LBjgg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",


### PR DESCRIPTION
- build(deps-dev): bump css-loader from 6.7.2 to 6.7.3 in /apps/concierge_site/assets #1266 
- build(deps): bump jquery from 3.6.1 to 3.6.3 in /apps/concierge_site/assets #1269
- build(deps): bump core-js from 3.26.1 to 3.27.2 in /apps/concierge_site/assets #1277
- build(deps-dev): bump sass from 1.56.1 to 1.58.0 in /apps/concierge_site/assets #1280