### PR TITLE
feat: Admin page to manage the boat-long migration

### DIFF
--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -7,20 +7,26 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
   alias AlertProcessor.Repo
 
   def index(conn, _params) do
-
     boat_f1_boat_long_count = subscription_count_for_route_and_stop("Boat-F1", "Boat-Long")
-    boat_eastboston_boat_long_count = subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long")
-    boat_eastboston_boat_long_north_5b_count = subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long-North-5B")
-    boat_lynn_boat_long_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long")
-    boat_lynn_boat_long_north_5c_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long-North-5C")
 
-    render(conn, "index.html", [
+    boat_eastboston_boat_long_count =
+      subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long")
+
+    boat_eastboston_boat_long_north_5b_count =
+      subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long-North-5B")
+
+    boat_lynn_boat_long_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long")
+
+    boat_lynn_boat_long_north_5c_count =
+      subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long-North-5C")
+
+    render(conn, "index.html",
       boat_f1_boat_long_count: boat_f1_boat_long_count,
       boat_eastboston_boat_long_count: boat_eastboston_boat_long_count,
       boat_eastboston_boat_long_north_5b_count: boat_eastboston_boat_long_north_5b_count,
       boat_lynn_boat_long_count: boat_lynn_boat_long_count,
       boat_lynn_boat_long_north_5c_count: boat_lynn_boat_long_north_5c_count
-    ])
+    )
   end
 
   defp subscription_count_for_route_and_stop(route, stop) do

--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -1,0 +1,34 @@
+defmodule ConciergeSite.Admin.BoatLongMigrationController do
+  use ConciergeSite.Web, :controller
+
+  import Ecto.Query
+
+  alias AlertProcessor.Model.Subscription
+  alias AlertProcessor.Repo
+
+  def index(conn, _params) do
+
+    boat_f1_boat_long_count = subscription_count_for_route_and_stop("Boat-F1", "Boat-Long")
+    boat_eastboston_boat_long_count = subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long")
+    boat_eastboston_boat_long_north_5b_count = subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long-North-5B")
+    boat_lynn_boat_long_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long")
+    boat_lynn_boat_long_north_5c_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long-North-5C")
+
+    render(conn, "index.html", [
+      boat_f1_boat_long_count: boat_f1_boat_long_count,
+      boat_eastboston_boat_long_count: boat_eastboston_boat_long_count,
+      boat_eastboston_boat_long_north_5b_count: boat_eastboston_boat_long_north_5b_count,
+      boat_lynn_boat_long_count: boat_lynn_boat_long_count,
+      boat_lynn_boat_long_north_5c_count: boat_lynn_boat_long_north_5c_count
+    ])
+  end
+
+  defp subscription_count_for_route_and_stop(route, stop) do
+    Repo.one(
+      from(s in Subscription,
+        where: s.route == ^route and (s.origin == ^stop or s.destination == ^stop),
+        select: count(s.id)
+      )
+    )
+  end
+end

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -119,6 +119,7 @@ defmodule ConciergeSite.Router do
 
     get("/", HomeController, :index)
     resources("/queries", QueriesController, only: [:index, :show])
+    get("/boat-long", BoatLongMigrationController, :index)
     get("/scr", ScrController, :index)
     post("/scr/phase1", ScrController, :phase1)
     post("/scr/phase2", ScrController, :phase2)

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -1,0 +1,26 @@
+<h1 class="heading__title">Boat-Long Subscription Migration</h1>
+<%= flash_info(@conn) %>
+
+<h2 class="heading__subtitle">Subscription Counts</h2>
+<dl>
+  <dt class="font-weight-normal">Subscription count for route: Boat-F1, stop: Boat-Long on (NO CHANGE)</dt>
+  <dd data-testid="boat-f1-boat-long-count"><%= @boat_f1_boat_long_count %></dd>
+</dl>
+<dl>
+  <dt class="font-weight-normal">Subscription count for route: Boat-EastBoston, stop: Boat-Long (OLD)</dt>
+  <dd data-testid="boat-eastboston-boat-long-count"><%= @boat_eastboston_boat_long_count %></dd>
+</dl>
+<dl>
+  <dt class="font-weight-normal">Subscription count for route: Boat-EastBoston, stop: Boat-Long-North-5B (NEW)</dt>
+  <dd data-testid="boat-eastboston-boat-long-north-5b-count"><%= @boat_eastboston_boat_long_north_5b_count %></dd>
+</dl>
+<dl>
+  <dt class="font-weight-normal">Subscription count for route: Boat-Lynn, stop: Boat-Long (OLD)</dt>
+  <dd data-testid="boat-lynn-boat-long-count"><%= @boat_lynn_boat_long_count %></dd>
+</dl>
+<dl>
+  <dt class="font-weight-normal">Subscription count for route: Boat-Lynn, stop: Boat-Long-North-5C (NEW)</dt>
+  <dd data-testid="boat-lynn-boat-long-north-5c-count"><%= @boat_lynn_boat_long_north_5c_count %></dd>
+</dl>
+
+

--- a/apps/concierge_site/lib/templates/admin/home/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/home/index.html.eex
@@ -4,6 +4,11 @@
   <%= link to: admin_queries_path(@conn, :index), class: "list-group-item list-group-item-action" do %>
     <i class="fa fa-database"></i> Database queries
   <% end %>
+
+  <%= link to: admin_boat_long_migration_path(@conn, :index), class: "list-group-item list-group-item-action" do %>
+    <i class="fa fa-code-fork"></i> Boat-Long Subscription Migration
+  <% end %>
+  
   <%= link to: admin_scr_path(@conn, :index), class: "list-group-item list-group-item-action" do %>
     <i class="fa fa-code-fork"></i> South Coast Rail migration
   <% end %>

--- a/apps/concierge_site/lib/views/admin/boat_long_migration_view.ex
+++ b/apps/concierge_site/lib/views/admin/boat_long_migration_view.ex
@@ -1,0 +1,3 @@
+defmodule ConciergeSite.Admin.BoatLongMigrationView do
+  use ConciergeSite.Web, :view
+end

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule BoatLongMigrationControllerTest do
+  use ConciergeSite.ConnCase, async: true
+
+  setup %{conn: conn} do
+    user = insert(:user, role: "admin")
+    conn = guardian_login(user, conn)
+
+    {:ok, user: user, conn: conn}
+  end
+
+  describe "index" do
+    test "renders successfully", %{conn: conn} do
+      conn = get(conn, admin_boat_long_migration_path(conn, :index))
+      assert html_response(conn, 200) =~ "Boat-Long Subscription Migration"
+    end
+
+    test "counts subscriptions", %{conn: conn} do
+      insert(:subscription, route: "Boat-F1", origin: "Boat-Long", destination: "Boat-Hingham")
+      insert(:subscription, route: "Boat-F1", origin: "Boat-Hingham", destination: "Boat-Long")
+      insert(:subscription, route: "Boat-F1")
+
+      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Long", destination: "Boat-Lewis")
+      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Lewis", destination: "Boat-Long")
+      insert(:subscription, route: "Boat-EastBoston")
+
+      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Long-North-5B", destination: "Boat-Lewis")
+      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Lewis", destination: "Boat-Long-North-5B")
+
+      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Long", destination: "Boat-Blossom")
+      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Blossom", destination: "Boat-Long")
+      insert(:subscription, route: "Boat-Lynn")
+
+      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Long-North-5C", destination: "Boat-Blossom")
+      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Blossom", destination: "Boat-Long-North-5C")
+
+      conn = get(conn, admin_boat_long_migration_path(conn, :index))
+
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-f1-boat-long-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-eastboston-boat-long-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-eastboston-boat-long-north-5b-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-lynn-boat-long-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-lynn-boat-long-north-5c-count\">2<\/dd>/
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = get(conn, admin_boat_long_migration_path(conn, :index))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
+end

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -19,27 +19,62 @@ defmodule BoatLongMigrationControllerTest do
       insert(:subscription, route: "Boat-F1", origin: "Boat-Hingham", destination: "Boat-Long")
       insert(:subscription, route: "Boat-F1")
 
-      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Long", destination: "Boat-Lewis")
-      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Lewis", destination: "Boat-Long")
+      insert(:subscription,
+        route: "Boat-EastBoston",
+        origin: "Boat-Long",
+        destination: "Boat-Lewis"
+      )
+
+      insert(:subscription,
+        route: "Boat-EastBoston",
+        origin: "Boat-Lewis",
+        destination: "Boat-Long"
+      )
+
       insert(:subscription, route: "Boat-EastBoston")
 
-      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Long-North-5B", destination: "Boat-Lewis")
-      insert(:subscription, route: "Boat-EastBoston", origin: "Boat-Lewis", destination: "Boat-Long-North-5B")
+      insert(:subscription,
+        route: "Boat-EastBoston",
+        origin: "Boat-Long-North-5B",
+        destination: "Boat-Lewis"
+      )
+
+      insert(:subscription,
+        route: "Boat-EastBoston",
+        origin: "Boat-Lewis",
+        destination: "Boat-Long-North-5B"
+      )
 
       insert(:subscription, route: "Boat-Lynn", origin: "Boat-Long", destination: "Boat-Blossom")
       insert(:subscription, route: "Boat-Lynn", origin: "Boat-Blossom", destination: "Boat-Long")
       insert(:subscription, route: "Boat-Lynn")
 
-      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Long-North-5C", destination: "Boat-Blossom")
-      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Blossom", destination: "Boat-Long-North-5C")
+      insert(:subscription,
+        route: "Boat-Lynn",
+        origin: "Boat-Long-North-5C",
+        destination: "Boat-Blossom"
+      )
+
+      insert(:subscription,
+        route: "Boat-Lynn",
+        origin: "Boat-Blossom",
+        destination: "Boat-Long-North-5C"
+      )
 
       conn = get(conn, admin_boat_long_migration_path(conn, :index))
 
       assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-f1-boat-long-count\">2<\/dd>/
-      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-eastboston-boat-long-count\">2<\/dd>/
-      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-eastboston-boat-long-north-5b-count\">2<\/dd>/
+
+      assert html_response(conn, 200) =~
+               ~r/<dd data-testid=\"boat-eastboston-boat-long-count\">2<\/dd>/
+
+      assert html_response(conn, 200) =~
+               ~r/<dd data-testid=\"boat-eastboston-boat-long-north-5b-count\">2<\/dd>/
+
       assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-lynn-boat-long-count\">2<\/dd>/
-      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-lynn-boat-long-north-5c-count\">2<\/dd>/
+
+      assert html_response(conn, 200) =~
+               ~r/<dd data-testid=\"boat-lynn-boat-long-north-5c-count\">2<\/dd>/
     end
 
     test "only available to admins", %{conn: conn} do


### PR DESCRIPTION
Precursor work towards [[T-Alerts] Migrate subscriptions at stop_id Boat-Long](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1214312229016931?focus=true)

Display subscription counts for the route and stop combinations we'll be concerned with during this migration.