### PR TITLE
ci: Update GitHub actions to the latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,16 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: asdf-cache
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: asdf-vm/actions/install@v1
+      - uses: asdf-vm/actions/install@v3
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      - uses: mbta/actions/reshim-asdf@v1
+      - uses: mbta/actions/reshim-asdf@v2
 
       - name: Elixir tools
         if: steps.asdf-cache.outputs.cache-hit != 'true'
@@ -45,7 +45,7 @@ jobs:
           mix local.rebar --force
           mix local.hex --force
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: ex-deps-cache
         with:
           path: |
@@ -58,7 +58,7 @@ jobs:
           mix deps.get
           mix deps.compile
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: js-deps-cache
         with:
           path: apps/concierge_site/assets/node_modules
@@ -72,13 +72,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
@@ -91,13 +91,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
@@ -110,13 +110,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
@@ -129,13 +129,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
@@ -167,19 +167,19 @@ jobs:
       API_KEY: ${{ secrets.API_KEY }}
       API_URL: https://api-dev.mbtace.com/
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
             deps
           key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: apps/concierge_site/assets/node_modules
           key: ${{ secrets.CACHE_UUID }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -187,7 +187,7 @@ jobs:
       - run: mix test --cover
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: elixir-lcov
           path: |
@@ -199,16 +199,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ secrets.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
-      - uses: actions/cache@v3
+      - uses: mbta/actions/reshim-asdf@v2
+      - uses: actions/cache@v4
         with:
           path: |
             _build
             deps
           key: ${{ secrets.CACHE_UUID }}-mix-${{ hashFiles('**/mix.lock') }}
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2


### PR DESCRIPTION
Took this step as a part of exploring [🐞 T-Alerts CI tests not running properly for Dependabot PRs](https://app.asana.com/0/1204819229687089/1206951379065663), but I don't expect it to fix that issue.