### PR TITLE
fix (test): Restore ferry stops to expected data

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -231,7 +231,10 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                route_id: "Boat-EastBoston",
                route_type: 4,
                short_name: "",
-               stop_list: []
+               stop_list: [
+                 {"Lewis Wharf", "Boat-Lewis", {42.365867, -71.041958}, 1},
+                 {"Long Wharf (North)", "Boat-Long", {42.360795, -71.049976}, 1}
+               ]
              }
            ] = route_info
   end


### PR DESCRIPTION
No Asana task, fixes a test that started failing today.

Reverts part of the test expectation changes from https://github.com/mbta/alerts_concierge/pull/1295 now that our GTFS file has been updated.