### PR TITLE
fix: don't put the `logout_uri` in the Guardian claims

### DIFF
--- a/apps/concierge_site/lib/controllers/auth_controller.ex
+++ b/apps/concierge_site/lib/controllers/auth_controller.ex
@@ -44,7 +44,9 @@ defmodule ConciergeSite.AuthController do
 
     {:ok, logout_uri} = UeberauthOidcc.initiate_logout_url(auth, logout_params)
 
-    SessionHelper.sign_in(conn, user, %{logout_uri: logout_uri})
+    conn
+    |> put_session("logout_uri", logout_uri)
+    |> SessionHelper.sign_in(user)
   end
 
   def callback(%{assigns: %{ueberauth_failure: failure}} = conn, _params) do

--- a/apps/concierge_site/lib/helpers/session_helper.ex
+++ b/apps/concierge_site/lib/helpers/session_helper.ex
@@ -20,11 +20,7 @@ defmodule ConciergeSite.SessionHelper do
   @spec sign_out(Conn.t()) :: Conn.t()
   @spec sign_out(Conn.t(), keyword()) :: Conn.t()
   def sign_out(conn, opts \\ []) do
-    logout_uri =
-      case Guardian.Plug.current_claims(conn) do
-        %{"logout_uri" => logout_uri} -> logout_uri
-        _ -> nil
-      end
+    logout_uri = Conn.get_session(conn, "logout_uri")
 
     redirect_to =
       if Keyword.get(opts, :skip_oidc_sign_out, false) or is_nil(logout_uri) do

--- a/apps/concierge_site/test/support/conn_case.ex
+++ b/apps/concierge_site/test/support/conn_case.ex
@@ -32,12 +32,8 @@ defmodule ConciergeSite.ConnCase do
         conn
         |> bypass_through(ConciergeSite.Router, [:browser])
         |> get("/")
-        |> ConciergeSite.Guardian.Plug.sign_in(
-          user,
-          %{
-            logout_uri: "http://oidc.example/end_session_uri"
-          }
-        )
+        |> put_session("logout_uri", "http://oidc.example/end_session_uri")
+        |> ConciergeSite.Guardian.Plug.sign_in(user)
         |> send_resp(200, "Flush the session")
         |> recycle()
       end

--- a/apps/concierge_site/test/web/controllers/auth_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/auth_controller_test.exs
@@ -30,7 +30,7 @@ defmodule ConciergeSite.Web.AuthControllerTest do
       assert %User{id: ^id, email: ^email, phone_number: ^phone_number} =
                Guardian.Plug.current_resource(conn)
 
-      assert %{"logout_uri" => _} = Guardian.Plug.current_claims(conn)
+      assert is_binary(Plug.Conn.get_session(conn, "logout_uri"))
     end
 
     test "given an ueberauth auth, redirects to the account options page (for an account with no trips)",


### PR DESCRIPTION
Putting it there results in a very large session cookie, as we're nesting 3 JWTs (ID token JWT in the logout_uri -> Guardian JWT -> Session JWT) which can push things over the 4096 byte cookie limit.