### PR TITLE
Adds image and alt text to emails

### DIFF
--- a/apps/alert_processor/lib/model/alert.ex
+++ b/apps/alert_processor/lib/model/alert.ex
@@ -29,7 +29,9 @@ defmodule AlertProcessor.Model.Alert do
     :reminder_times,
     :tracking_duration_type,
     :tracking_fetched_at,
-    :tracking_batch_id
+    :tracking_batch_id,
+    :image_url,
+    :image_alternative_text
   ]
 
   @type informed_entity :: [
@@ -62,7 +64,9 @@ defmodule AlertProcessor.Model.Alert do
           reminder_times: [DateTime.t()] | nil,
           tracking_duration_type: AlertFilters.duration_type() | nil,
           tracking_fetched_at: DateTime.t() | nil,
-          tracking_batch_id: Ecto.UUID.t() | nil
+          tracking_batch_id: Ecto.UUID.t() | nil,
+          image_url: String.t() | nil,
+          image_alternative_text: String.t() | nil
         }
 
   @doc """

--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -24,7 +24,9 @@ defmodule AlertProcessor.Model.Notification do
           last_push_notification: DateTime.t() | nil,
           alert: Alert.t() | nil,
           closed_timestamp: DateTime.t() | nil,
-          type: notification_type | nil
+          type: notification_type | nil,
+          image_url: String.t() | nil,
+          image_alternative_text: String.t() | nil
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -47,6 +49,8 @@ defmodule AlertProcessor.Model.Notification do
     field(:alert, :string, virtual: true)
     field(:closed_timestamp, :utc_datetime)
     field(:type, AlertProcessor.AtomType)
+    field(:image_url, :string)
+    field(:image_alternative_text, :string)
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/alert_processor/lib/rules_engine/notification_builder.ex
+++ b/apps/alert_processor/lib/rules_engine/notification_builder.ex
@@ -28,7 +28,9 @@ defmodule AlertProcessor.NotificationBuilder do
           &%AlertProcessor.Model.NotificationSubscription{subscription_id: &1.id}
         ),
       closed_timestamp: alert.closed_timestamp,
-      type: List.first(subscriptions).notification_type_to_send || :initial
+      type: List.first(subscriptions).notification_type_to_send || :initial,
+      image_url: alert.image_url,
+      image_alternative_text: alert.image_alternative_text
     }
   end
 

--- a/apps/alert_processor/priv/repo/migrations/20230830193726_add_images_to_alerts_and_notifications.exs
+++ b/apps/alert_processor/priv/repo/migrations/20230830193726_add_images_to_alerts_and_notifications.exs
@@ -1,0 +1,14 @@
+defmodule AlertProcessor.Repo.Migrations.AddImagesToAlerts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:alerts) do
+      add(:image_url, :string)
+      add(:image_alternative_text, :string)
+    end
+    alter table(:notifications) do
+      add(:image_url, :string)
+      add(:image_alternative_text, :string)
+    end
+  end
+end

--- a/apps/alert_processor/priv/repo/structure.sql
+++ b/apps/alert_processor/priv/repo/structure.sql
@@ -30,7 +30,9 @@ CREATE TABLE public.alerts (
     last_modified timestamp without time zone,
     data jsonb,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    image_url character varying(255),
+    image_alternative_text character varying(255)
 );
 
 
@@ -136,7 +138,9 @@ CREATE TABLE public.notifications (
     description text,
     url character varying(255),
     closed_timestamp timestamp without time zone,
-    type character varying(255)
+    type character varying(255),
+    image_url character varying(255),
+    image_alternative_text character varying(255)
 );
 
 
@@ -595,3 +599,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210528144213);
 INSERT INTO public."schema_migrations" (version) VALUES (20230208195021);
 INSERT INTO public."schema_migrations" (version) VALUES (20230823214704);
 INSERT INTO public."schema_migrations" (version) VALUES (20230824175754);
+INSERT INTO public."schema_migrations" (version) VALUES (20230830193726);

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -17,7 +17,9 @@ defmodule AlertProcessor.NotificationBuilderTest do
         id: "1",
         header: nil,
         active_period: [%{start: two_days_from_now, end: three_days_from_now}],
-        last_push_notification: one_hour_ago
+        last_push_notification: one_hour_ago,
+        image_url: "http://example.com/cool_image.png",
+        image_alternative_text: "a cool image"
       }
 
       {:ok, alert: alert}
@@ -47,8 +49,8 @@ defmodule AlertProcessor.NotificationBuilderTest do
         ],
         closed_timestamp: alert.closed_timestamp,
         type: :initial,
-        image_url: nil,
-        image_alternative_text: nil
+        image_url: "http://example.com/cool_image.png",
+        image_alternative_text: "a cool image"
       }
 
       notification = NotificationBuilder.build_notification({user, [sub]}, alert)

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -46,7 +46,9 @@ defmodule AlertProcessor.NotificationBuilderTest do
           }
         ],
         closed_timestamp: alert.closed_timestamp,
-        type: :initial
+        type: :initial,
+        image_url: nil,
+        image_alternative_text: nil
       }
 
       notification = NotificationBuilder.build_notification({user, [sub]}, alert)

--- a/apps/concierge_site/assets/mjml/notification.mjml
+++ b/apps/concierge_site/assets/mjml/notification.mjml
@@ -41,6 +41,11 @@
                 <%= notification.header %>
               </p>
               <br />
+              <%= if notification.image_url do %>
+                <a href="<%= notification.image_url %>" target="blank">
+                  <img src="<%= notification.image_url %>" alt="<%= notification.image_alternative_text %>" style="width: 100%;" />
+                </a>
+              <% end %>
               <%= if notification.description do %>
                 <p style="margin: 0; padding: 0; font-size: 16px; line-height: 1.5; color: #1c1e23;">
                   <%= String.replace(notification.description, "\r\n", "<br/>") %>

--- a/apps/concierge_site/assets/mjml/notification.mjml
+++ b/apps/concierge_site/assets/mjml/notification.mjml
@@ -43,7 +43,7 @@
               <br />
               <%= if notification.image_url do %>
                 <a href="<%= notification.image_url %>" target="blank">
-                  <img src="<%= notification.image_url %>" alt="<%= notification.image_alternative_text %>" style="width: 100%;" />
+                  <img src="<%= notification.image_url %>" alt="<%= notification.image_alternative_text %>" style="width: 100%; margin-top: 1.5rem; margin-bottom: 1.5rem;" />
                 </a>
               <% end %>
               <%= if notification.description do %>

--- a/apps/concierge_site/lib/mail_templates/notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.txt.eex
@@ -11,6 +11,10 @@ The issue described below has ended:
 
 <%= notification.header %>
 
+<%= notification.image_url %>
+
+<%= notification.image_alternative_text %>
+
 <%= notification.description %>
 <% end %>
 

--- a/apps/concierge_site/lib/mail_templates/notification.txt.eex
+++ b/apps/concierge_site/lib/mail_templates/notification.txt.eex
@@ -11,11 +11,13 @@ The issue described below has ended:
 
 <%= notification.header %>
 
-<%= notification.image_url %>
-
-<%= notification.image_alternative_text %>
+<%= if notification.image_url do %>
+  <%= notification.image_url %>
+  <%= notification.image_alternative_text %>
+<% end %>
 
 <%= notification.description %>
+
 <% end %>
 
 <%= if notification.last_push_notification do %>

--- a/apps/concierge_site/test/integration/sending_test.exs
+++ b/apps/concierge_site/test/integration/sending_test.exs
@@ -29,7 +29,9 @@ defmodule ConciergeSite.Integration.Sending do
         }
       ],
       last_push_notification: ~U[2018-01-01 05:00:00Z],
-      service_effect: "Service Effect"
+      service_effect: "Service Effect",
+      image_url: "http://example.com/cool_carrot.png",
+      image_alternative_text: "cool carrot"
     }
 
     @subscription %{

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -78,8 +78,8 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     assert body =~ "Last Updated: Jan 18 2017 02:00 PM"
     assert body =~ "feedback?alert_id=123&user_id=456&rating=yes"
     assert body =~ "feedback?alert_id=123&user_id=456&rating=no"
-
     assert body =~ "/email_opened/notification/123/a7722510-6a27-44ee-808e-b242312abb6d/img.gif"
+    assert body =~ "http://www.example.com/alert-info.png"
   end
 
   test "html_email/1 includes content for closed alerts" do

--- a/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
+++ b/apps/concierge_site/test/lib/dissemination/notification_email_test.exs
@@ -20,6 +20,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     header: "Red line inbound from Alewife station closure",
     description: "There is a fire in at south station so it is closed",
     url: "http://www.example.com/alert-info",
+    image_url: "http://www.example.com/alert-info.png",
     alert: @alert,
     last_push_notification: %DateTime{
       year: 2017,
@@ -47,6 +48,7 @@ defmodule ConciergeSite.Dissemination.NotificationEmailTest do
     assert body =~ "Red line delay"
     assert body =~ "Red line inbound from Alewife station closure"
     assert body =~ "There is a fire in at south station so it is closed"
+    assert body =~ "http://www.example.com/alert-info.png"
     assert body =~ "Last Updated: Jan 18 2017 02:00 PM"
   end
 


### PR DESCRIPTION
Reference for the shape the image data comes in as: https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-translatedimage

Asana ticket:  https://app.asana.com/0/1167196461144361/1204624899415315/f