### PR TITLE
Fix: Migrate GitHub actions to v2 and assumed role

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,16 +29,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: mbta/actions/build-push-ecr@v1
+      - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-ecs@v1
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: alerts-concierge
           ecs-service: alerts-concierge-${{ env.TARGET }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
This PR migrates the deploy workflow to use v2 of `build-push-ecr` and `deploy-ecs` actions. 

There's a test failure happening in this pipeline, so I'd like to get team opinion here. I wouldn't have expected these changes to affect any test coverage. 