### PR TITLE
Login in with mbta_uuid

### DIFF
--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -240,6 +240,15 @@ defmodule AlertProcessor.Model.User do
   @spec get(id()) :: t() | nil
   def get(id), do: Repo.get(__MODULE__, id)
 
+  @spec get_by_alternate_id(%{id: id() | nil, mbta_uuid: id() | nil}) :: [t()]
+  def get_by_alternate_id(%{id: id, mbta_uuid: mbta_uuid}) do
+    from(u in __MODULE__,
+      where: u.id in [^id, ^mbta_uuid]
+    )
+    |> Repo.all()
+    |> Enum.filter(&(!is_nil(&1)))
+  end
+
   @spec for_email(String.t()) :: t | nil
   def for_email(email) do
     email =

--- a/apps/alert_processor/lib/model/user.ex
+++ b/apps/alert_processor/lib/model/user.ex
@@ -240,8 +240,11 @@ defmodule AlertProcessor.Model.User do
   @spec get(id()) :: t() | nil
   def get(id), do: Repo.get(__MODULE__, id)
 
-  @spec get_by_alternate_id(%{id: id() | nil, mbta_uuid: id() | nil}) :: [t()]
+  @spec get_by_alternate_id(%{id: id(), mbta_uuid: id() | nil}) :: [t()]
   def get_by_alternate_id(%{id: id, mbta_uuid: mbta_uuid}) do
+    # can get accounts using id or mbta_uuid
+    # which is the old-style ID for accounts from the time before SSO.
+
     from(u in __MODULE__,
       where: u.id in [^id, ^mbta_uuid]
     )

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -215,7 +215,12 @@ defmodule AlertProcessor.Model.UserTest do
       assert User.get_by_alternate_id(%{id: nil, mbta_uuid: user.id}) == [user]
     end
 
-    test "returns two users if both present (unlikely)" do
+    test "returns a user if both id's are the same " do
+      user = insert(:user)
+      assert User.get_by_alternate_id(%{id: user.id, mbta_uuid: user.id}) == [user]
+    end
+
+    test "returns two users if both ids present and different (unlikely)" do
       user = insert(:user)
       user2 = insert(:user)
       assert User.get_by_alternate_id(%{id: user.id, mbta_uuid: user2.id}) == [user, user2]

--- a/apps/alert_processor/test/alert_processor/model/user_test.exs
+++ b/apps/alert_processor/test/alert_processor/model/user_test.exs
@@ -204,6 +204,29 @@ defmodule AlertProcessor.Model.UserTest do
     end
   end
 
+  describe "get_by_alternate_id/1" do
+    test "returns a user by id if present" do
+      user = insert(:user)
+      assert User.get_by_alternate_id(%{id: user.id, mbta_uuid: nil}) == [user]
+    end
+
+    test "returns a user by mbta_uuid if present" do
+      user = insert(:user)
+      assert User.get_by_alternate_id(%{id: nil, mbta_uuid: user.id}) == [user]
+    end
+
+    test "returns two users if both present (unlikely)" do
+      user = insert(:user)
+      user2 = insert(:user)
+      assert User.get_by_alternate_id(%{id: user.id, mbta_uuid: user2.id}) == [user, user2]
+    end
+
+    test "returns empty_list if no matching user" do
+      bad_id = UUID.uuid4()
+      assert User.get_by_alternate_id(%{id: bad_id, mbta_uuid: nil}) == []
+    end
+  end
+
   describe "for_email/1" do
     test "returns a user if present" do
       user = insert(:user)

--- a/apps/concierge_site/lib/controllers/auth_controller.ex
+++ b/apps/concierge_site/lib/controllers/auth_controller.ex
@@ -21,7 +21,7 @@ defmodule ConciergeSite.AuthController do
                 extra: %{
                   raw_info: %{
                     claims: %{"sub" => id},
-                    userinfo: userinfo
+                    userinfo: %{"mbta_uuid" => mbta_uuid} = userinfo
                   }
                 }
               } = auth
@@ -34,7 +34,7 @@ defmodule ConciergeSite.AuthController do
     role = parse_role({:ok, userinfo})
 
     user =
-      id
+      %{id: id, mbta_uuid: mbta_uuid}
       |> get_or_create_user(email, phone_number, role)
       |> use_props_from_token(email, phone_number, role)
 
@@ -44,9 +44,15 @@ defmodule ConciergeSite.AuthController do
 
     {:ok, logout_uri} = UeberauthOidcc.initiate_logout_url(auth, logout_params)
 
-    conn
-    |> put_session("logout_uri", logout_uri)
-    |> SessionHelper.sign_in(user)
+    case user do
+      nil ->
+        SessionHelper.sign_out(conn, skip_oidc_sign_out: true)
+
+      _ ->
+        conn
+        |> put_session("logout_uri", logout_uri)
+        |> SessionHelper.sign_in(user)
+    end
   end
 
   def callback(%{assigns: %{ueberauth_failure: failure}} = conn, _params) do
@@ -67,11 +73,20 @@ defmodule ConciergeSite.AuthController do
     SessionHelper.sign_out(conn)
   end
 
-  @spec get_or_create_user(User.id(), String.t(), String.t() | nil, String.t()) :: User.t()
-  defp get_or_create_user(id, email, phone_number, role) do
-    case User.get(id) do
-      nil ->
-        # The user just created their account in Keycloak so we need to add them to our database
+  @spec get_or_create_user(
+          %{id: User.id() | nil, mbta_uuid: User.id() | nil},
+          String.t(),
+          String.t() | nil,
+          String.t()
+        ) ::
+          User.t() | :find_user_error
+  defp get_or_create_user(%{id: id, mbta_uuid: mbta_uuid} = id_map, email, phone_number, role) do
+    # This checks both the normal id from Keycloak, and the legacy mbta_uuid. We should get either 0 or 1 users back.
+    user_list = User.get_by_alternate_id(id_map)
+
+    case length(user_list) do
+      0 ->
+        # If neither ID is found, the user just created their account in Keycloak so we need to add them to our database
         Repo.insert!(%User{
           id: id,
           email: email,
@@ -81,8 +96,14 @@ defmodule ConciergeSite.AuthController do
 
         User.get(id)
 
-      user ->
-        user
+      1 ->
+        # If 1 user is found, we want to return that user
+        hd(user_list)
+
+      2 ->
+        # If 2 users are found, something weird happened. Log and return nil. User will be redirected to landing page.
+        Logger.warn("User with 2 ids found. sub id: #{id}, mbta_uuid: #{mbta_uuid}")
+        :find_user_error
     end
   end
 
@@ -92,7 +113,15 @@ defmodule ConciergeSite.AuthController do
   # able to use them to send notifications), but in cases where the user just
   # changed one of these fields in Keycloak, we might not have had time receive
   # that message yet, so the values in the token are more authoritative.
-  @spec use_props_from_token(User.t(), String.t(), String.t() | nil, String.t()) :: User.t()
+  @spec use_props_from_token(
+          User.t() | :find_user_error,
+          String.t(),
+          String.t() | nil,
+          String.t()
+        ) ::
+          User.t() | nil
+  defp use_props_from_token(:find_user_error, _, _, _), do: nil
+
   defp use_props_from_token(user, email, phone_number, role) do
     %User{
       user


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1204819229687089/1207565926717083/f)

 Lets a user login in from keycloak if their user id matches either the `sub` id or the `mbta_uuid`. Does not log in and redirects to landing page if both are somehow found.