### PR TITLE
Handle case where minute is nil in trip controller times

### DIFF
--- a/apps/concierge_site/lib/param_parsers/param_time.ex
+++ b/apps/concierge_site/lib/param_parsers/param_time.ex
@@ -20,13 +20,18 @@ defmodule ConciergeSite.ParamParsers.ParamTime do
       ~T[12:00:00]
       iex> ConciergeSite.ParamParsers.ParamTime.to_time(nil)
       nil
+      iex> ConciergeSite.ParamParsers.ParamTime.to_time(%{"am_pm" => "PM", "hour" => "12", "minute" => nil})
+      ~T[12:00:00]
   """
   @spec to_time(map) :: Time.t()
   def to_time(nil), do: nil
 
   def to_time(form_time) do
     hour = hour(form_time["hour"], form_time["am_pm"])
-    minute = String.to_integer(form_time["minute"])
+
+    minute =
+      if is_binary(form_time["minute"]), do: String.to_integer(form_time["minute"]), else: 0
+
     second = 0
 
     {:ok, time} = Time.from_erl({hour, minute, second})


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1167196461144361/1208104645530658/f), addresses [this](https://mbtace.sentry.io/issues/5735409443/?alert_rule_id=15245594&alert_type=issue&environment=prod&notification_uuid=324a5329-0b8c-4e2d-a5cf-8bce279ed3d2&project=5583106&referrer=slack) Sentry error.

It doesn't seem possible to me that a user could see this error in normal site use, since the form will always send back a string chosen from a dropdown. However, handling it is pretty simple, I decided to default to 0 if the minute is not a string. The risk is that the user will have intended a different minute, but they can see and modify the resulting trip like normal. Also how did they even get there.