### PR TITLE
ci: Create pull request attachments on Asana tasks

### DIFF
--- a/.github/workflows/create-asana-attachment.yaml
+++ b/.github/workflows/create-asana-attachment.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name: Create pull request attachments on Asana tasks
+    steps:
+      - name: Create pull request attachments
+        uses: Asana/create-app-attachment-github-action@latest
+        id: postAttachment
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+      - name: Log output status
+        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"


### PR DESCRIPTION
No Asana ticket, ironically.

I've already set the `ASANA_SECRET` repository secret.