### PR TITLE
Add secure headers

### DIFF
--- a/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
+++ b/apps/alert_processor/test/alert_processor/service_info/service_info_cache_test.exs
@@ -248,7 +248,6 @@ defmodule AlertProcessor.ServiceInfoCacheTest do
                stop_list: [
                  {"Hingham", "Boat-Hingham", {42.253956, -70.919844}, 1},
                  {"Rowes Wharf", "Boat-Rowes", {42.355721, -71.049897}, 1},
-                 {"Georges Island", "Boat-George", {42.319742, -70.930427}, 1},
                  {"Hull", "Boat-Hull", {42.303251, -70.920215}, 1},
                  {"Logan Airport Ferry Terminal", "Boat-Logan", {42.359789, -71.02734}, 1},
                  {"Long Wharf (North)", "Boat-Long", {42.360795, -71.049976}, 1}

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -15,7 +15,13 @@ defmodule ConciergeSite.Router do
     plug(:fetch_session)
     plug(:fetch_flash)
     plug(:protect_from_forgery)
-    plug(:put_secure_browser_headers)
+
+    plug :put_secure_browser_headers, %{
+      "strict-transport-security" => "max-age=31536000",
+      "content-security-policy" =>
+        "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' www.googletagmanager.com insitez.blob.core.windows.net;"
+    }
+
     plug(ConciergeSite.Plugs.AssignCurrentUser)
     plug(ConciergeSite.Plugs.RateLimit, enable?: Mix.env() != :test)
   end


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1204819229687089/1208252819442811/f)

A recent security audit revealed we need to add some more secure headers. The `put secure browser headers` plug takes care of most of them, so we were really only missing 2.