### PR TITLE
fix (test): Add a new stop to the test expectation

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -261,6 +261,7 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                short_name: "",
                stop_list: [
                  {"Blossom Street Pier", "Boat-Blossom", {42.45481, -70.94802}, 1},
+                 {"Long Wharf (North)", "Boat-Long", {42.360795, -71.049976}, 1},
                  {"Long Wharf (South) - Gate 4", "Boat-Long-South-4", {42.359897, -71.04859}, 1}
                ]
              },


### PR DESCRIPTION
No Asana ticket, I just noticed the failing test.

This must have been added in the latest GTFS release.