### PR TITLE
feat: implement admin dashboard for South Coast Rail migration

### DIFF
--- a/apps/alert_processor/lib/model/notification_subscription.ex
+++ b/apps/alert_processor/lib/model/notification_subscription.ex
@@ -4,6 +4,8 @@ defmodule AlertProcessor.Model.NotificationSubscription do
   """
   use Ecto.Schema
 
+  @type t :: %__MODULE__{}
+
   schema "notification_subscriptions" do
     belongs_to(:notification, AlertProcessor.Model.Notification, type: :binary_id)
     belongs_to(:subscription, AlertProcessor.Model.Subscription, type: :binary_id)

--- a/apps/concierge_site/lib/controllers/admin/scr_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/scr_controller.ex
@@ -1,0 +1,214 @@
+defmodule ConciergeSite.Admin.ScrController do
+  use ConciergeSite.Web, :controller
+  import Ecto.Query
+  alias AlertProcessor.Model.NotificationSubscription
+  alias AlertProcessor.Model.Subscription
+  alias AlertProcessor.Repo
+
+  @old_route "CR-Middleborough"
+  @new_route "CR-NewBedford"
+  @old_stop_id "place-MM-0356"
+  @new_stop_id "place-MBS-0350"
+  @new_stop_lat 41.887
+  @new_stop_long -70.923209
+
+  def index(conn, _params) do
+    counts =
+      Repo.all(
+        from(s in Subscription,
+          where: s.route == @old_route or s.route == @new_route,
+          group_by: s.route,
+          select: %{s.route => count(s.id)}
+        )
+      )
+      |> Enum.reduce(%{}, &Map.merge/2)
+
+    render(conn, "index.html",
+      count_before: Map.get(counts, @old_route, 0),
+      count_after: Map.get(counts, @new_route, 0)
+    )
+  end
+
+  def phase1(conn, _params) do
+    {:ok, flash} =
+      Repo.transaction(fn ->
+        subscriptions = get_relevant_subscriptions_by_route_and_id()
+
+        old_subscriptions = Map.get(subscriptions, @old_route, %{})
+        already_migrated_subscriptions = Map.get(subscriptions, @new_route, %{})
+
+        new_subscriptions =
+          old_subscriptions
+          |> Enum.flat_map(fn {_, old_subscription} ->
+            new_subscription_for_old_subscription(
+              old_subscription,
+              already_migrated_subscriptions
+            )
+            |> List.wrap()
+          end)
+
+        relevant_subscription_ids =
+          new_subscriptions
+          |> Enum.flat_map(fn %Subscription{id: new_id} ->
+            [new_id, uuid_op(new_id, &(&1 - 1)) |> Ecto.UUID.cast!()]
+          end)
+
+        notification_subscriptions = get_relevant_nses_by_sub_and_notif(relevant_subscription_ids)
+
+        new_subscription_count = length(new_subscriptions)
+
+        new_notification_subscription_count =
+          new_subscriptions
+          |> Enum.reduce(0, fn new_subscription, count ->
+            count + migrate_nses(new_subscription, notification_subscriptions)
+          end)
+
+        "Migrated #{new_subscription_count} subscriptions and #{new_notification_subscription_count} associations to notifications."
+      end)
+
+    conn
+    |> put_flash(:info, flash)
+    |> redirect(to: admin_scr_path(conn, :index))
+  end
+
+  def phase2(conn, _params) do
+    {:ok, flash} =
+      Repo.transaction(fn ->
+        {sub_count, subscription_ids} =
+          Repo.delete_all(from(s in Subscription, where: s.route == @old_route, select: s.id))
+
+        {ns_count, _} =
+          Repo.delete_all(
+            from(ns in NotificationSubscription, where: ns.subscription_id in ^subscription_ids)
+          )
+
+        "Deleted #{sub_count} subscriptions and #{ns_count} associations to notifications."
+      end)
+
+    conn
+    |> put_flash(:info, flash)
+    |> redirect(to: admin_scr_path(conn, :index))
+  end
+
+  @doc """
+  Performs a mathematical operation on the last digit only of the given UUID,
+  wrapping between 0 and f as needed.
+  """
+  @spec uuid_op(String.t(), (integer() -> integer())) :: String.t()
+  def uuid_op(uuid, op) do
+    last_digit = String.last(uuid)
+
+    adjacent_last_digit =
+      last_digit
+      |> String.to_integer(16)
+      |> Kernel.+(16)
+      |> op.()
+      |> Integer.to_string(16)
+      |> String.last()
+      |> String.downcase()
+
+    String.slice(uuid, 0..(String.length(uuid) - 2)) <> adjacent_last_digit
+  end
+
+  @spec get_relevant_subscriptions_by_route_and_id :: %{
+          String.t() => %{String.t() => Subscription.t()}
+        }
+  defp get_relevant_subscriptions_by_route_and_id do
+    Repo.all(
+      from(s in Subscription,
+        where: s.route == @old_route or s.route == @new_route
+      )
+    )
+    |> Enum.group_by(& &1.route)
+    |> Map.new(fn {route, subscriptions} ->
+      {route, Map.new(subscriptions, &{&1.id, &1})}
+    end)
+  end
+
+  @spec new_subscription_for_old_subscription(Subscription.t(), %{String.t() => Subscription.t()}) ::
+          Subscription.t() | nil
+  defp new_subscription_for_old_subscription(
+         %Subscription{id: old_id} = old_subscription,
+         already_migrated_subscriptions
+       ) do
+    new_id = old_id |> uuid_op(&(&1 + 1))
+
+    if not Map.has_key?(already_migrated_subscriptions, new_id) do
+      new_subscription = %Subscription{
+        old_subscription
+        | id: new_id |> Ecto.UUID.cast!(),
+          route: @new_route,
+          inserted_at: nil,
+          updated_at: nil
+      }
+
+      new_subscription =
+        if new_subscription.origin == @old_stop_id do
+          %Subscription{
+            new_subscription
+            | origin: @new_stop_id,
+              origin_lat: @new_stop_lat,
+              origin_long: @new_stop_long
+          }
+        else
+          new_subscription
+        end
+
+      new_subscription =
+        if new_subscription.destination == @old_stop_id do
+          %Subscription{
+            new_subscription
+            | destination: @new_stop_id,
+              destination_lat: @new_stop_lat,
+              destination_long: @new_stop_long
+          }
+        else
+          new_subscription
+        end
+
+      new_subscription
+      |> Repo.insert!()
+    end
+  end
+
+  @spec get_relevant_nses_by_sub_and_notif([Ecto.UUID.t()]) :: %{
+          Subscription.id() => %{String.t() => NotificationSubscription.t()}
+        }
+  defp get_relevant_nses_by_sub_and_notif(relevant_subscription_ids) do
+    Repo.all(
+      from(ns in NotificationSubscription,
+        where: ns.subscription_id in ^relevant_subscription_ids
+      )
+    )
+    |> Enum.group_by(& &1.subscription_id)
+    |> Map.new(fn {subscription_id, ns_list} ->
+      {subscription_id, ns_list |> Enum.group_by(& &1.notification_id)}
+    end)
+  end
+
+  @spec migrate_nses(Subscription.t(), %{
+          Subscription.id() => %{String.t() => NotificationSubscription.t()}
+        }) :: non_neg_integer()
+  defp migrate_nses(new_subscription, notification_subscriptions) do
+    new_id = new_subscription.id
+    old_id = uuid_op(new_id, &(&1 - 1))
+
+    old_id_ns_by_notification = Map.get(notification_subscriptions, old_id, %{})
+    new_id_ns_by_notification = Map.get(notification_subscriptions, new_id, %{})
+
+    old_id_ns_by_notification
+    |> Enum.reduce(0, fn {notification_id, _old_ns}, count ->
+      if Map.has_key?(new_id_ns_by_notification, notification_id) do
+        count
+      else
+        %NotificationSubscription{
+          notification_id: notification_id,
+          subscription_id: new_id
+        }
+        |> Repo.insert!()
+
+        count + 1
+      end
+    end)
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -119,6 +119,9 @@ defmodule ConciergeSite.Router do
 
     get("/", HomeController, :index)
     resources("/queries", QueriesController, only: [:index, :show])
+    get("/scr", ScrController, :index)
+    post("/scr/phase1", ScrController, :phase1)
+    post("/scr/phase2", ScrController, :phase2)
   end
 
   scope "/mailchimp", ConciergeSite do

--- a/apps/concierge_site/lib/templates/admin/home/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/home/index.html.eex
@@ -4,4 +4,7 @@
   <%= link to: admin_queries_path(@conn, :index), class: "list-group-item list-group-item-action" do %>
     <i class="fa fa-database"></i> Database queries
   <% end %>
+  <%= link to: admin_scr_path(@conn, :index), class: "list-group-item list-group-item-action" do %>
+    <i class="fa fa-code-fork"></i> South Coast Rail migration
+  <% end %>
 </div>

--- a/apps/concierge_site/lib/templates/admin/scr/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/scr/index.html.eex
@@ -1,0 +1,41 @@
+<h1 class="heading__title">South Coast Rail Migration</h1>
+<%= flash_info(@conn) %>
+
+<p><%= @count_before %> Middleborough/Lakeville Line subscriptions</p>
+<p><%= @count_after %> Fall River/New Bedford Line subscriptions</p>
+
+<p>Phase 1: <%= link to: admin_scr_path(@conn, :phase1), class: "btn btn-primary", method: :post do %><i class="fa fa-play-circle-o"></i> Run<% end %></p>
+<ul>
+<li>Copies subscriptions that have not already been copied</li>
+<li>Marks notifications as sent</li>
+</ul>
+
+<p>Phase 2: <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#scr-phase2-confirm"><i class="fa fa-play-circle-o"></i> Run</button></p>
+<ul>
+<li>Deletes old subscriptions</li>
+</ul>
+
+<div id="scr-phase2-confirm" class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmation</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>This will delete <%= @count_before %> Middleborough/Lakeville Line subscriptions.</p>
+        <%= if @count_before > @count_after do %>
+          <div class="alert alert-danger" role="alert">
+            That’s more than the <%= @count_after %> Fall River/New Bedford Line subscriptions! Consider running Phase 1 again first to make sure no data is lost.
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <%= link to: admin_scr_path(@conn, :phase2), class: "btn btn-danger", method: :post do %>Delete Middleborough subscriptions<% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/concierge_site/lib/views/admin/scr_view.ex
+++ b/apps/concierge_site/lib/views/admin/scr_view.ex
@@ -1,0 +1,3 @@
+defmodule ConciergeSite.Admin.ScrView do
+  use ConciergeSite.Web, :view
+end

--- a/apps/concierge_site/test/web/controllers/admin/scr_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/scr_controller_test.exs
@@ -1,0 +1,158 @@
+defmodule ConciergeSite.Admin.ScrControllerTest do
+  use ConciergeSite.ConnCase, async: true
+  alias AlertProcessor.Model.NotificationSubscription
+  alias AlertProcessor.Model.Subscription
+  alias AlertProcessor.Repo
+  alias ConciergeSite.Admin.ScrController
+
+  setup %{conn: conn} do
+    user = insert(:user, role: "admin")
+    conn = guardian_login(user, conn)
+
+    {:ok, user: user, conn: conn}
+  end
+
+  describe "index" do
+    test "lists counts on old and new routes", %{conn: conn} do
+      trip = insert(:trip)
+
+      insert_list(13, :subscription, trip_id: trip.id, route: "CR-Middleborough")
+      insert_list(12, :subscription, trip_id: trip.id, route: "CR-NewBedford")
+
+      conn = get(conn, admin_scr_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "13 Middleborough/Lakeville Line subscriptions"
+      assert html_response(conn, 200) =~ "12 Fall River/New Bedford Line subscriptions"
+    end
+
+    test "warns on phase 2 if more old subscriptions than new", %{conn: conn} do
+      trip = insert(:trip)
+
+      insert_list(8, :subscription, trip_id: trip.id, route: "CR-Middleborough")
+      insert_list(2, :subscription, trip_id: trip.id, route: "CR-NewBedford")
+
+      conn = get(conn, admin_scr_path(conn, :index))
+
+      assert html_response(conn, 200) =~
+               "That’s more than the 2 Fall River/New Bedford Line subscriptions!"
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = get(conn, admin_scr_path(conn, :index))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
+
+  describe "phase1" do
+    test "copies subscriptions and notifications if needed", %{conn: conn} do
+      [trip1, trip2] = insert_list(2, :trip)
+
+      sub11 = insert(:subscription, trip: trip1, route: "CR-Middleborough")
+
+      sub11after =
+        insert(:subscription,
+          id: ScrController.uuid_op(sub11.id, &(&1 + 1)),
+          trip: trip1,
+          route: "CR-NewBedford"
+        )
+
+      sub12 = insert(:subscription, trip: trip1, route: "CR-Middleborough")
+      [sub21, sub22] = insert_list(2, :subscription, trip: trip2, route: "CR-Middleborough")
+
+      alert = insert(:saved_alert)
+
+      [notif1, notif2] = insert_list(2, :notification, alert_id: alert.id, status: :sent)
+
+      insert(:notification_subscription, notification: notif1, subscription: sub11)
+      insert(:notification_subscription, notification: notif1, subscription: sub11after)
+      insert(:notification_subscription, notification: notif1, subscription: sub12)
+      insert(:notification_subscription, notification: notif2, subscription: sub21)
+      insert(:notification_subscription, notification: notif2, subscription: sub22)
+
+      conn = post(conn, admin_scr_path(conn, :phase1))
+      assert redirected_to(conn) == admin_scr_path(conn, :index)
+
+      [sub11id, sub11afterid, sub12id, sub21id, sub22id] =
+        [sub11, sub11after, sub12, sub21, sub22] |> Enum.map(& &1.id)
+
+      [sub12afterid, sub21afterid, sub22afterid] =
+        [sub12id, sub21id, sub22id]
+        |> Enum.map(fn id_before -> ScrController.uuid_op(id_before, &(&1 + 1)) end)
+
+      assert %{
+               ^sub11id => %Subscription{},
+               ^sub11afterid => %Subscription{},
+               ^sub12id => %Subscription{},
+               ^sub12afterid => %Subscription{},
+               ^sub21id => %Subscription{},
+               ^sub21afterid => %Subscription{},
+               ^sub22id => %Subscription{},
+               ^sub22afterid => %Subscription{}
+             } = Repo.all(Subscription) |> Map.new(&{&1.id, &1})
+
+      all_ns = Repo.all(NotificationSubscription)
+
+      assert MapSet.new([sub11id, sub11afterid, sub12id, sub12afterid]) ==
+               all_ns
+               |> Enum.filter(&(&1.notification_id == notif1.id))
+               |> MapSet.new(& &1.subscription_id)
+
+      assert MapSet.new([sub21id, sub21afterid, sub22id, sub22afterid]) ==
+               all_ns
+               |> Enum.filter(&(&1.notification_id == notif2.id))
+               |> MapSet.new(& &1.subscription_id)
+
+      assert get_flash(conn, :info) ==
+               "Migrated 3 subscriptions and 3 associations to notifications."
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_scr_path(conn, :phase1))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
+
+  describe "phase2" do
+    test "deletes old subscriptions and notification deliveries", %{conn: conn} do
+      trip = insert(:trip)
+
+      sub_before = insert(:subscription, trip: trip, route: "CR-Middleborough")
+
+      sub_after =
+        insert(:subscription,
+          id: ScrController.uuid_op(sub_before.id, &(&1 + 1)),
+          trip: trip,
+          route: "CR-NewBedford"
+        )
+
+      alert = insert(:saved_alert)
+      notif = insert(:notification, alert_id: alert.id, status: :sent)
+
+      insert(:notification_subscription, notification: notif, subscription: sub_before)
+      insert(:notification_subscription, notification: notif, subscription: sub_after)
+
+      conn = post(conn, admin_scr_path(conn, :phase2))
+      assert redirected_to(conn) == admin_scr_path(conn, :index)
+
+      assert Repo.one!(Subscription).id == sub_after.id
+      assert Repo.one!(NotificationSubscription).subscription_id == sub_after.id
+
+      assert get_flash(conn, :info) ==
+               "Deleted 1 subscriptions and 1 associations to notifications."
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_scr_path(conn, :phase2))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
+end


### PR DESCRIPTION
Some highlights:
- Since the subscriptions have UUIDs, if we derive a UUID for the copied subscription deterministically from the initial subscription, we can then check if we've already copied that subscription and skip it, making the migration phase 1 idempotent. (The route on a subscription can't be changed, as far as I can tell, so we don't have to worry about creating a duplicate-of-a-duplicate 16 times and looping back around to the original UUID again.)
- I'm not actually certain whether or not creating duplicate `NotificationSubscription`s is necessary to avoid resending notifications for active alerts at migration time, but it seemed like it might be.
- Since we've got Bootstrap 4 already set up, I'm using a [Bootstrap modal](https://getbootstrap.com/docs/4.6/components/modal/) to confirm the destructive migration phase 2.
- I tried fitting the entire migration into the existing admin queries interface, but copying the associated `NotificationSubscription`s was hard to do in pure SQL (and the UUID rewriting was less straightforward, and that code seems like it's only designed for read-only queries anyway).