### PR TITLE
fix: Prevent open redirects via our auth path

### DIFF
--- a/apps/concierge_site/lib/plugs/validate_auth_redirect.ex
+++ b/apps/concierge_site/lib/plugs/validate_auth_redirect.ex
@@ -1,0 +1,28 @@
+defmodule ConciergeSite.Plugs.ValidateAuthRedirect do
+  @moduledoc """
+  Validates that custom auth redirects (used for the register page) are only
+  going to the configured auth provider and nowhere else. This prevents an open
+  redirect security vulnerability.
+  """
+  @behaviour Plug
+  require Logger
+  import Plug.Conn
+  alias Plug.Conn
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(%Conn{query_params: %{"uri" => uri}} = conn, _opts) do
+    base_uri = Application.get_env(:concierge_site, :keycloak_base_uri)
+
+    if String.starts_with?(uri, base_uri) do
+      conn
+    else
+      Logger.warning("Potentially malicious request: redirect_uri=#{uri}")
+      send_resp(conn, :bad_request, "Bad redirect URI")
+    end
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -98,8 +98,17 @@ defmodule ConciergeSite.Router do
   end
 
   scope "/auth", ConciergeSite do
-    pipe_through([:redirect_prod_http, :browser])
+    pipe_through([
+      :redirect_prod_http,
+      :browser,
+      ConciergeSite.Plugs.ValidateAuthRedirect
+    ])
+
     get("/:provider", AuthController, :request)
+  end
+
+  scope "/auth", ConciergeSite do
+    pipe_through([:redirect_prod_http, :browser])
     get("/:provider/register", AuthController, :register)
     get("/:provider/callback", AuthController, :callback)
     get("/:provider/logout", AuthController, :logout)

--- a/apps/concierge_site/test/lib/plugs/validate_auth_redirect_test.exs
+++ b/apps/concierge_site/test/lib/plugs/validate_auth_redirect_test.exs
@@ -1,0 +1,65 @@
+defmodule ConciergeSite.Plugs.ValidateAuthRedirectTest do
+  use ConciergeSite.ConnCase
+  use Plug.Test
+
+  import Test.Support.Helpers
+
+  alias ConciergeSite.Plugs.ValidateAuthRedirect
+  alias Plug.Conn
+
+  describe "ValidateAuthRedirect" do
+    @tag :capture_log
+    test "sends a bad request response if requesting an invalid auth redirect URI param", %{
+      conn: original_conn
+    } do
+      reassign_env(:concierge_site, :keycloak_base_uri, "https://example.com/TEST-BASE-URI")
+
+      redirect_uri =
+        "https://malicious-site.com/TEST-BASE-URI/auth/realms/MBTA/protocol/openid-connect/registrations?client_id=t-alerts&response_type=code&scope=openid"
+
+      original_conn = %Conn{
+        original_conn
+        | query_params: %{
+            "uri" => redirect_uri
+          }
+      }
+
+      conn = ValidateAuthRedirect.call(original_conn, %{})
+
+      assert response(conn, 400) =~ "Bad redirect URI"
+    end
+
+    test "allows the redirect for requests with valid auth redirect URI param", %{
+      conn: original_conn
+    } do
+      reassign_env(:concierge_site, :keycloak_base_uri, "https://example.com/TEST-BASE-URI")
+
+      redirect_uri =
+        "https://example.com/TEST-BASE-URI/auth/realms/MBTA/protocol/openid-connect/registrations?client_id=t-alerts&response_type=code&scope=openid"
+
+      original_conn = %Conn{
+        original_conn
+        | query_params: %{
+            "uri" => redirect_uri
+          }
+      }
+
+      conn = ValidateAuthRedirect.call(original_conn, %{})
+
+      assert conn == original_conn
+    end
+
+    test "allows the redirect for requests without a redirect URI param", %{
+      conn: original_conn
+    } do
+      original_conn = %Conn{
+        original_conn
+        | query_params: %{}
+      }
+
+      conn = ValidateAuthRedirect.call(original_conn, %{})
+
+      assert conn == original_conn
+    end
+  end
+end


### PR DESCRIPTION
Asana ticket: [Security: open redirect from /auth/keycloak](https://app.asana.com/0/1204819229687089/1205499918315636)