### PR TITLE
Makes bus route input same as other methods

### DIFF
--- a/apps/concierge_site/lib/views/route_select_helper_choicesjs.ex
+++ b/apps/concierge_site/lib/views/route_select_helper_choicesjs.ex
@@ -28,7 +28,7 @@ defmodule ConciergeSite.RouteSelectHelperChoicesJS do
       end,
       content_tag :div, data: [type: "mode-select", id: "bus"], class: "d-none" do
         content_tag :select,
-                    attributes(input_name, field, :bus, attrs ++ [multiple: true], false) do
+                    attributes(input_name, field, :bus, attrs, false) do
           options(:bus, selected)
         end
       end


### PR DESCRIPTION
This ended up being a very simple change.

![Screenshot 2023-06-12 at 2 29 49 PM](https://github.com/mbta/alerts_concierge/assets/17047573/a6d602ac-5949-43ab-b2fc-c8d2e895aced)

Card: https://app.asana.com/0/1167196461144361/1204795620691106/f