### PR TITLE
feat: Use the built-in UUI generate function

### DIFF
--- a/apps/alert_processor/priv/repo/migrations/20170601111510_add_uuid_extension.exs
+++ b/apps/alert_processor/priv/repo/migrations/20170601111510_add_uuid_extension.exs
@@ -2,21 +2,20 @@ defmodule AlertProcessor.Repo.Migrations.AddUuidExtension do
   use Ecto.Migration
 
   def up do
-    execute "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;"
     alter table(:users) do
-      modify :id, :uuid, default: fragment("uuid_generate_v4()")
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
       modify :inserted_at, :utc_datetime, default: fragment("now()")
       modify :updated_at, :utc_datetime, default: fragment("now()")
     end
 
     alter table(:subscriptions) do
-      modify :id, :uuid, default: fragment("uuid_generate_v4()")
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
       modify :inserted_at, :utc_datetime, default: fragment("now()")
       modify :updated_at, :utc_datetime, default: fragment("now()")
     end
 
     alter table(:informed_entities) do
-      modify :id, :uuid, default: fragment("uuid_generate_v4()")
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
       modify :inserted_at, :utc_datetime, default: fragment("now()")
       modify :updated_at, :utc_datetime, default: fragment("now()")
     end
@@ -40,6 +39,5 @@ defmodule AlertProcessor.Repo.Migrations.AddUuidExtension do
       modify :inserted_at, :utc_datetime, default: nil
       modify :updated_at, :utc_datetime, default: nil
     end
-    execute "DROP EXTENSION \"uuid-ossp\";"
   end
 end

--- a/apps/alert_processor/priv/repo/migrations/20170711152200_add_password_resets_table.exs
+++ b/apps/alert_processor/priv/repo/migrations/20170711152200_add_password_resets_table.exs
@@ -3,7 +3,7 @@ defmodule MbtaServer.Repo.Migrations.AddPasswordResetsTable do
 
   def change do
     create table(:password_resets, primary_key: false) do
-      add :id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()")
+      add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
       add :user_id, references(:users, type: :uuid, on_delete: :delete_all)
       add :expired_at, :utc_datetime
       add :redeemed_at, :utc_datetime

--- a/apps/alert_processor/priv/repo/migrations/20180220221033_trips.exs
+++ b/apps/alert_processor/priv/repo/migrations/20180220221033_trips.exs
@@ -3,7 +3,7 @@ defmodule AlertProcessor.Repo.Migrations.Trips do
 
   def change do
     create table(:trips, primary_key: false) do
-      add :id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()")
+      add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
       add :user_id, references(:users, type: :uuid), null: false
       add :alert_priority_type, :string, null: false
       add :relevant_days, {:array, :string}, null: false, default: []

--- a/apps/alert_processor/priv/repo/migrations/20200430210043_add_user_id_index_to_notifications.exs
+++ b/apps/alert_processor/priv/repo/migrations/20200430210043_add_user_id_index_to_notifications.exs
@@ -1,6 +1,7 @@
 defmodule AlertProcessor.Repo.Migrations.AddUserIdIndexToNotifications do
   use Ecto.Migration
   @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def change do
     create index(:notifications, [:user_id], concurrently: true)

--- a/apps/alert_processor/priv/repo/migrations/20230208195021_drop_uuid_ossp_extension.exs
+++ b/apps/alert_processor/priv/repo/migrations/20230208195021_drop_uuid_ossp_extension.exs
@@ -1,0 +1,25 @@
+defmodule AlertProcessor.Repo.Migrations.DropUuidOsspExtension do
+  use Ecto.Migration
+
+  def up do
+    # Use the built-in function for generating UUIDs instead of the version from the uuid-ossp extension. Previously, earlier migrations used the function `uuid_generate_v4`. Those migrations have now been changed in code so databases migrated from scratch will reference that function, but this migration will update existing database schemas.
+    alter table(:users) do
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
+    end
+    alter table(:subscriptions) do
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
+    end
+    alter table(:informed_entities) do
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
+    end
+    alter table(:password_resets, primary_key: false) do
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
+    end
+    alter table(:trips, primary_key: false) do
+      modify :id, :uuid, default: fragment("gen_random_uuid()")
+    end
+
+    # The uuid-ossp extension used to be required for generating UUIDs, but now the `gen_random_uuid` function is built in to Postgres starting with version 13 so we no longer need this extension.
+    execute "DROP EXTENSION IF EXISTS \"uuid-ossp\";"
+  end
+end

--- a/apps/alert_processor/priv/repo/structure.sql
+++ b/apps/alert_processor/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.6
--- Dumped by pg_dump version 13.6
+-- Dumped from database version 14.6 (Homebrew)
+-- Dumped by pg_dump version 14.6 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -15,20 +15,6 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
-
-
---
--- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
-
 
 SET default_tablespace = '';
 
@@ -71,7 +57,7 @@ CREATE TABLE public.guardian_tokens (
 --
 
 CREATE TABLE public.informed_entities (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     subscription_id uuid,
     direction_id integer,
     facility_type character varying(255),
@@ -159,7 +145,7 @@ CREATE TABLE public.notifications (
 --
 
 CREATE TABLE public.password_resets (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid,
     expired_at timestamp without time zone,
     redeemed_at timestamp without time zone,
@@ -183,7 +169,7 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.subscriptions (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid,
     inserted_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
@@ -217,7 +203,7 @@ CREATE TABLE public.subscriptions (
 --
 
 CREATE TABLE public.trips (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,
     relevant_days character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
     start_time time without time zone NOT NULL,
@@ -237,7 +223,7 @@ CREATE TABLE public.trips (
 --
 
 CREATE TABLE public.users (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     email character varying(255) NOT NULL,
     phone_number character varying(255),
     inserted_at timestamp without time zone DEFAULT now() NOT NULL,
@@ -644,3 +630,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20190610143559);
 INSERT INTO public."schema_migrations" (version) VALUES (20200430210043);
 INSERT INTO public."schema_migrations" (version) VALUES (20210421143058);
 INSERT INTO public."schema_migrations" (version) VALUES (20210528144213);
+INSERT INTO public."schema_migrations" (version) VALUES (20230208195021);

--- a/apps/concierge_site/test/web/controllers/trip_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/trip_controller_test.exs
@@ -340,8 +340,7 @@ defmodule ConciergeSite.TripControllerTest do
         return_start_time: %{"am_pm" => "PM", "hour" => "5", "minute" => "00"},
         round_trip: "true",
         start_time: %{"am_pm" => "AM", "hour" => "8", "minute" => "00"},
-        alternate_routes:
-          "%7B%22741%20-%201%22:[%22710%20-%201~~Route%20CT1~~bus%22,%22747%20-%201~~Route%20CT2~~bus%22]%7D"
+        alternate_routes: "%7B%22741%20-%201%22:[%22747%20-%201~~Route%20CT2~~bus%22]%7D"
       }
 
       conn =
@@ -356,7 +355,6 @@ defmodule ConciergeSite.TripControllerTest do
       assert html_response(conn, 200) =~
                "<span class=\"trip__card--route\">Silver Line SL1</span>"
 
-      assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">Route 710</span>"
       assert html_response(conn, 200) =~ "<span class=\"trip__card--route\">Route CT2</span>"
     end
 


### PR DESCRIPTION
Part of getting [Set up a production-like environment to support load testing](https://app.asana.com/0/1167196461144361/1203535165046759) working.

The `gen_random_uuid` function is provided by Postgres starting in
version 13.

Remove the uuid-ossp extension that is no longer needed.

Also:
fix: Disable migration lock on concurrent migration
This was raised as necessary in the logs while running a migration.