### PR TITLE
fix (ci): Name the Asana attachment workflow

### DIFF
--- a/.github/workflows/create-asana-attachment.yaml
+++ b/.github/workflows/create-asana-attachment.yaml
@@ -1,3 +1,5 @@
+name: Create Asana Attachment
+
 on:
   pull_request:
     types: [opened, reopened]


### PR DESCRIPTION
No ticket, just noticed this in the GitHub UI.