### PR TITLE
feat: Migration and deletion steps for Boat-Long stops

### DIFF
--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -55,6 +55,17 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
         @eastboston_new_stop_long
       )
 
+  def migrate_boat_lynn(conn, _params),
+    do:
+      migrate_for(
+        conn,
+        @lynn_route,
+        @lynn_old_stop,
+        @lynn_new_stop,
+        @lynn_new_stop_lat,
+        @lynn_new_stop_long
+      )
+
   @spec subscription_count_for_route_and_stop(Route.route_id(), Route.stop_id()) ::
           non_neg_integer()
   def subscription_count_for_route_and_stop(route, stop) do

--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -69,6 +69,9 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
   def delete_boat_eastboston(conn, _params),
     do: delete_for(conn, @eastboston_route, @eastboston_old_stop)
 
+  def delete_boat_lynn(conn, _params),
+    do: delete_for(conn, @lynn_route, @lynn_old_stop)
+
   @spec subscription_count_for_route_and_stop(Route.route_id(), Route.stop_id()) ::
           non_neg_integer()
   def subscription_count_for_route_and_stop(route, stop) do

--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -66,6 +66,9 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
         @lynn_new_stop_long
       )
 
+  def delete_boat_eastboston(conn, _params),
+    do: delete_for(conn, @eastboston_route, @eastboston_old_stop)
+
   @spec subscription_count_for_route_and_stop(Route.route_id(), Route.stop_id()) ::
           non_neg_integer()
   def subscription_count_for_route_and_stop(route, stop) do
@@ -136,12 +139,33 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
     |> redirect(to: admin_boat_long_migration_path(conn, :index))
   end
 
+  defp delete_for(conn, route, stop) do
+    {count, _} = delete_subscriptions_by_route_and_id(route, stop)
+
+    flash = "Deleted #{count} subscriptions."
+
+    conn
+    |> put_flash(:info, flash)
+    |> redirect(to: admin_boat_long_migration_path(conn, :index))
+  end
+
   @spec subscriptions_by_route_and_id(Route.route_id(), Route.stop_id()) :: [Subscription.t()]
   defp subscriptions_by_route_and_id(route, stop) do
     Repo.all(
       from(s in Subscription,
         where: s.route == ^route and (s.origin == ^stop or s.destination == ^stop)
       )
+    )
+  end
+
+  @spec delete_subscriptions_by_route_and_id(Route.route_id(), Route.stop_id()) ::
+          {non_neg_integer(), nil | [term()]}
+  defp delete_subscriptions_by_route_and_id(route, stop) do
+    Repo.delete_all(
+      from(s in Subscription,
+        where: s.route == ^route and (s.origin == ^stop or s.destination == ^stop)
+      ),
+      timeout: 60_000
     )
   end
 

--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -3,6 +3,7 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
 
   import Ecto.Query
 
+  alias AlertProcessor.Model.Route
   alias AlertProcessor.Model.Subscription
   alias AlertProcessor.Repo
 
@@ -12,10 +13,14 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
   @eastboston_route "Boat-EastBoston"
   @eastboston_old_stop "Boat-Long"
   @eastboston_new_stop "Boat-Long-North-5B"
+  @eastboston_new_stop_lat 42.36089
+  @eastboston_new_stop_long -71.04964
 
   @lynn_route "Boat-Lynn"
   @lynn_old_stop "Boat-Long"
   @lynn_new_stop "Boat-Long-North-5C"
+  @lynn_new_stop_lat 42.36095
+  @lynn_new_stop_long -71.04925
 
   def index(conn, _params) do
     f1_count = subscription_count_for_route_and_stop(@f1_route, @f1_stop)
@@ -28,8 +33,7 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
 
     lynn_old_stop_count = subscription_count_for_route_and_stop(@lynn_route, @lynn_old_stop)
 
-    lynn_new_stop_count =
-      subscription_count_for_route_and_stop(@lynn_route, @lynn_new_stop)
+    lynn_new_stop_count = subscription_count_for_route_and_stop(@lynn_route, @lynn_new_stop)
 
     render(conn, "index.html",
       f1_count: f1_count,
@@ -40,12 +44,150 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
     )
   end
 
-  defp subscription_count_for_route_and_stop(route, stop) do
+  def migrate_boat_eastboston(conn, _params),
+    do:
+      migrate_for(
+        conn,
+        @eastboston_route,
+        @eastboston_old_stop,
+        @eastboston_new_stop,
+        @eastboston_new_stop_lat,
+        @eastboston_new_stop_long
+      )
+
+  @spec subscription_count_for_route_and_stop(Route.route_id(), Route.stop_id()) ::
+          non_neg_integer()
+  def subscription_count_for_route_and_stop(route, stop) do
     Repo.one(
       from(s in Subscription,
         where: s.route == ^route and (s.origin == ^stop or s.destination == ^stop),
         select: count(s.id)
       )
     )
+  end
+
+  @doc """
+  Performs a mathematical operation on the last digit only of the given UUID,
+  wrapping between 0 and f as needed.
+  """
+  @spec uuid_op(String.t(), (integer() -> integer())) :: String.t()
+  def uuid_op(uuid, op) do
+    last_digit = String.last(uuid)
+
+    adjacent_last_digit =
+      last_digit
+      |> String.to_integer(16)
+      |> Kernel.+(16)
+      |> op.()
+      |> Integer.to_string(16)
+      |> String.last()
+      |> String.downcase()
+
+    String.slice(uuid, 0..(String.length(uuid) - 2)) <> adjacent_last_digit
+  end
+
+  defp migrate_for(conn, route, old_stop, new_stop, new_stop_lat, new_stop_long) do
+    {:ok, flash} =
+      Repo.transaction(
+        fn ->
+          subsciptions = subscriptions_by_route_and_id(route, old_stop)
+
+          already_migrated_subscription_ids =
+            route
+            |> subscriptions_by_route_and_id(new_stop)
+            |> Enum.map(& &1.id)
+
+          new_subscriptions =
+            Enum.map(subsciptions, fn subscription ->
+              new_subscription(
+                subscription,
+                already_migrated_subscription_ids,
+                old_stop,
+                new_stop,
+                new_stop_lat,
+                new_stop_long
+              )
+            end)
+
+          {new_subscriptions, already_migrated_subscriptions} =
+            Enum.split_with(new_subscriptions, &match?(%Subscription{}, &1))
+
+          new_subscription_count = length(new_subscriptions)
+          already_mgrated_count = length(already_migrated_subscriptions)
+
+          "Migrated #{new_subscription_count} subscriptions, #{already_mgrated_count} were already migrated."
+        end,
+        timeout: 60_000
+      )
+
+    conn
+    |> put_flash(:info, flash)
+    |> redirect(to: admin_boat_long_migration_path(conn, :index))
+  end
+
+  @spec subscriptions_by_route_and_id(Route.route_id(), Route.stop_id()) :: [Subscription.t()]
+  defp subscriptions_by_route_and_id(route, stop) do
+    Repo.all(
+      from(s in Subscription,
+        where: s.route == ^route and (s.origin == ^stop or s.destination == ^stop)
+      )
+    )
+  end
+
+  @spec new_subscription(
+          Subscription.t(),
+          [Subscription.id()],
+          Route.stop_id(),
+          Route.stop_id(),
+          float(),
+          float()
+        ) ::
+          Subscription.t() | :already_migrated
+  defp new_subscription(
+         %Subscription{id: old_id} = old_subscription,
+         already_migrated_subscription_ids,
+         old_stop,
+         new_stop,
+         new_stop_lat,
+         new_stop_long
+       ) do
+    new_id = uuid_op(old_id, &(&1 + 1))
+
+    if Enum.member?(already_migrated_subscription_ids, new_id) do
+      :already_migrated
+    else
+      new_subscription = %Subscription{
+        old_subscription
+        | id: Ecto.UUID.cast!(new_id),
+          inserted_at: nil,
+          updated_at: nil
+      }
+
+      new_subscription =
+        if new_subscription.origin == old_stop do
+          %Subscription{
+            new_subscription
+            | origin: new_stop,
+              origin_lat: new_stop_lat,
+              origin_long: new_stop_long
+          }
+        else
+          new_subscription
+        end
+
+      new_subscription =
+        if new_subscription.destination == old_stop do
+          %Subscription{
+            new_subscription
+            | destination: new_stop,
+              destination_lat: new_stop_lat,
+              destination_long: new_stop_long
+          }
+        else
+          new_subscription
+        end
+
+      Repo.insert!(new_subscription)
+    end
   end
 end

--- a/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
+++ b/apps/concierge_site/lib/controllers/admin/boat_long_migration_controller.ex
@@ -6,26 +6,37 @@ defmodule ConciergeSite.Admin.BoatLongMigrationController do
   alias AlertProcessor.Model.Subscription
   alias AlertProcessor.Repo
 
+  @f1_route "Boat-F1"
+  @f1_stop "Boat-Long"
+
+  @eastboston_route "Boat-EastBoston"
+  @eastboston_old_stop "Boat-Long"
+  @eastboston_new_stop "Boat-Long-North-5B"
+
+  @lynn_route "Boat-Lynn"
+  @lynn_old_stop "Boat-Long"
+  @lynn_new_stop "Boat-Long-North-5C"
+
   def index(conn, _params) do
-    boat_f1_boat_long_count = subscription_count_for_route_and_stop("Boat-F1", "Boat-Long")
+    f1_count = subscription_count_for_route_and_stop(@f1_route, @f1_stop)
 
-    boat_eastboston_boat_long_count =
-      subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long")
+    eastboston_old_stop_count =
+      subscription_count_for_route_and_stop(@eastboston_route, @eastboston_old_stop)
 
-    boat_eastboston_boat_long_north_5b_count =
-      subscription_count_for_route_and_stop("Boat-EastBoston", "Boat-Long-North-5B")
+    eastboston_new_stop_count =
+      subscription_count_for_route_and_stop(@eastboston_route, @eastboston_new_stop)
 
-    boat_lynn_boat_long_count = subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long")
+    lynn_old_stop_count = subscription_count_for_route_and_stop(@lynn_route, @lynn_old_stop)
 
-    boat_lynn_boat_long_north_5c_count =
-      subscription_count_for_route_and_stop("Boat-Lynn", "Boat-Long-North-5C")
+    lynn_new_stop_count =
+      subscription_count_for_route_and_stop(@lynn_route, @lynn_new_stop)
 
     render(conn, "index.html",
-      boat_f1_boat_long_count: boat_f1_boat_long_count,
-      boat_eastboston_boat_long_count: boat_eastboston_boat_long_count,
-      boat_eastboston_boat_long_north_5b_count: boat_eastboston_boat_long_north_5b_count,
-      boat_lynn_boat_long_count: boat_lynn_boat_long_count,
-      boat_lynn_boat_long_north_5c_count: boat_lynn_boat_long_north_5c_count
+      f1_count: f1_count,
+      eastboston_old_stop_count: eastboston_old_stop_count,
+      eastboston_new_stop_count: eastboston_new_stop_count,
+      lynn_old_stop_count: lynn_old_stop_count,
+      lynn_new_stop_count: lynn_new_stop_count
     )
   end
 

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -120,6 +120,12 @@ defmodule ConciergeSite.Router do
     get("/", HomeController, :index)
     resources("/queries", QueriesController, only: [:index, :show])
     get("/boat-long", BoatLongMigrationController, :index)
+
+    post(
+      "/boat-long/migrate-boat-eastboston",
+      BoatLongMigrationController,
+      :migrate_boat_eastboston
+    )
   end
 
   scope "/mailchimp", ConciergeSite do

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -126,6 +126,12 @@ defmodule ConciergeSite.Router do
       BoatLongMigrationController,
       :migrate_boat_eastboston
     )
+
+    post(
+      "/boat-long/migrate-boat-lynn",
+      BoatLongMigrationController,
+      :migrate_boat_lynn
+    )
   end
 
   scope "/mailchimp", ConciergeSite do

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -132,6 +132,12 @@ defmodule ConciergeSite.Router do
       BoatLongMigrationController,
       :migrate_boat_lynn
     )
+
+    post(
+      "/boat-long/delete-boat-eastboston",
+      BoatLongMigrationController,
+      :delete_boat_eastboston
+    )
   end
 
   scope "/mailchimp", ConciergeSite do

--- a/apps/concierge_site/lib/router.ex
+++ b/apps/concierge_site/lib/router.ex
@@ -138,6 +138,12 @@ defmodule ConciergeSite.Router do
       BoatLongMigrationController,
       :delete_boat_eastboston
     )
+
+    post(
+      "/boat-long/delete-boat-lynn",
+      BoatLongMigrationController,
+      :delete_boat_lynn
+    )
   end
 
   scope "/mailchimp", ConciergeSite do

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -4,23 +4,23 @@
 <h2 class="heading__subtitle">Subscription Counts</h2>
 <dl>
   <dt class="font-weight-normal">Subscription count for route: Boat-F1, stop: Boat-Long on (NO CHANGE)</dt>
-  <dd data-testid="boat-f1-boat-long-count"><%= @boat_f1_boat_long_count %></dd>
+  <dd data-testid="f1-long-count"><%= @f1_count %></dd>
 </dl>
 <dl>
   <dt class="font-weight-normal">Subscription count for route: Boat-EastBoston, stop: Boat-Long (OLD)</dt>
-  <dd data-testid="boat-eastboston-boat-long-count"><%= @boat_eastboston_boat_long_count %></dd>
+  <dd data-testid="eastboston-old-stop-count"><%= @eastboston_old_stop_count %></dd>
 </dl>
 <dl>
   <dt class="font-weight-normal">Subscription count for route: Boat-EastBoston, stop: Boat-Long-North-5B (NEW)</dt>
-  <dd data-testid="boat-eastboston-boat-long-north-5b-count"><%= @boat_eastboston_boat_long_north_5b_count %></dd>
+  <dd data-testid="eastboston-new-stop-count"><%= @eastboston_new_stop_count %></dd>
 </dl>
 <dl>
   <dt class="font-weight-normal">Subscription count for route: Boat-Lynn, stop: Boat-Long (OLD)</dt>
-  <dd data-testid="boat-lynn-boat-long-count"><%= @boat_lynn_boat_long_count %></dd>
+  <dd data-testid="lynn-old-stop-count"><%= @lynn_old_stop_count %></dd>
 </dl>
 <dl>
   <dt class="font-weight-normal">Subscription count for route: Boat-Lynn, stop: Boat-Long-North-5C (NEW)</dt>
-  <dd data-testid="boat-lynn-boat-long-north-5c-count"><%= @boat_lynn_boat_long_north_5c_count %></dd>
+  <dd data-testid="lynn-new-stop-count"><%= @lynn_new_stop_count %></dd>
 </dl>
 
 

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -36,10 +36,10 @@
     </ul>
   </li>
   <li class="mt-4">
-    TKTK Delete old subscriptions for Boat-EastBoston: 
-    <%!-- <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
+    Delete old subscriptions for Boat-EastBoston: 
+    <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#eastboston-delete-confirm">
       <i class="fa fa-play-circle-o"></i> Run
-    <% end %> --%>
+    </button>
     <ul>
       <li>Deletes subscriptions involving stop Boat-Long on route Boat-EastBoston</li>
     </ul>
@@ -63,3 +63,28 @@
     </ul>
   </li>
 </ol>
+
+<div id="eastboston-delete-confirm" class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmation</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>This will delete <%= @eastboston_old_stop_count %> route: Boat-EastBoston, stop: Boat-Long subscriptions.</p>
+        <%= if @eastboston_old_stop_count > @eastboston_new_stop_count do %>
+          <div class="alert alert-danger" role="alert">
+            That’s more than the <%= @eastboston_new_stop_count %> route: Boat-EastBoston, stop: Boat-Long-North-5B subscriptions! Consider running Step 1 again first to make sure no data is lost.
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <%= link to: admin_boat_long_migration_path(@conn, :delete_boat_eastboston), class: "btn btn-danger", method: :post do %>Delete Boat-EastBoston @ Boat-Long subscriptions<% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -26,13 +26,40 @@
 <h2 class="heading__subtitle">Migration Actions</h2>
 
 <ol>
-  <li>
-    Boat-EastBoston: 
+  <li class="mt-4">
+    Create new subscriptions for Boat-EastBoston: 
     <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
       <i class="fa fa-play-circle-o"></i> Run
     <% end %>
     <ul>
       <li>Copies subscriptions involving stop Boat-Long on route Boat-EastBoston to use stop Boat-Long-North-5B</li>
+    </ul>
+  </li>
+  <li class="mt-4">
+    TKTK Delete old subscriptions for Boat-EastBoston: 
+    <%!-- <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
+      <i class="fa fa-play-circle-o"></i> Run
+    <% end %> --%>
+    <ul>
+      <li>Deletes subscriptions involving stop Boat-Long on route Boat-EastBoston</li>
+    </ul>
+  </li>
+  <li class="mt-4">
+    Create new subscriptions for Boat-Lynn: 
+    <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_lynn), class: "btn btn-primary", method: :post do %>
+      <i class="fa fa-play-circle-o"></i> Run
+    <% end %>
+    <ul>
+      <li>Copies subscriptions involving stop Boat-Long on route Boat-Lynn to use stop Boat-Long-North-5C</li>
+    </ul>
+  </li>
+  <li class="mt-4">
+    TKTK Delete old subscriptions for Boat-Lynn: 
+    <%!-- <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
+      <i class="fa fa-play-circle-o"></i> Run
+    <% end %> --%>
+    <ul>
+      <li>Deletes subscriptions involving stop Boat-Long on route Boat-Lynn</li>
     </ul>
   </li>
 </ol>

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -54,10 +54,10 @@
     </ul>
   </li>
   <li class="mt-4">
-    TKTK Delete old subscriptions for Boat-Lynn: 
-    <%!-- <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
+    Delete old subscriptions for Boat-Lynn: 
+    <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#lynn-delete-confirm">
       <i class="fa fa-play-circle-o"></i> Run
-    <% end %> --%>
+    </button>
     <ul>
       <li>Deletes subscriptions involving stop Boat-Long on route Boat-Lynn</li>
     </ul>
@@ -84,6 +84,31 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
         <%= link to: admin_boat_long_migration_path(@conn, :delete_boat_eastboston), class: "btn btn-danger", method: :post do %>Delete Boat-EastBoston @ Boat-Long subscriptions<% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="lynn-delete-confirm" class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmation</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>This will delete <%= @lynn_old_stop_count %> route: Boat-Lynn, stop: Boat-Long subscriptions.</p>
+        <%= if @lynn_old_stop_count > @lynn_new_stop_count do %>
+          <div class="alert alert-danger" role="alert">
+            That’s more than the <%= @lynn_new_stop_count %> route: Boat-Lynn, stop: Boat-Long-North-5C subscriptions! Consider running Step 1 again first to make sure no data is lost.
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <%= link to: admin_boat_long_migration_path(@conn, :delete_boat_lynn), class: "btn btn-danger", method: :post do %>Delete Boat-Lynn @ Boat-Long subscriptions<% end %>
       </div>
     </div>
   </div>

--- a/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
+++ b/apps/concierge_site/lib/templates/admin/boat_long_migration/index.html.eex
@@ -23,4 +23,16 @@
   <dd data-testid="lynn-new-stop-count"><%= @lynn_new_stop_count %></dd>
 </dl>
 
+<h2 class="heading__subtitle">Migration Actions</h2>
 
+<ol>
+  <li>
+    Boat-EastBoston: 
+    <%= link to: admin_boat_long_migration_path(@conn, :migrate_boat_eastboston), class: "btn btn-primary", method: :post do %>
+      <i class="fa fa-play-circle-o"></i> Run
+    <% end %>
+    <ul>
+      <li>Copies subscriptions involving stop Boat-Long on route Boat-EastBoston to use stop Boat-Long-North-5B</li>
+    </ul>
+  </li>
+</ol>

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -194,4 +194,87 @@ defmodule BoatLongMigrationControllerTest do
       assert redirected_to(conn) == "/trips"
     end
   end
+
+  describe "migrate_boat_lynn" do
+    test "makes a copy of each subscription substituting the new stop", %{conn: conn} do
+      starting_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      starting_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_old_stop,
+        destination: @lynn_other_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_other_stop,
+        destination: @lynn_old_stop
+      )
+
+      insert(:subscription, route: @lynn_route)
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_new_stop,
+        destination: @lynn_other_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_other_stop,
+        destination: @lynn_new_stop
+      )
+
+      before_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      before_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      assert before_old_stop_count - starting_old_stop_count == 2
+      assert before_new_stop_count - starting_new_stop_count == 2
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :migrate_boat_lynn))
+      assert redirected_to(conn) == admin_boat_long_migration_path(conn, :index)
+
+      after_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      after_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      assert after_old_stop_count - before_old_stop_count == 0
+      assert after_new_stop_count - before_new_stop_count == 2
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :migrate_boat_lynn))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
 end

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -63,18 +63,18 @@ defmodule BoatLongMigrationControllerTest do
 
       conn = get(conn, admin_boat_long_migration_path(conn, :index))
 
-      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-f1-boat-long-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"f1-long-count\">2<\/dd>/
 
       assert html_response(conn, 200) =~
-               ~r/<dd data-testid=\"boat-eastboston-boat-long-count\">2<\/dd>/
+               ~r/<dd data-testid=\"eastboston-old-stop-count\">2<\/dd>/
 
       assert html_response(conn, 200) =~
-               ~r/<dd data-testid=\"boat-eastboston-boat-long-north-5b-count\">2<\/dd>/
+               ~r/<dd data-testid=\"eastboston-new-stop-count\">2<\/dd>/
 
-      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"boat-lynn-boat-long-count\">2<\/dd>/
+      assert html_response(conn, 200) =~ ~r/<dd data-testid=\"lynn-old-stop-count\">2<\/dd>/
 
       assert html_response(conn, 200) =~
-               ~r/<dd data-testid=\"boat-lynn-boat-long-north-5c-count\">2<\/dd>/
+               ~r/<dd data-testid=\"lynn-new-stop-count\">2<\/dd>/
     end
 
     test "only available to admins", %{conn: conn} do

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -1,6 +1,22 @@
 defmodule BoatLongMigrationControllerTest do
   use ConciergeSite.ConnCase, async: true
 
+  alias ConciergeSite.Admin.BoatLongMigrationController
+
+  @f1_route "Boat-F1"
+  @f1_stop "Boat-Long"
+  @f1_other_stop "Boat-Hingham"
+
+  @eastboston_route "Boat-EastBoston"
+  @eastboston_old_stop "Boat-Long"
+  @eastboston_new_stop "Boat-Long-North-5B"
+  @eastboston_other_stop "Boat-Lewis"
+
+  @lynn_route "Boat-Lynn"
+  @lynn_old_stop "Boat-Long"
+  @lynn_new_stop "Boat-Long-North-5C"
+  @lynn_other_stop "Boat-Blossom"
+
   setup %{conn: conn} do
     user = insert(:user, role: "admin")
     conn = guardian_login(user, conn)
@@ -15,50 +31,60 @@ defmodule BoatLongMigrationControllerTest do
     end
 
     test "counts subscriptions", %{conn: conn} do
-      insert(:subscription, route: "Boat-F1", origin: "Boat-Long", destination: "Boat-Hingham")
-      insert(:subscription, route: "Boat-F1", origin: "Boat-Hingham", destination: "Boat-Long")
-      insert(:subscription, route: "Boat-F1")
+      insert(:subscription, route: @f1_route, origin: @f1_stop, destination: @f1_other_stop)
+      insert(:subscription, route: @f1_route, origin: @f1_other_stop, destination: @f1_stop)
+      insert(:subscription, route: @f1_route)
 
       insert(:subscription,
-        route: "Boat-EastBoston",
-        origin: "Boat-Long",
-        destination: "Boat-Lewis"
+        route: @eastboston_route,
+        origin: @eastboston_old_stop,
+        destination: @eastboston_other_stop
       )
 
       insert(:subscription,
-        route: "Boat-EastBoston",
-        origin: "Boat-Lewis",
-        destination: "Boat-Long"
+        route: @eastboston_route,
+        origin: @eastboston_other_stop,
+        destination: @eastboston_old_stop
       )
 
-      insert(:subscription, route: "Boat-EastBoston")
+      insert(:subscription, route: @eastboston_route)
 
       insert(:subscription,
-        route: "Boat-EastBoston",
-        origin: "Boat-Long-North-5B",
-        destination: "Boat-Lewis"
-      )
-
-      insert(:subscription,
-        route: "Boat-EastBoston",
-        origin: "Boat-Lewis",
-        destination: "Boat-Long-North-5B"
-      )
-
-      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Long", destination: "Boat-Blossom")
-      insert(:subscription, route: "Boat-Lynn", origin: "Boat-Blossom", destination: "Boat-Long")
-      insert(:subscription, route: "Boat-Lynn")
-
-      insert(:subscription,
-        route: "Boat-Lynn",
-        origin: "Boat-Long-North-5C",
-        destination: "Boat-Blossom"
+        route: @eastboston_route,
+        origin: @eastboston_new_stop,
+        destination: @eastboston_other_stop
       )
 
       insert(:subscription,
-        route: "Boat-Lynn",
-        origin: "Boat-Blossom",
-        destination: "Boat-Long-North-5C"
+        route: @eastboston_route,
+        origin: @eastboston_other_stop,
+        destination: @eastboston_new_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_old_stop,
+        destination: @lynn_other_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_other_stop,
+        destination: @lynn_old_stop
+      )
+
+      insert(:subscription, route: @lynn_route)
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_new_stop,
+        destination: @lynn_other_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_other_stop,
+        destination: @lynn_new_stop
       )
 
       conn = get(conn, admin_boat_long_migration_path(conn, :index))
@@ -81,6 +107,89 @@ defmodule BoatLongMigrationControllerTest do
       conn = guardian_login(insert(:user, role: "user"), conn)
 
       conn = get(conn, admin_boat_long_migration_path(conn, :index))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
+
+  describe "migrate_boat_eastboston" do
+    test "makes a copy of each subscription substituting the new stop", %{conn: conn} do
+      starting_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      starting_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_old_stop,
+        destination: @eastboston_other_stop
+      )
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_other_stop,
+        destination: @eastboston_old_stop
+      )
+
+      insert(:subscription, route: @eastboston_route)
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_new_stop,
+        destination: @eastboston_other_stop
+      )
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_other_stop,
+        destination: @eastboston_new_stop
+      )
+
+      before_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      before_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      assert before_old_stop_count - starting_old_stop_count == 2
+      assert before_new_stop_count - starting_new_stop_count == 2
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :migrate_boat_eastboston))
+      assert redirected_to(conn) == admin_boat_long_migration_path(conn, :index)
+
+      after_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      after_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      assert after_old_stop_count - before_old_stop_count == 0
+      assert after_new_stop_count - before_new_stop_count == 2
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :migrate_boat_eastboston))
 
       assert redirected_to(conn) == "/trips"
     end

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -277,4 +277,74 @@ defmodule BoatLongMigrationControllerTest do
       assert redirected_to(conn) == "/trips"
     end
   end
+
+  describe "delete_boat_eastboston" do
+    test "deletes old subscriptions and notification deliveries", %{conn: conn} do
+      starting_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      starting_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_old_stop,
+        destination: @eastboston_other_stop
+      )
+
+      insert(:subscription,
+        route: @eastboston_route,
+        origin: @eastboston_new_stop,
+        destination: @eastboston_other_stop
+      )
+
+      before_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      before_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      assert before_old_stop_count - starting_old_stop_count == 1
+      assert before_new_stop_count - starting_new_stop_count == 1
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :delete_boat_eastboston))
+      assert redirected_to(conn) == admin_boat_long_migration_path(conn, :index)
+      assert get_flash(conn, :info) == "Deleted 1 subscriptions."
+
+      after_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_old_stop
+        )
+
+      after_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @eastboston_route,
+          @eastboston_new_stop
+        )
+
+      assert after_old_stop_count - before_old_stop_count == -1
+      assert after_new_stop_count - before_new_stop_count == 0
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :delete_boat_eastboston))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
 end

--- a/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
+++ b/apps/concierge_site/test/web/controllers/admin/boat_long_migration_controller_test.exs
@@ -347,4 +347,74 @@ defmodule BoatLongMigrationControllerTest do
       assert redirected_to(conn) == "/trips"
     end
   end
+
+  describe "delete_boat_lynn" do
+    test "deletes old subscriptions and notification deliveries", %{conn: conn} do
+      starting_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      starting_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_old_stop,
+        destination: @lynn_other_stop
+      )
+
+      insert(:subscription,
+        route: @lynn_route,
+        origin: @lynn_new_stop,
+        destination: @lynn_other_stop
+      )
+
+      before_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      before_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      assert before_old_stop_count - starting_old_stop_count == 1
+      assert before_new_stop_count - starting_new_stop_count == 1
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :delete_boat_lynn))
+      assert redirected_to(conn) == admin_boat_long_migration_path(conn, :index)
+      assert get_flash(conn, :info) == "Deleted 1 subscriptions."
+
+      after_old_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_old_stop
+        )
+
+      after_new_stop_count =
+        BoatLongMigrationController.subscription_count_for_route_and_stop(
+          @lynn_route,
+          @lynn_new_stop
+        )
+
+      assert after_old_stop_count - before_old_stop_count == -1
+      assert after_new_stop_count - before_new_stop_count == 0
+    end
+
+    test "only available to admins", %{conn: conn} do
+      conn = guardian_login(insert(:user, role: "user"), conn)
+
+      conn = post(conn, admin_boat_long_migration_path(conn, :delete_boat_lynn))
+
+      assert redirected_to(conn) == "/trips"
+    end
+  end
 end


### PR DESCRIPTION
Closes [[T-Alerts] Migrate subscriptions at stop_id Boat-Long](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1214312229016931?focus=true)

- Subscriptions for Boat-Long on route Boat-F1  remain unchanged
- Subscriptions for Boat-Long on route Boat-EastBoston should be rewritten to be for the stop Boat-Long-North-5B (We are duplicating with the new stop, and then deleting the old versions)
- Subscriptions for Boat-Long on route Boat-Lynn should be rewritten to be for the stop Boat-Long-North-5C (We are duplicating with the new stop, and then deleting the old versions)