### PR TITLE
fix: Always show "Your MBTA Account" in settings

### DIFF
--- a/apps/concierge_site/assets/js/radio-toggle.js
+++ b/apps/concierge_site/assets/js/radio-toggle.js
@@ -88,10 +88,8 @@ function toggleEvents($) {
       case "user[sms_toggle]":
         const $phoneContainerEl = $("div[data-phone='input']");
         const $communicationModelEl = $("#user_communication_mode");
-        const $myAccountEl = $("#your_account");
         if (inputValue == "true" && !$labelEl.hasClass("disabled")) {
           $phoneContainerEl.removeClass("d-none");
-          $myAccountEl.addClass("d-none");
           $communicationModelEl.val("sms");
           setTimeout(() => {
             $phoneContainerEl.find("input").focus();
@@ -99,7 +97,6 @@ function toggleEvents($) {
         } else {
           $communicationModelEl.val("email");
           $phoneContainerEl.addClass("d-none");
-          $myAccountEl.removeClass("d-none");
         }
         break;
 

--- a/apps/concierge_site/lib/templates/account/edit_keycloak.html.eex
+++ b/apps/concierge_site/lib/templates/account/edit_keycloak.html.eex
@@ -71,7 +71,7 @@
         </div>
       <% end %>
       <div class="my-5 min-h-[16rem]">
-        <div id="your_account" class="<%= if communication_mode == "sms", do: "d-none" %>">
+        <div id="your_account">
           <h2 style="font-size: 1.25rem;">Your MBTA Account</h2>
           <ul>
             <li class="mb-2">


### PR DESCRIPTION
Asana ticket: [MBTA account links disappear when "Text me" is selected](https://app.asana.com/0/1204819229687089/1205257335187901/f)

Note that this is merging into the `mss-keycloak` branch.

Available for testing on [dev](https://alerts-concierge-dev.mbtace.com/account/edit).