### PR TITLE
fix: Log as warning for sending failures that get retried

### DIFF
--- a/apps/alert_processor/lib/dissemination/notification_worker.ex
+++ b/apps/alert_processor/lib/dissemination/notification_worker.ex
@@ -44,7 +44,8 @@ defmodule AlertProcessor.NotificationWorker do
             send(self(), :work)
 
           {:error, {:http_error, 400, _}} ->
-            log_error(
+            log(
+              :error,
               id,
               notification,
               "event=send_failure action=put_back_on_queue time=#{now() - send_start}"
@@ -54,7 +55,8 @@ defmodule AlertProcessor.NotificationWorker do
             send(self(), :work)
 
           {:error, _} ->
-            log_error(
+            log(
+              :error,
               id,
               notification,
               "event=send_failure action=none time=#{now() - send_start}"
@@ -78,18 +80,17 @@ defmodule AlertProcessor.NotificationWorker do
     {:noreply, id}
   end
 
-  defp log(id, notification, message) do
-    mode = if(is_nil(notification.phone_number), do: "email", else: "sms")
-    Logger.info("worker_log id=#{id} mode=#{mode} notification=#{notification.id} #{message}")
-  end
-
   defp log(id, message) do
     Logger.info("worker_log id=#{id} #{message}")
   end
 
-  defp log_error(id, notification, message) do
+  defp log(level \\ :info, id, notification, message) do
     mode = if(is_nil(notification.phone_number), do: "email", else: "sms")
-    Logger.error("worker_log id=#{id} mode=#{mode} notification=#{notification.id} #{message}")
+
+    Logger.log(
+      level,
+      "worker_log id=#{id} mode=#{mode} notification=#{notification.id} #{message}"
+    )
   end
 
   defp now() do

--- a/apps/alert_processor/lib/dissemination/notification_worker.ex
+++ b/apps/alert_processor/lib/dissemination/notification_worker.ex
@@ -45,7 +45,7 @@ defmodule AlertProcessor.NotificationWorker do
 
           {:error, {:http_error, 400, _}} ->
             log(
-              :error,
+              :warning,
               id,
               notification,
               "event=send_failure action=put_back_on_queue time=#{now() - send_start}"


### PR DESCRIPTION
These 400 failures typically represent throttling responses from AWS. We
are able to retry sending, which generally results in success. Given
this, a warning log message is sufficient. This prevents us from
triggering an alert due to an expected situation when we are sending a
high volume of notifications in a short time period.