### PR TITLE
fix (test): Update trip IDs for latest GTFS

### DIFF
--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1204,12 +1204,12 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # are active as of 2022-11-09.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "CR-598332-909"
-                   6 -> "CR-598427-1905"
-                   7 -> "CR-598560-2905"
+                   day when day in 1..5 -> "CR-627824-909"
+                   6 -> "CR-628434-1905"
+                   7 -> "CR-628592-2905"
                  end)
   @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
-                                     day when day in 1..5 -> ~T[08:25:00]
+                                     day when day in 1..5 -> ~T[08:20:00]
                                      day when day in 6..7 -> ~T[08:43:00]
                                    end)
 


### PR DESCRIPTION
No ticket. This fixes tests that are [currently failing in CI](https://github.com/mbta/alerts_concierge/actions/runs/6511645499/job/17687900913?pr=1363) after the latest GTFS release.

[Successful CI run](https://github.com/mbta/alerts_concierge/actions/runs/6534640916/job/17742298536)