### PR TITLE
feat: Update MBTA Go CTA URL

### DIFF
--- a/apps/alert_processor/lib/model/notification.ex
+++ b/apps/alert_processor/lib/model/notification.ex
@@ -154,11 +154,11 @@ defmodule AlertProcessor.Model.Notification do
 
   @spec bus_delay_cta_text([String.t()] | nil) :: String.t() | nil
   defp bus_delay_cta_text([route]) do
-    "Track your bus at https://mbta.com/route/#{route} or use the MBTA Go app: https://go.mbta.com"
+    "Track your bus at https://mbta.com/route/#{route} or use the MBTA Go app: https://go.mbta.com/t-alert"
   end
 
   defp bus_delay_cta_text([_, _ | _]),
-    do: "To track your bus, use the MBTA Go app: https://go.mbta.com"
+    do: "To track your bus, use the MBTA Go app: https://go.mbta.com/t-alert"
 
   defp bus_delay_cta_text(_), do: nil
 

--- a/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
+++ b/apps/alert_processor/test/alert_processor/rules_engine/notification_builder_test.exs
@@ -115,7 +115,7 @@ defmodule AlertProcessor.NotificationBuilderTest do
 
       assert %Notification{
                call_to_action:
-                 "Track your bus at https://mbta.com/route/1 or use the MBTA Go app: https://go.mbta.com"
+                 "Track your bus at https://mbta.com/route/1 or use the MBTA Go app: https://go.mbta.com/t-alert"
              } = notification
     end
 
@@ -141,7 +141,8 @@ defmodule AlertProcessor.NotificationBuilderTest do
       notification = NotificationBuilder.build_notification(user_subs, alert)
 
       assert %Notification{
-               call_to_action: "To track your bus, use the MBTA Go app: https://go.mbta.com"
+               call_to_action:
+                 "To track your bus, use the MBTA Go app: https://go.mbta.com/t-alert"
              } = notification
     end
 

--- a/apps/alert_processor/test/integration/matching_test.exs
+++ b/apps/alert_processor/test/integration/matching_test.exs
@@ -1201,12 +1201,12 @@ defmodule AlertProcessor.Integration.MatchingTest do
   # NOTE: The following tests use a set of specific trip IDs. At the time the tests are run, the
   # trip for the current day of the week must have schedules present in the API. All trips must
   # depart from Fairmount station outbound and the time must be specified here. These test trips
-  # are active as of 2025-07-21.
+  # are active as of 2025-08-15.
 
   @test_trip_id (case Date.utc_today() |> Date.day_of_week() do
-                   day when day in 1..5 -> "July14UpdatesWKDY-742861-1625"
-                   6 -> "July14UpdatesWKND-743298-6625"
-                   7 -> "July14UpdatesWKND-743298-6625"
+                   day when day in 1..5 -> "TempNECV2-758215-1625"
+                   6 -> "BungalowWKND-755499-6625"
+                   7 -> "BungalowWKND-755499-6625"
                  end)
   @test_trip_departs_fairmount_at (case Date.utc_today() |> Date.day_of_week() do
                                      day when day in 1..5 -> ~T[10:13:00]


### PR DESCRIPTION
The new URL adds campaign tracking to the link so that we can tell when people are installing the app through this link.

This change should not be released until after https://github.com/mbta/mobile_app_backend/pull/363 is deployed to prod.