### PR TITLE
HOT FIX: Don't fetch ferry data temporarily

### DIFF
--- a/apps/alert_processor/lib/service_info/service_info_cache.ex
+++ b/apps/alert_processor/lib/service_info/service_info_cache.ex
@@ -14,7 +14,7 @@ defmodule AlertProcessor.ServiceInfoCache do
   @info_types [
     :parent_stop_info,
     :subway_full_routes,
-    :ferry_general_ids,
+    # :ferry_general_ids,
     :commuter_rail_trip_ids,
     :facility_map
   ]


### PR DESCRIPTION
There are no running trips, and the app isn't properly handling a response with no data. That should be fixed properly, but in the meantime, this stops the bleeding.