### PR TITLE
feat: Clarify where email image links to in alt text

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -124,4 +124,20 @@ defmodule AlertProcessor.Model.Notification do
       )
     )
   end
+
+  @spec image_alternative_text(t()) :: String.t()
+  @spec image_alternative_text(t(), email? :: boolean()) :: String.t()
+  def image_alternative_text(notification, email? \\ false)
+
+  def image_alternative_text(%__MODULE__{image_alternative_text: nil} = notification, email?),
+    do: image_alternative_text(%__MODULE__{notification | image_alternative_text: ""}, email?)
+
+  def image_alternative_text(%__MODULE__{image_alternative_text: image_alternative_text}, true) do
+    [image_alternative_text, "Link opens a full-size version of the image."]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join(" ")
+  end
+
+  def image_alternative_text(%__MODULE__{image_alternative_text: image_alternative_text}, false),
+    do: image_alternative_text
 end

--- a/apps/alert_processor/test/alert_processor/model/notification_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/notification_test.exs
@@ -317,6 +317,31 @@ defmodule AlertProcessor.Model.NotificationTest do
     end
   end
 
+  describe "image_alternative_text" do
+    test "returns the Notifaction's image_alternative_text" do
+      alt_text = "Test alt text."
+      notification = struct(Notification, image_alternative_text: alt_text)
+
+      assert Notification.image_alternative_text(notification) == alt_text
+    end
+
+    test "if email? is true, appends info about the link" do
+      notification = struct(Notification, image_alternative_text: "Test alt text.")
+
+      assert Notification.image_alternative_text(notification, true) ==
+               "Test alt text. Link opens a full-size version of the image."
+    end
+
+    test "handles missing image_alternative_text" do
+      notification = struct(Notification, image_alternative_text: nil)
+
+      assert Notification.image_alternative_text(notification) == ""
+
+      assert Notification.image_alternative_text(notification, true) ==
+               "Link opens a full-size version of the image."
+    end
+  end
+
   defp notification_details(
          alert_id,
          notification_number,

--- a/apps/concierge_site/assets/mjml/notification.mjml
+++ b/apps/concierge_site/assets/mjml/notification.mjml
@@ -43,7 +43,7 @@
               <br />
               <%= if notification.image_url do %>
                 <a href="<%= notification.image_url %>" target="blank">
-                  <img src="<%= notification.image_url %>" alt="<%= notification.image_alternative_text %>" style="margin-top: 1.5rem; margin-bottom: 1.5rem;" width="500"/>
+                  <img src="<%= notification.image_url %>" alt="<%= Notification.image_alternative_text(notification, true) %>" style="margin-top: 1.5rem; margin-bottom: 1.5rem;" width="500"/>
                 </a>
               <% end %>
               <%= if notification.description do %>


### PR DESCRIPTION
Asana ticket: [Clarify where image links to in alt text](https://app.asana.com/0/1204819229687089/1206700151817918)