### PR TITLE
feat: Store the ID token and use it to log the user out

### DIFF
--- a/apps/concierge_site/lib/controllers/auth_controller.ex
+++ b/apps/concierge_site/lib/controllers/auth_controller.ex
@@ -26,7 +26,12 @@ defmodule ConciergeSite.AuthController do
                   other: %{
                     user_info: %{"mbta_uuid" => id, "email" => email} = user_info
                   }
-                } = credentials
+                } = credentials,
+              extra: %{
+                raw_info: %{
+                  tokens: %{"id_token" => id_token}
+                }
+              }
             }
           }
         } = conn,
@@ -44,7 +49,7 @@ defmodule ConciergeSite.AuthController do
       |> get_or_create_user(email, phone_number, role)
       |> use_props_from_token(email, phone_number, role)
 
-    SessionHelper.sign_in(conn, user)
+    SessionHelper.sign_in(conn, user, %{id_token: id_token})
   end
 
   def callback(%{assigns: %{ueberauth_failure: failure}} = conn, _params) do

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -64,13 +64,15 @@ defmodule ConciergeSite.Router do
     post("/api/feedback", FeedbackController, :new)
     get("/digest/feedback", DigestFeedbackController, :feedback)
     post("/api/digest/feedback", DigestFeedbackController, :new)
-    resources("/login", SessionController, only: [:new, :create, :delete], singleton: true)
+    resources("/login", SessionController, only: [:new, :create], singleton: true)
     resources("/account", AccountController, only: [:new, :create])
     resources("/password_resets", PasswordResetController, only: [:new, :create, :edit, :update])
   end
 
   scope "/", ConciergeSite do
     pipe_through([:redirect_prod_http, :browser, :browser_auth, :layout])
+
+    resources("/login", SessionController, only: [:delete], singleton: true)
 
     get("/account/options", AccountController, :options_new)
     post("/account/options", AccountController, :options_create)

--- a/apps/concierge_site/lib/templates/account/edit_keycloak.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit_keycloak.html.eex
@@ -75,9 +75,7 @@
           <h2 style="font-size: 1.25rem;">Your MBTA Account</h2>
           <ul>
             <li class="mb-2">
-              <a href="https://login-sandbox.mbtace.com/auth/realms/MBTA/protocol/openid-connect/auth?client_id=t-alerts&amp;kc_action=MBTA_UPDATE_PROFILE&amp;response_type=code&amp;redirect_uri=https://alerts-concierge-dev.mbtace.com/account/edit">
-                Update your email address
-              </a>
+              <%= link to: update_profile_url(@conn) do %>Update your email address<% end %>
               <span>
               (currently <%= email(@current_user) %>)
               </span>

--- a/apps/concierge_site/test/web/controllers/auth_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/auth_controller_test.exs
@@ -163,6 +163,11 @@ defmodule ConciergeSite.Web.AuthControllerTest do
             "preferred_username" => email
           }
         }
+      },
+      extra: %{
+        raw_info: %{
+          tokens: %{"id_token" => "FAKE ID TOKEN"}
+        }
       }
     }
   end


### PR DESCRIPTION
Asana ticket: [Update T-Alerts Logout Configuration](https://app.asana.com/0/1204819229687089/1204927567478482)

This logout URL is the new structure for Keycloak version 19.

fix: Retrieve the auth session before logging out
The user is actually logged in for this session action, so we want to
retrieve the auth credentials so that we can properly log the user out.

@ErinLMoore Note: this is just merging into the open branch for https://github.com/mbta/alerts_concierge/pull/1309, but I thought it would be useful to get a quick check from you anyway.